### PR TITLE
Add claude-history-query: non-interactive CLI for scripts and LLM agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "syntect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ pulldown-cmark = "0.13"
 unicode-width = "0.2"
 arboard = "3.4"
 syntect = { version = "5.2", default-features = false, features = ["default-fancy"] }
+regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ homepage = "https://github.com/raine/claude-history"
 keywords = ["claude", "claude-code", "fzf", "cli", "history"]
 categories = ["command-line-utilities"]
 
+[lib]
+name = "claude_history"
+path = "src/lib.rs"
+
+[[bin]]
+name = "claude-history"
+path = "src/main.rs"
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ path = "src/lib.rs"
 name = "claude-history"
 path = "src/main.rs"
 
+[[bin]]
+name = "claude-history-query"
+path = "src/query_main.rs"
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ brew install raine/claude-history/claude-history
 cargo install claude-history
 ```
 
+### From source
+
+```sh
+git clone https://github.com/raine/claude-history.git
+cd claude-history
+cargo install --locked --path .
+```
+
+This installs both binaries: `claude-history` (TUI) and `claude-history-query` (CLI).
+
 ## Usage
 
 Run the tool from inside the project directory you're interested in:
@@ -397,6 +407,98 @@ $ just check
 ```
 
 This runs `cargo fmt`, `cargo clippy --fix`, and `cargo build` in parallel.
+
+## claude-history-query
+
+A non-interactive CLI companion optimized for shell scripts and LLM agents.
+Outputs JSONL or human-readable formats suitable for pipelines.
+
+### Commands
+
+```sh
+claude-history-query list [OPTIONS]    # List conversations
+claude-history-query show <ID>         # Show conversation content
+claude-history-query usage             # Self-documenting help for LLMs
+```
+
+### Examples
+
+```sh
+# Resume most recent conversation
+claude --resume "$(claude-history-query list -n 1 -f uuid)"
+
+# Search and resume with fzf
+claude --resume "$(claude-history-query list -g -f uuid | fzf)"
+
+# Export recent conversations to JSONL
+claude-history-query list --since 1w --jsonl > backup.jsonl
+
+# Find conversations about a topic
+claude-history-query list -g --query "docker && kubernetes"
+
+# Delete old conversations
+claude-history-query list --before 2024-01-01 -f path | xargs rm
+
+# Count conversations per project
+claude-history-query list -g -f cwd | sort | uniq -c | sort -rn
+```
+
+### Output formats
+
+* `--human` (default) — Human-readable with relative timestamps
+* `--jsonl` — JSON Lines, one object per line for parsing with `jq`
+
+### Field selection
+
+Use `-f/--field` to output specific fields (tab-separated in human mode, filtered JSON in JSONL mode):
+
+```sh
+claude-history-query list -f uuid -f cwd
+# abc123    /home/user/project
+# def456    /home/user/other
+```
+
+Available fields: `uuid`, `path`, `cwd`, `timestamp`, `preview`, `project`
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | General error (I/O, parsing) |
+| 2 | Invalid arguments |
+| 3 | No results found |
+
+### Full options
+
+```
+claude-history-query list [OPTIONS]
+
+Options:
+  -g, --global                Search all projects globally
+  -s, --since <DURATION>      Since duration ago (2d, 1w, 3h)
+      --after <DATE>          After date (YYYY-MM-DD)
+      --before <DATE>         Before date (YYYY-MM-DD)
+      --include-path <REGEX>  Include paths matching pattern
+      --exclude-path <REGEX>  Exclude paths matching pattern
+      --query <EXPR>          Boolean search (e.g., "rust && !deprecated")
+  -f, --field <FIELD>         Output specific field(s)
+  -n, --limit <N>             Limit results
+      --sort <ORDER>          newest, oldest, most-messages, least-messages
+      --human                 Human-readable output (default)
+      --jsonl                 JSON Lines output
+  -q, --quiet                 Suppress non-error output
+
+claude-history-query show <ID> [OPTIONS]
+
+Options:
+  -t, --tools                 Include tool calls
+      --thinking              Include thinking blocks
+      --ts-after <TS>         Messages after timestamp
+      --ts-before <TS>        Messages before timestamp
+      --human                 Human-readable output (default)
+      --jsonl                 JSON Lines output
+```
 
 ## Related projects
 

--- a/docs/plans/2026-02-06-claude-history-query-design.md
+++ b/docs/plans/2026-02-06-claude-history-query-design.md
@@ -1,0 +1,278 @@
+# claude-history-query CLI Design
+
+A programmatic CLI interface for searching Claude Code conversation history, optimized for both human users and LLM agents.
+
+## Motivation
+
+The existing `claude-history` binary provides a TUI for interactive browsing. This companion tool provides a UNIX-philosophy CLI that:
+
+* Outputs structured data (JSONL) for machine consumption
+* Composes with standard tools (`jq`, `fzf`, `xargs`)
+* Self-documents via `usage` command for LLM agent discovery
+* Uses explicit format flags rather than TTY auto-detection
+
+## Command Structure
+
+```
+claude-history-query <command> [options]
+
+Commands:
+  list     List conversations with filters
+  show     Output conversation content
+  usage    Print documentation for LLM agents
+```
+
+### Global Options
+
+```
+--human      Human-readable output (default)
+--jsonl      JSONL output (one JSON object per line)
+```
+
+## Commands
+
+### list
+
+List conversations with optional filters.
+
+```
+claude-history-query list [options]
+```
+
+**Options:**
+
+```
+-g, --global              Search all projects (not just current directory)
+-s, --since <DURATION>    Conversations within duration (e.g., 2d, 1w, 3h)
+--after <DATE|TIMESTAMP>  Conversations after date/time (YYYY-MM-DD or HH:mm)
+--before <DATE|TIMESTAMP> Conversations before date/time
+--include-path <PATTERN>  Include projects matching regex pattern
+--exclude-path <PATTERN>  Exclude projects matching regex pattern
+-q, --query <EXPR>        Boolean content query (e.g., "foo && !bar")
+--field <FIELD>           Output only specified field(s)
+--limit <N>               Limit results to N conversations
+--sort <ORDER>            Sort order: newest (default), oldest
+```
+
+**Available fields:** `uuid`, `path`, `cwd`, `timestamp`, `preview`, `project`
+
+**Output Examples:**
+
+```bash
+# Human output (default)
+claude-history-query list --human
+# [1] 2d ago  ~/projects/myapp  "Fix authentication bug..."
+# [2] 5d ago  ~/work/api        "Add rate limiting..."
+
+# JSONL output
+claude-history-query list --jsonl
+# {"uuid":"abc123","path":"/home/...","cwd":"...","timestamp":"...","preview":"..."}
+
+# Single field output
+claude-history-query list --field uuid
+# abc123
+# def456
+
+# Multiple fields (tab-separated)
+claude-history-query list --field uuid --field cwd
+# abc123	/home/user/projects/myapp
+
+# Field selection with JSONL
+claude-history-query list --jsonl --field uuid --field timestamp
+# {"uuid":"abc123","timestamp":"2026-02-04T14:30:00Z"}
+```
+
+### show
+
+Output full conversation content.
+
+```
+claude-history-query show <UUID|PATH> [options]
+```
+
+**Options:**
+
+```
+--format <FORMAT>         Output format: markdown (default), plain, raw
+--tools                   Include tool calls in output
+--thinking                Include thinking blocks in output
+--ts-after <TIMESTAMP>    Only messages after this time
+--ts-before <TIMESTAMP>   Only messages before this time
+--human                   Human-readable with syntax highlighting (default)
+--jsonl                   Each message as JSONL record
+```
+
+**Output Examples:**
+
+```bash
+# Human output (default)
+claude-history-query show abc123 --human
+# # Conversation: abc123
+# # Project: ~/projects/myapp
+# # Started: 2026-02-04 14:30
+#
+# ## User
+# Fix the authentication bug in login.rs
+#
+# ## Assistant
+# I'll look at the login.rs file...
+
+# JSONL output
+claude-history-query show abc123 --jsonl
+# {"role":"user","content":"Fix the authentication...","timestamp":"..."}
+# {"role":"assistant","content":"I'll look at...","timestamp":"..."}
+
+# Filter by message timestamp
+claude-history-query show abc123 --ts-after 09:00 --ts-before 12:00
+```
+
+**Identifier Resolution:**
+
+* If argument looks like UUID (alphanumeric, no path separators): search for matching session
+* If argument is a path: use directly
+* Exit with error if UUID matches multiple sessions
+
+### usage
+
+Output documentation optimized for LLM agents.
+
+```
+claude-history-query usage [--format human|markdown|jsonl]
+```
+
+**Purpose:** Self-describing interface for LLM agents to discover tool capabilities.
+
+**Output Example (markdown):**
+
+```markdown
+# claude-history-query
+
+Search and query Claude Code conversation history.
+
+## Commands
+
+### list
+List conversations with optional filters.
+Options: -g, --since, --after, --before, --include-path, --exclude-path, -q, --field, --limit, --sort
+
+### show <UUID|PATH>
+Output conversation content.
+Options: --format, --tools, --thinking, --ts-after, --ts-before
+
+## Common Patterns
+
+- Resume: `claude --resume "$(claude-history-query list --limit 1 --field uuid)"`
+- Search: `claude-history-query list -q 'keyword' --jsonl`
+```
+
+## Compound Command Patterns
+
+Operations like `delete` and `resume` are not implemented as subcommands. Instead, compose with shell tools:
+
+### Resume a Conversation
+
+```bash
+# Interactive selection, then resume
+claude --resume "$(claude-history-query list -g --field uuid | fzf)"
+
+# Resume most recent from current project
+claude --resume "$(claude-history-query list --limit 1 --field uuid)"
+
+# Resume most recent matching query
+claude --resume "$(claude-history-query list -q 'authentication' --limit 1 --field uuid)"
+```
+
+### Delete Conversations
+
+```bash
+# Delete single conversation by UUID
+rm "$(claude-history-query list --field path | grep abc123)"
+
+# Delete all conversations older than 30 days
+claude-history-query list --before 30d --field path | xargs rm
+
+# Interactive multi-select delete
+claude-history-query list -g --field path | fzf --multi | xargs rm
+```
+
+### Filtering Pipelines
+
+```bash
+# Find conversations about "docker" in work projects
+claude-history-query list -g --include-path '/work/' -q 'docker' --jsonl | jq '.uuid'
+
+# Export last week's conversations to archive
+claude-history-query list --since 1w --jsonl > weekly-backup.jsonl
+
+# Count conversations per project
+claude-history-query list -g --field cwd | sort | uniq -c | sort -rn
+
+# Convert JSONL to JSON array if needed
+claude-history-query list --jsonl | jq -s '.'
+```
+
+## Exit Codes
+
+```
+0   Success
+1   General error (IO, parse failure)
+2   Invalid arguments / usage error
+3   No results found (empty query result)
+4   Ambiguous identifier (UUID matches multiple)
+```
+
+### Error Handling
+
+* Errors go to stderr, never stdout (keeps pipelines clean)
+* `--quiet` suppresses non-essential output (no short form to avoid collision with `-q`/`--query`)
+
+```bash
+# Won't pollute the pipeline even on error
+claude-history-query list -q 'nonexistent' --field uuid | wc -l
+# stderr: "No conversations match query"
+# stdout: (empty)
+# exit: 3
+```
+
+## Architecture
+
+### Binary Structure
+
+```
+claude-history/
+├── src/
+│   ├── lib.rs              # Shared library (existing filters, parsers)
+│   ├── main.rs             # TUI binary (existing claude-history)
+│   └── bin/
+│       └── claude-history-query.rs   # New CLI binary
+├── Cargo.toml              # Add [[bin]] entry
+```
+
+### Dependencies
+
+Reuses existing library crate:
+
+* `claude_history::time_filter::TimeFilter`
+* `claude_history::path_filter::PathFilter`
+* `claude_history::query::{parse_query, evaluate}`
+* `history::Conversation`, loaders
+
+No TUI dependencies (ratatui, crossterm) - keeps binary small.
+
+### Implementation Order
+
+1. Add `src/bin/claude-history-query.rs` scaffold with clap
+2. Implement `list` command using existing loaders
+3. Implement `show` command using existing display logic
+4. Implement `usage` command (static documentation)
+5. Add `--field` output formatting
+6. Add `--ts-after/--ts-before` to show
+7. Documentation with compound examples
+
+## Design Principles
+
+* **Explicit over implicit:** Always use `--human` or `--jsonl` flags rather than TTY auto-detection
+* **UNIX composability:** Single-purpose commands that combine with `jq`, `fzf`, `xargs`
+* **Self-documenting:** `usage` command provides LLM-friendly documentation
+* **Minimal subcommands:** Compound operations via shell composition, not built-in commands
+* **Descriptive naming:** `claude-history-query` over abbreviated `chq`

--- a/docs/plans/2026-02-06-claude-history-query-implementation.md
+++ b/docs/plans/2026-02-06-claude-history-query-implementation.md
@@ -1,0 +1,833 @@
+# claude-history-query Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a programmatic CLI binary for searching Claude Code conversation history, optimized for scripts and LLM agents.
+
+**Architecture:** New binary `src/query_main.rs` sharing internal modules with existing `src/main.rs`. Uses same `history`, `error`, `cli` modules. Clap-based CLI with three commands: `list`, `show`, `usage`. Output in human-readable or JSONL format.
+
+**Tech Stack:** Rust, clap (derive), serde_json, existing internal modules.
+
+**Key Insight:** Place binary at `src/query_main.rs` (not `src/bin/`) so it's part of the same crate and can access all internal modules directly via `crate::history`, `crate::error`, etc.
+
+---
+
+## Task 1: Add Binary Scaffold
+
+**Files:**
+
+* Modify: `Cargo.toml:17-19`
+* Create: `src/query_main.rs`
+
+**Step 1: Add [[bin]] entry to Cargo.toml**
+
+Add after line 19 (after existing `[[bin]]` block):
+
+```toml
+[[bin]]
+name = "claude-history-query"
+path = "src/query_main.rs"
+```
+
+**Step 2: Create minimal binary scaffold**
+
+Create `src/query_main.rs`:
+
+```rust
+//! claude-history-query: Programmatic CLI for conversation search
+//!
+//! Designed for scripts and LLM agents with structured output.
+
+mod claude;
+mod cli;
+mod config;
+mod debug;
+mod debug_log;
+mod error;
+mod history;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use error::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
+enum OutputFormat {
+    #[default]
+    Human,
+    Jsonl,
+}
+
+#[derive(Parser)]
+#[command(name = "claude-history-query")]
+#[command(about = "Search Claude Code conversation history (programmatic CLI)")]
+#[command(version)]
+struct Cli {
+    /// Output format: human (default) or jsonl
+    #[arg(long, value_enum, global = true, default_value_t = OutputFormat::Human)]
+    human: bool,
+
+    /// Output in JSONL format (one JSON object per line)
+    #[arg(long, global = true)]
+    jsonl: bool,
+
+    /// Suppress non-essential output
+    #[arg(long, global = true)]
+    quiet: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List conversations with filters
+    List(ListArgs),
+    /// Output conversation content
+    Show(ShowArgs),
+    /// Print documentation for LLM agents
+    Usage,
+}
+
+#[derive(clap::Args)]
+struct ListArgs {
+    /// Search all projects globally
+    #[arg(long, short = 'g')]
+    global: bool,
+
+    /// Filter by duration (e.g., 2d, 1w, 3h)
+    #[arg(long, short = 's', value_name = "DURATION")]
+    since: Option<String>,
+
+    /// Filter conversations after date/time
+    #[arg(long, value_name = "DATE|TIME")]
+    after: Option<String>,
+
+    /// Filter conversations before date/time
+    #[arg(long, value_name = "DATE|TIME")]
+    before: Option<String>,
+
+    /// Include paths matching regex
+    #[arg(long, action = clap::ArgAction::Append, value_name = "PATTERN")]
+    include_path: Vec<String>,
+
+    /// Exclude paths matching regex
+    #[arg(long, action = clap::ArgAction::Append, value_name = "PATTERN")]
+    exclude_path: Vec<String>,
+
+    /// Boolean content query
+    #[arg(long, short = 'q', value_name = "QUERY")]
+    query: Option<String>,
+
+    /// Output only specified field(s): uuid, path, cwd, timestamp, preview, project
+    #[arg(long, action = clap::ArgAction::Append, value_name = "FIELD")]
+    field: Vec<String>,
+
+    /// Limit results to N conversations
+    #[arg(long, value_name = "N")]
+    limit: Option<usize>,
+
+    /// Sort order
+    #[arg(long, default_value = "newest", value_parser = ["newest", "oldest"])]
+    sort: String,
+}
+
+#[derive(clap::Args)]
+struct ShowArgs {
+    /// UUID or path to conversation
+    identifier: String,
+
+    /// Output format: markdown, plain, raw
+    #[arg(long, default_value = "markdown")]
+    format: String,
+
+    /// Include tool calls
+    #[arg(long)]
+    tools: bool,
+
+    /// Include thinking blocks
+    #[arg(long)]
+    thinking: bool,
+
+    /// Only messages after this time
+    #[arg(long, value_name = "TIME")]
+    ts_after: Option<String>,
+
+    /// Only messages before this time
+    #[arg(long, value_name = "TIME")]
+    ts_before: Option<String>,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    let format = if cli.jsonl {
+        OutputFormat::Jsonl
+    } else {
+        OutputFormat::Human
+    };
+
+    match cli.command {
+        Commands::List(args) => {
+            eprintln!("list: global={}, format={:?} (not implemented)", args.global, format);
+        }
+        Commands::Show(args) => {
+            eprintln!("show: {} (not implemented)", args.identifier);
+        }
+        Commands::Usage => {
+            eprintln!("usage (not implemented)");
+        }
+    }
+
+    Ok(())
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `cargo build --bin claude-history-query`
+Expected: Compiles successfully
+
+**Step 4: Verify help works**
+
+Run: `cargo run --bin claude-history-query -- --help`
+Expected: Shows help with list, show, usage subcommands
+
+**Step 5: Commit**
+
+```bash
+git add Cargo.toml src/query_main.rs
+git commit -m "feat: add claude-history-query binary scaffold
+
+New programmatic CLI for scripts and LLM agents.
+Subcommands: list, show, usage (stubs).
+Shares internal modules with main binary.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement List Command Core Logic
+
+**Files:**
+
+* Modify: `src/query_main.rs`
+
+**Step 1: Add imports and output struct**
+
+Add after the `mod` declarations:
+
+```rust
+use claude_history::path_filter::PathFilter;
+use claude_history::query::{evaluate, parse_query, QueryExpr};
+use claude_history::time_filter::TimeFilter;
+use error::AppError;
+use history::Conversation;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ConversationOutput {
+    uuid: String,
+    path: String,
+    cwd: Option<String>,
+    timestamp: String,
+    preview: String,
+    project: Option<String>,
+}
+
+impl From<&Conversation> for ConversationOutput {
+    fn from(conv: &Conversation) -> Self {
+        Self {
+            uuid: conv.path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string(),
+            path: conv.path.display().to_string(),
+            cwd: conv.cwd.as_ref().map(|p| p.display().to_string()),
+            timestamp: conv.timestamp.to_rfc3339(),
+            preview: conv.preview.clone(),
+            project: conv.project_name.clone(),
+        }
+    }
+}
+```
+
+**Step 2: Implement run_list function**
+
+Add before `main()`:
+
+```rust
+fn build_time_filter(args: &ListArgs) -> Result<Option<TimeFilter>> {
+    if args.since.is_none() && args.after.is_none() && args.before.is_none() {
+        return Ok(None);
+    }
+
+    let mut filter = TimeFilter::new();
+
+    if let Some(ref since) = args.since {
+        filter = filter
+            .with_since(since)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --since: {}", e)))?;
+    }
+    if let Some(ref after) = args.after {
+        filter = filter
+            .with_after(after)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --after: {}", e)))?;
+    }
+    if let Some(ref before) = args.before {
+        filter = filter
+            .with_before(before)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --before: {}", e)))?;
+    }
+
+    Ok(Some(filter))
+}
+
+fn build_path_filter(args: &ListArgs) -> Result<Option<PathFilter>> {
+    if args.include_path.is_empty() && args.exclude_path.is_empty() {
+        return Ok(None);
+    }
+
+    PathFilter::from_patterns(&args.include_path, &args.exclude_path)
+        .map(Some)
+        .map_err(|e| AppError::InvalidArgs(format!("Invalid path pattern: {}", e)))
+}
+
+fn run_list(args: ListArgs, format: OutputFormat, quiet: bool) -> Result<()> {
+    let time_filter = build_time_filter(&args)?;
+    let path_filter = build_path_filter(&args)?;
+    let query_expr = args.query.as_ref()
+        .map(|q| parse_query(q))
+        .transpose()
+        .map_err(|e| AppError::InvalidArgs(format!("Invalid query: {}", e)))?;
+
+    // Load conversations
+    let mut conversations = if args.global {
+        history::load_all_conversations(false, None, time_filter.as_ref(), path_filter.as_ref())?
+    } else {
+        let current_dir = std::env::current_dir()?;
+        let projects_dir = history::get_claude_projects_dir(&current_dir)?;
+        if !projects_dir.exists() {
+            return Err(AppError::ProjectsDirNotFound(projects_dir.display().to_string()));
+        }
+        history::load_conversations(&projects_dir, false, None, time_filter.as_ref(), path_filter.as_ref())?
+    };
+
+    // Apply content query filter
+    if let Some(ref query) = query_expr {
+        conversations.retain(|conv| evaluate(query, &conv.full_text));
+    }
+
+    // Apply sort
+    if args.sort == "oldest" {
+        conversations.reverse();
+    }
+
+    // Apply limit
+    if let Some(limit) = args.limit {
+        conversations.truncate(limit);
+    }
+
+    if conversations.is_empty() {
+        if !quiet {
+            eprintln!("No conversations found");
+        }
+        std::process::exit(3);
+    }
+
+    // Output
+    output_list(&conversations, &args.field, format);
+
+    Ok(())
+}
+
+fn output_list(conversations: &[Conversation], fields: &[String], format: OutputFormat) {
+    for conv in conversations {
+        let out = ConversationOutput::from(conv);
+
+        match format {
+            OutputFormat::Jsonl => {
+                if fields.is_empty() {
+                    println!("{}", serde_json::to_string(&out).unwrap());
+                } else {
+                    let filtered = filter_fields(&out, fields);
+                    println!("{}", serde_json::to_string(&filtered).unwrap());
+                }
+            }
+            OutputFormat::Human => {
+                if fields.is_empty() {
+                    // Full human output
+                    let age = chrono_humanize::HumanTime::from(conv.timestamp);
+                    let project = out.project.as_deref().unwrap_or("unknown");
+                    println!("{}\t{}\t{}\t{}", out.uuid, age, project, out.preview);
+                } else if fields.len() == 1 {
+                    println!("{}", get_field(&out, &fields[0]));
+                } else {
+                    let vals: Vec<_> = fields.iter().map(|f| get_field(&out, f)).collect();
+                    println!("{}", vals.join("\t"));
+                }
+            }
+        }
+    }
+}
+
+fn filter_fields(out: &ConversationOutput, fields: &[String]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for field in fields {
+        match field.as_str() {
+            "uuid" => { map.insert("uuid".into(), serde_json::json!(out.uuid)); }
+            "path" => { map.insert("path".into(), serde_json::json!(out.path)); }
+            "cwd" => { map.insert("cwd".into(), serde_json::json!(out.cwd)); }
+            "timestamp" => { map.insert("timestamp".into(), serde_json::json!(out.timestamp)); }
+            "preview" => { map.insert("preview".into(), serde_json::json!(out.preview)); }
+            "project" => { map.insert("project".into(), serde_json::json!(out.project)); }
+            _ => {}
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+fn get_field(out: &ConversationOutput, field: &str) -> String {
+    match field {
+        "uuid" => out.uuid.clone(),
+        "path" => out.path.clone(),
+        "cwd" => out.cwd.clone().unwrap_or_default(),
+        "timestamp" => out.timestamp.clone(),
+        "preview" => out.preview.clone(),
+        "project" => out.project.clone().unwrap_or_default(),
+        _ => String::new(),
+    }
+}
+```
+
+**Step 3: Wire up in run()**
+
+Update the `Commands::List` match arm:
+
+```rust
+Commands::List(args) => run_list(args, format, cli.quiet)?,
+```
+
+**Step 4: Add chrono-humanize import**
+
+Add to top of file:
+
+```rust
+use chrono_humanize;
+```
+
+**Step 5: Verify list works**
+
+Run: `cargo run --bin claude-history-query -- list -g --limit 3`
+Expected: Shows 3 conversations
+
+Run: `cargo run --bin claude-history-query -- list --jsonl --limit 2`
+Expected: JSONL output
+
+Run: `cargo run --bin claude-history-query -- list --field uuid --limit 2`
+Expected: Just UUIDs
+
+**Step 6: Commit**
+
+```bash
+git add src/query_main.rs
+git commit -m "feat(query): implement list command with all filters
+
+- Time filtering: --since, --after, --before
+- Path filtering: --include-path, --exclude-path
+- Content query: -q/--query
+- Output control: --field, --limit, --sort
+- Formats: --human (default), --jsonl
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Implement Show Command
+
+**Files:**
+
+* Modify: `src/query_main.rs`
+
+**Step 1: Add show command imports and implementation**
+
+Add these functions:
+
+```rust
+fn find_conversation_by_id(uuid: &str) -> Result<std::path::PathBuf> {
+    let projects_root = history::get_claude_projects_root()?;
+
+    // Search all project directories for matching UUID
+    for entry in std::fs::read_dir(&projects_root)? {
+        let entry = entry?;
+        let project_dir = entry.path();
+        if !project_dir.is_dir() {
+            continue;
+        }
+
+        for file in std::fs::read_dir(&project_dir)? {
+            let file = file?;
+            let path = file.path();
+            if path.extension().map(|e| e == "jsonl").unwrap_or(false) {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    if stem == uuid || stem.starts_with(&format!("{}-", uuid)) {
+                        return Ok(path);
+                    }
+                }
+            }
+        }
+    }
+
+    Err(AppError::NoHistoryFound(format!("UUID: {}", uuid)))
+}
+
+fn run_show(args: ShowArgs, format: OutputFormat) -> Result<()> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    // Resolve identifier to path
+    let path = if args.identifier.contains('/') || args.identifier.contains('.') {
+        std::path::PathBuf::from(&args.identifier)
+    } else {
+        find_conversation_by_id(&args.identifier)?
+    };
+
+    if !path.exists() {
+        return Err(AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("File not found: {}", path.display()),
+        )));
+    }
+
+    let file = File::open(&path)?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let entry: serde_json::Value = serde_json::from_str(&line)?;
+
+        // Filter by message type
+        let msg_type = entry.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        // Skip tool messages unless --tools
+        if !args.tools && (msg_type == "tool_use" || msg_type == "tool_result") {
+            continue;
+        }
+
+        // Handle based on format
+        match format {
+            OutputFormat::Jsonl => {
+                println!("{}", line);
+            }
+            OutputFormat::Human => {
+                // Simple human-readable output
+                if let Some(role) = entry.get("role").and_then(|r| r.as_str()) {
+                    match role {
+                        "user" => {
+                            if let Some(content) = entry.get("content") {
+                                println!("## User\n");
+                                print_content(content);
+                                println!();
+                            }
+                        }
+                        "assistant" => {
+                            if let Some(content) = entry.get("content") {
+                                println!("## Assistant\n");
+                                print_content(content);
+                                println!();
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_content(content: &serde_json::Value) {
+    match content {
+        serde_json::Value::String(s) => println!("{}", s),
+        serde_json::Value::Array(arr) => {
+            for item in arr {
+                if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                    println!("{}", text);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+```
+
+**Step 2: Wire up in run()**
+
+Update the `Commands::Show` match arm:
+
+```rust
+Commands::Show(args) => run_show(args, format)?,
+```
+
+**Step 3: Verify show works**
+
+Run: `cargo run --bin claude-history-query -- list --field uuid --limit 1`
+(Note the UUID)
+
+Run: `cargo run --bin claude-history-query -- show <UUID>`
+Expected: Shows conversation content
+
+Run: `cargo run --bin claude-history-query -- show --jsonl <UUID>`
+Expected: JSONL message stream
+
+**Step 4: Commit**
+
+```bash
+git add src/query_main.rs
+git commit -m "feat(query): implement show command
+
+- Accepts UUID or path
+- Filters: --tools, --thinking
+- Formats: human (markdown-ish) or jsonl
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Implement Usage Command
+
+**Files:**
+
+* Modify: `src/query_main.rs`
+
+**Step 1: Add usage command implementation**
+
+```rust
+fn run_usage(format: OutputFormat) {
+    match format {
+        OutputFormat::Human | OutputFormat::Jsonl => {
+            // Same markdown output for both (usage is documentation)
+            print!(r#"# claude-history-query
+
+Search and query Claude Code conversation history.
+
+## Commands
+
+### list
+List conversations with optional filters.
+
+Options:
+  -g, --global         Search all projects
+  -s, --since DURATION Filter by duration (2d, 1w, 3h)
+  --after DATE|TIME    Filter after date/time
+  --before DATE|TIME   Filter before date/time
+  --include-path PAT   Include paths matching regex
+  --exclude-path PAT   Exclude paths matching regex
+  -q, --query EXPR     Boolean content query
+  --field FIELD        Output specific field(s)
+  --limit N            Limit results
+  --sort ORDER         newest (default) or oldest
+
+### show <UUID|PATH>
+Output conversation content.
+
+Options:
+  --format FORMAT      markdown, plain, raw
+  --tools              Include tool calls
+  --thinking           Include thinking blocks
+  --ts-after TIME      Messages after time
+  --ts-before TIME     Messages before time
+
+## Output Formats
+
+--human    Human-readable (default)
+--jsonl    One JSON object per line
+
+## Field Names
+
+uuid, path, cwd, timestamp, preview, project
+
+## Common Patterns
+
+Resume conversation:
+  claude --resume "$(claude-history-query list --limit 1 --field uuid)"
+
+Search and resume:
+  claude --resume "$(claude-history-query list -q 'auth' --field uuid | fzf)"
+
+Export to backup:
+  claude-history-query list --since 1w --jsonl > backup.jsonl
+
+Delete old conversations:
+  claude-history-query list --before 30d --field path | xargs rm
+
+## Exit Codes
+
+0  Success
+1  General error
+2  Invalid arguments
+3  No results found
+"#);
+        }
+    }
+}
+```
+
+**Step 2: Wire up in run()**
+
+Update the `Commands::Usage` match arm:
+
+```rust
+Commands::Usage => run_usage(format),
+```
+
+**Step 3: Verify usage works**
+
+Run: `cargo run --bin claude-history-query -- usage`
+Expected: Shows documentation
+
+**Step 4: Commit**
+
+```bash
+git add src/query_main.rs
+git commit -m "feat(query): implement usage command
+
+Self-documenting CLI for LLM agents.
+Shows commands, options, common patterns.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add Exit Code Handling
+
+**Files:**
+
+* Modify: `src/query_main.rs`
+
+**Step 1: Define exit codes**
+
+Add after imports:
+
+```rust
+mod exit_codes {
+    pub const SUCCESS: i32 = 0;
+    pub const ERROR: i32 = 1;
+    pub const INVALID_ARGS: i32 = 2;
+    pub const NO_RESULTS: i32 = 3;
+}
+```
+
+**Step 2: Update main() for proper exit codes**
+
+```rust
+fn main() {
+    match run() {
+        Ok(()) => std::process::exit(exit_codes::SUCCESS),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            let code = match &e {
+                AppError::InvalidArgs(_) => exit_codes::INVALID_ARGS,
+                AppError::NoHistoryFound(_) => exit_codes::NO_RESULTS,
+                _ => exit_codes::ERROR,
+            };
+            std::process::exit(code);
+        }
+    }
+}
+```
+
+**Step 3: Verify exit codes**
+
+Run: `cargo run --bin claude-history-query -- list -q 'xyznonexistent123'; echo $?`
+Expected: Exit code 3
+
+Run: `cargo run --bin claude-history-query -- list --since invalid; echo $?`
+Expected: Exit code 2
+
+**Step 4: Commit**
+
+```bash
+git add src/query_main.rs
+git commit -m "feat(query): add proper exit codes
+
+0=success, 1=error, 2=invalid args, 3=no results
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Final Testing and Documentation
+
+**Files:**
+
+* Modify: `README.md` (optional section about query binary)
+
+**Step 1: Run full test suite**
+
+Run: `cargo test`
+Expected: All tests pass
+
+**Step 2: Test key workflows**
+
+```bash
+# List with JSONL
+cargo run --bin claude-history-query -- list -g --jsonl --limit 5
+
+# Field selection
+cargo run --bin claude-history-query -- list --field uuid --field cwd --limit 3
+
+# Resume pattern
+UUID=$(cargo run --bin claude-history-query -- list --limit 1 --field uuid)
+echo "Would resume: $UUID"
+
+# Show conversation
+cargo run --bin claude-history-query -- show "$UUID"
+
+# Usage
+cargo run --bin claude-history-query -- usage
+```
+
+**Step 3: Commit final version**
+
+```bash
+git add -A
+git commit -m "feat(query): complete claude-history-query implementation
+
+Programmatic CLI for scripts and LLM agents:
+- list: search with filters, field selection, JSONL output
+- show: view conversation content
+- usage: self-documenting for LLM discovery
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+---
+
+## Summary
+
+| Task | Description | Key Files |
+|------|-------------|-----------|
+| 1 | Binary scaffold | Cargo.toml, src/query_main.rs |
+| 2 | List command | src/query_main.rs |
+| 3 | Show command | src/query_main.rs |
+| 4 | Usage command | src/query_main.rs |
+| 5 | Exit codes | src/query_main.rs |
+| 6 | Testing | - |
+
+Total: 6 tasks, single file implementation leveraging existing modules.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,6 +189,25 @@ pub struct Args {
     )]
     pub exclude_path: Vec<String>,
 
+    // ==================== Content Filtering ====================
+    /// Boolean search query to filter conversations by content
+    ///
+    /// Searches the full conversation text using boolean expressions:
+    /// - Terms: `rust`, `"exact phrase"`
+    /// - AND: `rust && api`
+    /// - OR: `rust || python`
+    /// - NOT: `!deprecated`
+    /// - Grouping: `(rust || go) && !java`
+    ///
+    /// Matching is case-insensitive.
+    #[arg(
+        long,
+        short = 'q',
+        value_name = "QUERY",
+        help = "Boolean search query (e.g., 'rust && !deprecated')"
+    )]
+    pub query: Option<String>,
+
     /// Display output through a pager (less)
     #[arg(long, group = "pager_display")]
     pub pager: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,6 +122,38 @@ pub struct Args {
     )]
     pub global: bool,
 
+    // ==================== Time Filtering ====================
+    /// Show conversations since a duration ago (e.g., 2d, 1w, 3h)
+    ///
+    /// Duration format: <number><unit> where unit is:
+    /// - h: hours (e.g., 3h = 3 hours ago)
+    /// - d: days (e.g., 2d = 2 days ago)
+    /// - w: weeks (e.g., 1w = 1 week ago)
+    /// - m: months, ~30 days (e.g., 1m = ~30 days ago)
+    #[arg(
+        long,
+        short = 's',
+        value_name = "DURATION",
+        help = "Show conversations since duration (e.g., 2d, 1w, 3h)"
+    )]
+    pub since: Option<String>,
+
+    /// Show conversations after a specific date (YYYY-MM-DD)
+    #[arg(
+        long,
+        value_name = "DATE",
+        help = "Show conversations after date (YYYY-MM-DD)"
+    )]
+    pub after: Option<String>,
+
+    /// Show conversations before a specific date (YYYY-MM-DD)
+    #[arg(
+        long,
+        value_name = "DATE",
+        help = "Show conversations before date (YYYY-MM-DD)"
+    )]
+    pub before: Option<String>,
+
     /// Display output through a pager (less)
     #[arg(long, group = "pager_display")]
     pub pager: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,6 +154,41 @@ pub struct Args {
     )]
     pub before: Option<String>,
 
+    // ==================== Path Filtering ====================
+    /// Include only paths matching regex pattern
+    ///
+    /// Can be specified multiple times; paths matching ANY pattern are included.
+    /// If no include patterns are specified, all paths are included by default.
+    ///
+    /// Examples:
+    /// - --include-path "/work/" (paths containing /work/)
+    /// - --include-path "^/home/user/projects" (paths starting with...)
+    /// - --include-path "(?i)rust" (case-insensitive match)
+    #[arg(
+        long,
+        action = clap::ArgAction::Append,
+        value_name = "PATTERN",
+        help = "Include paths matching regex (can be repeated)"
+    )]
+    pub include_path: Vec<String>,
+
+    /// Exclude paths matching regex pattern
+    ///
+    /// Can be specified multiple times; paths matching ANY pattern are excluded.
+    /// Exclusions take precedence over inclusions.
+    ///
+    /// Examples:
+    /// - --exclude-path "test" (exclude paths containing 'test')
+    /// - --exclude-path "node_modules" (exclude node_modules)
+    /// - --exclude-path "\\.git" (exclude .git directories)
+    #[arg(
+        long,
+        action = clap::ArgAction::Append,
+        value_name = "PATTERN",
+        help = "Exclude paths matching regex (can be repeated)"
+    )]
+    pub exclude_path: Vec<String>,
+
     /// Display output through a pager (less)
     #[arg(long, group = "pager_display")]
     pub pager: bool,

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ pub enum AppError {
 
     #[error("Configuration error: {0}")]
     ConfigError(String),
+
+    #[error("Invalid argument: {0}")]
+    InvalidArgs(String),
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -2,6 +2,19 @@
 //!
 //! This module handles loading conversations from Claude project directories,
 //! both synchronously and via streaming for the TUI.
+//!
+//! # Time Filtering
+//!
+//! All load functions accept an optional [`TimeFilter`] to restrict results
+//! to conversations within a specific time range.
+//!
+//! ```rust,ignore
+//! use claude_history::time_filter::TimeFilter;
+//!
+//! // Load only conversations from the last 2 days
+//! let filter = TimeFilter::from_since("2d").unwrap();
+//! let conversations = load_conversations(&projects_dir, false, None, Some(&filter))?;
+//! ```
 
 use super::parser::process_conversation_file;
 use super::path::{
@@ -11,6 +24,7 @@ use super::{Conversation, LoaderMessage, Project};
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
+use claude_history::time_filter::TimeFilter;
 use rayon::prelude::*;
 use std::fs::read_dir;
 use std::path::Path;
@@ -18,11 +32,18 @@ use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::SystemTime;
 
-/// Load conversations from ALL projects globally
+/// Load conversations from ALL projects globally.
+///
+/// # Arguments
+///
+/// * `show_last` - If true, show last messages in preview instead of first
+/// * `debug_level` - Optional debug logging level
+/// * `time_filter` - Optional time filter to restrict results by timestamp
 #[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time_filter: Option<&TimeFilter>,
 ) -> Result<Vec<Conversation>> {
     let root = super::get_claude_projects_root()?;
     let projects = list_projects(&root)?;
@@ -37,7 +58,7 @@ pub fn load_all_conversations(
         .par_iter()
         .flat_map(|project| {
             let project_dir = root.join(&project.name);
-            match load_conversations(&project_dir, show_last, debug_level) {
+            match load_conversations(&project_dir, show_last, debug_level, time_filter) {
                 Ok(mut convs) => {
                     // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
@@ -82,16 +103,24 @@ pub fn load_all_conversations(
     Ok(all_conversations)
 }
 
-/// Start loading all conversations in the background
-/// Returns a receiver that will receive LoaderMessage updates
+/// Start loading all conversations in the background.
+///
+/// Returns a receiver that will receive [`LoaderMessage`] updates as projects are loaded.
+///
+/// # Arguments
+///
+/// * `show_last` - If true, show last messages in preview instead of first
+/// * `debug_level` - Optional debug logging level
+/// * `time_filter` - Optional time filter to restrict results by timestamp (owned, will be moved to thread)
 pub fn load_all_conversations_streaming(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time_filter: Option<TimeFilter>,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level);
+        load_all_streaming_inner(tx, show_last, debug_level, time_filter);
     });
 
     rx
@@ -101,6 +130,7 @@ fn load_all_streaming_inner(
     tx: Sender<LoaderMessage>,
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time_filter: Option<TimeFilter>,
 ) {
     // First, validate that the projects root exists (fatal if not)
     let root = match super::get_claude_projects_root() {
@@ -136,7 +166,7 @@ fn load_all_streaming_inner(
     projects.par_iter().for_each(|project| {
         let project_dir = root.join(&project.name);
 
-        match load_conversations(&project_dir, show_last, debug_level) {
+        match load_conversations(&project_dir, show_last, debug_level, time_filter.as_ref()) {
             Ok(mut convs) => {
                 if convs.is_empty() {
                     return;
@@ -223,11 +253,32 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
     Ok(projects)
 }
 
-/// Find and process all conversation files in one pass
+/// Find and process all conversation files in one pass.
+///
+/// # Arguments
+///
+/// * `projects_dir` - The Claude projects directory to load from
+/// * `show_last` - If true, show last messages in preview instead of first
+/// * `debug_level` - Optional debug logging level
+/// * `time_filter` - Optional time filter to restrict results by timestamp
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use claude_history::time_filter::TimeFilter;
+///
+/// // Load all conversations
+/// let all = load_conversations(&dir, false, None, None)?;
+///
+/// // Load only last week's conversations
+/// let filter = TimeFilter::from_since("1w").unwrap();
+/// let recent = load_conversations(&dir, false, None, Some(&filter))?;
+/// ```
 pub fn load_conversations(
     projects_dir: &Path,
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time_filter: Option<&TimeFilter>,
 ) -> Result<Vec<Conversation>> {
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
@@ -300,6 +351,23 @@ pub fn load_conversations(
 
     // Ensure deterministic ordering after parallel processing
     conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    // Apply time filter if provided
+    if let Some(filter) = time_filter {
+        let before_count = conversations.len();
+        conversations.retain(|conv| filter.matches(conv.timestamp));
+        let filtered_count = before_count - conversations.len();
+        if filtered_count > 0 {
+            debug::info(
+                debug_level,
+                &format!(
+                    "Time filter excluded {} conversations ({} remaining)",
+                    filtered_count,
+                    conversations.len()
+                ),
+            );
+        }
+    }
 
     // Inject project info into each conversation
     let fallback_path = projects_dir

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -3,17 +3,23 @@
 //! This module handles loading conversations from Claude project directories,
 //! both synchronously and via streaming for the TUI.
 //!
-//! # Time Filtering
+//! # Filtering
 //!
-//! All load functions accept an optional [`TimeFilter`] to restrict results
-//! to conversations within a specific time range.
+//! All load functions accept optional filters to restrict results:
+//! - [`TimeFilter`] - Filter by conversation timestamp
+//! - [`PathFilter`] - Filter by project directory path
 //!
 //! ```rust,ignore
 //! use claude_history::time_filter::TimeFilter;
+//! use claude_history::path_filter::PathFilter;
 //!
-//! // Load only conversations from the last 2 days
-//! let filter = TimeFilter::from_since("2d").unwrap();
-//! let conversations = load_conversations(&projects_dir, false, None, Some(&filter))?;
+//! // Load only conversations from the last 2 days in work projects
+//! let time_filter = TimeFilter::from_since("2d").unwrap();
+//! let path_filter = PathFilter::new().with_include("/work/").unwrap();
+//! let conversations = load_conversations(
+//!     &projects_dir, false, None,
+//!     Some(&time_filter), Some(&path_filter),
+//! )?;
 //! ```
 
 use super::parser::process_conversation_file;
@@ -24,6 +30,7 @@ use super::{Conversation, LoaderMessage, Project};
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
+use claude_history::path_filter::PathFilter;
 use claude_history::time_filter::TimeFilter;
 use rayon::prelude::*;
 use std::fs::read_dir;
@@ -39,11 +46,13 @@ use std::time::SystemTime;
 /// * `show_last` - If true, show last messages in preview instead of first
 /// * `debug_level` - Optional debug logging level
 /// * `time_filter` - Optional time filter to restrict results by timestamp
+/// * `path_filter` - Optional path filter to restrict results by project path
 #[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time_filter: Option<&TimeFilter>,
+    path_filter: Option<&PathFilter>,
 ) -> Result<Vec<Conversation>> {
     let root = super::get_claude_projects_root()?;
     let projects = list_projects(&root)?;
@@ -56,9 +65,25 @@ pub fn load_all_conversations(
     // Load conversations from all projects in parallel
     let mut all_conversations: Vec<Conversation> = projects
         .par_iter()
+        .filter(|project| {
+            // Apply path filter at project level
+            if let Some(filter) = path_filter {
+                let project_path = decode_project_dir_name_to_path(&project.name);
+                let matches = filter.matches(&project_path);
+                if !matches {
+                    debug::debug(
+                        debug_level,
+                        &format!("Path filter excluded project: {}", project_path.display()),
+                    );
+                }
+                matches
+            } else {
+                true
+            }
+        })
         .flat_map(|project| {
             let project_dir = root.join(&project.name);
-            match load_conversations(&project_dir, show_last, debug_level, time_filter) {
+            match load_conversations(&project_dir, show_last, debug_level, time_filter, None) {
                 Ok(mut convs) => {
                     // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
@@ -112,15 +137,17 @@ pub fn load_all_conversations(
 /// * `show_last` - If true, show last messages in preview instead of first
 /// * `debug_level` - Optional debug logging level
 /// * `time_filter` - Optional time filter to restrict results by timestamp (owned, will be moved to thread)
+/// * `path_filter` - Optional path filter to restrict results by project path (owned, will be moved to thread)
 pub fn load_all_conversations_streaming(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time_filter: Option<TimeFilter>,
+    path_filter: Option<PathFilter>,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level, time_filter);
+        load_all_streaming_inner(tx, show_last, debug_level, time_filter, path_filter);
     });
 
     rx
@@ -131,6 +158,7 @@ fn load_all_streaming_inner(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time_filter: Option<TimeFilter>,
+    path_filter: Option<PathFilter>,
 ) {
     // First, validate that the projects root exists (fatal if not)
     let root = match super::get_claude_projects_root() {
@@ -163,10 +191,28 @@ fn load_all_streaming_inner(
     );
 
     // Process projects in parallel and send batches as they complete
-    projects.par_iter().for_each(|project| {
-        let project_dir = root.join(&project.name);
+    projects
+        .par_iter()
+        .filter(|project| {
+            // Apply path filter at project level
+            if let Some(ref filter) = path_filter {
+                let project_path = decode_project_dir_name_to_path(&project.name);
+                let matches = filter.matches(&project_path);
+                if !matches {
+                    debug::debug(
+                        debug_level,
+                        &format!("Path filter excluded project: {}", project_path.display()),
+                    );
+                }
+                matches
+            } else {
+                true
+            }
+        })
+        .for_each(|project| {
+            let project_dir = root.join(&project.name);
 
-        match load_conversations(&project_dir, show_last, debug_level, time_filter.as_ref()) {
+            match load_conversations(&project_dir, show_last, debug_level, time_filter.as_ref(), None) {
             Ok(mut convs) => {
                 if convs.is_empty() {
                     return;
@@ -261,24 +307,27 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
 /// * `show_last` - If true, show last messages in preview instead of first
 /// * `debug_level` - Optional debug logging level
 /// * `time_filter` - Optional time filter to restrict results by timestamp
+/// * `path_filter` - Optional path filter (typically applied at project level by callers)
 ///
 /// # Examples
 ///
 /// ```rust,ignore
 /// use claude_history::time_filter::TimeFilter;
+/// use claude_history::path_filter::PathFilter;
 ///
 /// // Load all conversations
-/// let all = load_conversations(&dir, false, None, None)?;
+/// let all = load_conversations(&dir, false, None, None, None)?;
 ///
 /// // Load only last week's conversations
-/// let filter = TimeFilter::from_since("1w").unwrap();
-/// let recent = load_conversations(&dir, false, None, Some(&filter))?;
+/// let time_filter = TimeFilter::from_since("1w").unwrap();
+/// let recent = load_conversations(&dir, false, None, Some(&time_filter), None)?;
 /// ```
 pub fn load_conversations(
     projects_dir: &Path,
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time_filter: Option<&TimeFilter>,
+    _path_filter: Option<&PathFilter>,  // Filtering happens at project level in callers
 ) -> Result<Vec<Conversation>> {
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 // Re-export public API
-pub use loader::{load_all_conversations_streaming, load_conversations};
+pub use loader::{load_all_conversations, load_all_conversations_streaming, load_conversations};
 pub use parser::process_conversation_file;
 pub use path::{convert_path_to_project_dir_name, format_short_name_from_path};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,14 @@
 //!
 //! - [`time_filter`] - Time-based filtering with duration and date range support
 //! - [`path_filter`] - Path-based filtering with regex include/exclude patterns
+//! - [`query`] - Boolean query parsing and evaluation for content search
 //!
 //! ## Example
 //!
 //! ```rust,no_run
 //! use claude_history::time_filter::TimeFilter;
 //! use claude_history::path_filter::PathFilter;
+//! use claude_history::query::{parse_query, evaluate};
 //! use chrono::{Duration, Local};
 //! use std::path::Path;
 //!
@@ -35,7 +37,13 @@
 //!     .unwrap();
 //!
 //! assert!(path_filter.matches(Path::new("/home/user/work/myapp")));
+//!
+//! // Create a boolean query for content search
+//! let query = parse_query("rust && !deprecated").unwrap();
+//! assert!(evaluate(&query, "new rust api"));
+//! assert!(!evaluate(&query, "deprecated rust code"));
 //! ```
 
 pub mod path_filter;
+pub mod query;
 pub mod time_filter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,28 @@
+//! # claude-history
+//!
+//! A library for searching and browsing Claude Code conversation history.
+//!
+//! This library provides functionality to:
+//! - Load and parse Claude Code conversation files (JSONL format)
+//! - Search conversations with various filters
+//! - Display conversations in the terminal
+//!
+//! ## Modules
+//!
+//! - [`time_filter`] - Time-based filtering with duration and date range support
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use claude_history::time_filter::TimeFilter;
+//! use chrono::{Duration, Local};
+//!
+//! // Create a filter for conversations from the last 2 days
+//! let filter = TimeFilter::from_since("2d").unwrap();
+//!
+//! // Check if a timestamp matches
+//! let recent = Local::now() - Duration::hours(6);
+//! assert!(filter.matches(recent));
+//! ```
+
+pub mod time_filter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,19 +10,32 @@
 //! ## Modules
 //!
 //! - [`time_filter`] - Time-based filtering with duration and date range support
+//! - [`path_filter`] - Path-based filtering with regex include/exclude patterns
 //!
 //! ## Example
 //!
 //! ```rust,no_run
 //! use claude_history::time_filter::TimeFilter;
+//! use claude_history::path_filter::PathFilter;
 //! use chrono::{Duration, Local};
+//! use std::path::Path;
 //!
-//! // Create a filter for conversations from the last 2 days
-//! let filter = TimeFilter::from_since("2d").unwrap();
+//! // Create a time filter for conversations from the last 2 days
+//! let time_filter = TimeFilter::from_since("2d").unwrap();
 //!
 //! // Check if a timestamp matches
 //! let recent = Local::now() - Duration::hours(6);
-//! assert!(filter.matches(recent));
+//! assert!(time_filter.matches(recent));
+//!
+//! // Create a path filter to include only work projects
+//! let path_filter = PathFilter::new()
+//!     .with_include("/work/")
+//!     .unwrap()
+//!     .with_exclude("test")
+//!     .unwrap();
+//!
+//! assert!(path_filter.matches(Path::new("/home/user/work/myapp")));
 //! ```
 
+pub mod path_filter;
 pub mod time_filter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod tui;
 
 use clap::Parser;
 use claude_history::path_filter::PathFilter;
+use claude_history::query::{evaluate, parse_query, QueryExpr};
 use claude_history::time_filter::TimeFilter;
 use cli::Args;
 use error::{AppError, Result};
@@ -109,6 +110,7 @@ fn run() -> Result<()> {
     // Build filters from CLI args
     let time_filter = build_time_filter(&args)?;
     let path_filter = build_path_filter(&args)?;
+    let content_query = build_content_query(&args)?;
 
     // Handle --render flag: render a JSONL file in ledger format and exit
     if let Some(ref render_path) = args.render {
@@ -147,24 +149,70 @@ fn run() -> Result<()> {
 
     // Determine how to load conversations based on mode
     let (conversations, selected_path) = if args.global {
-        // Global Search (-g) - use streaming loader for instant startup
-        let rx = history::load_all_conversations_streaming(
-            show_last,
-            args.debug,
-            time_filter.clone(),
-            path_filter.clone(),
-        );
+        // Global Search (-g)
+        // If content query specified, use sync loading so we can filter before display
+        // Otherwise use streaming for instant startup UX
+        if let Some(ref query) = content_query {
+            // Sync loading with content filter
+            let mut conversations = history::load_all_conversations(
+                show_last,
+                args.debug,
+                time_filter.as_ref(),
+                path_filter.as_ref(),
+            )?;
 
-        match tui::run_with_loader(rx, use_relative_time, tool_display, show_thinking)? {
-            (tui::Action::Select(path), convs) => (convs, path),
-            (tui::Action::Resume(path), convs) => {
-                let conv = convs.iter().find(|c| c.path == path);
-                let project_path = conv.and_then(|c| c.project_path.as_ref());
-                resume_with_claude(&path, project_path, default_args)?;
-                return Ok(());
+            // Apply content query filter
+            let before_count = conversations.len();
+            conversations = filter_by_query(conversations, query);
+            debug::info(
+                args.debug,
+                &format!(
+                    "Query filter: {} conversations matched (from {})",
+                    conversations.len(),
+                    before_count
+                ),
+            );
+
+            if conversations.is_empty() {
+                return Err(AppError::NoHistoryFound("query filter".to_string()));
             }
-            (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
-            (tui::Action::Delete(_), _) => unreachable!("Delete is handled internally"),
+
+            match tui::run(
+                conversations.clone(),
+                use_relative_time,
+                tool_display,
+                show_thinking,
+            )? {
+                tui::Action::Select(path) => (conversations, path),
+                tui::Action::Resume(path) => {
+                    let conv = conversations.iter().find(|c| c.path == path);
+                    let project_path = conv.and_then(|c| c.project_path.as_ref());
+                    resume_with_claude(&path, project_path, default_args)?;
+                    return Ok(());
+                }
+                tui::Action::Quit => return Err(AppError::SelectionCancelled),
+                tui::Action::Delete(_) => unreachable!("Delete is handled internally"),
+            }
+        } else {
+            // Streaming loader for instant startup (no content filter)
+            let rx = history::load_all_conversations_streaming(
+                show_last,
+                args.debug,
+                time_filter.clone(),
+                path_filter.clone(),
+            );
+
+            match tui::run_with_loader(rx, use_relative_time, tool_display, show_thinking)? {
+                (tui::Action::Select(path), convs) => (convs, path),
+                (tui::Action::Resume(path), convs) => {
+                    let conv = convs.iter().find(|c| c.path == path);
+                    let project_path = conv.and_then(|c| c.project_path.as_ref());
+                    resume_with_claude(&path, project_path, default_args)?;
+                    return Ok(());
+                }
+                (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
+                (tui::Action::Delete(_), _) => unreachable!("Delete is handled internally"),
+            }
         }
     } else {
         // Current Directory mode - synchronous loading is fast enough
@@ -189,7 +237,7 @@ fn run() -> Result<()> {
             ));
         }
 
-        let conversations = history::load_conversations(
+        let mut conversations = history::load_conversations(
             &projects_dir,
             show_last,
             args.debug,
@@ -197,8 +245,27 @@ fn run() -> Result<()> {
             path_filter.as_ref(),
         )?;
 
+        // Apply content query filter if specified
+        if let Some(ref query) = content_query {
+            let before_count = conversations.len();
+            conversations = filter_by_query(conversations, query);
+            debug::info(
+                args.debug,
+                &format!(
+                    "Query filter: {} conversations matched (from {})",
+                    conversations.len(),
+                    before_count
+                ),
+            );
+        }
+
         if conversations.is_empty() {
-            return Err(AppError::NoHistoryFound("selected scope".to_string()));
+            let scope = if content_query.is_some() {
+                "query filter"
+            } else {
+                "selected scope"
+            };
+            return Err(AppError::NoHistoryFound(scope.to_string()));
         }
 
         match tui::run(
@@ -341,6 +408,30 @@ fn build_path_filter(args: &Args) -> Result<Option<PathFilter>> {
     PathFilter::from_patterns(&args.include_path, &args.exclude_path)
         .map(Some)
         .map_err(|e| AppError::InvalidArgs(format!("Invalid path filter pattern: {}", e)))
+}
+
+/// Build a content query filter from CLI arguments.
+///
+/// Returns None if no query is specified.
+fn build_content_query(args: &Args) -> Result<Option<QueryExpr>> {
+    match &args.query {
+        None => Ok(None),
+        Some(query_str) => parse_query(query_str)
+            .map(Some)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid query: {}", e))),
+    }
+}
+
+/// Filter conversations by content query.
+///
+/// Returns only conversations where the full_text matches the query.
+fn filter_by_query(mut conversations: Vec<history::Conversation>, query: &QueryExpr) -> Vec<history::Conversation> {
+    conversations.retain(|conv| evaluate(query, &conv.full_text));
+    // Re-index after filtering
+    for (idx, conv) in conversations.iter_mut().enumerate() {
+        conv.index = idx;
+    }
+    conversations
 }
 
 fn resume_with_claude(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod tool_format;
 mod tui;
 
 use clap::Parser;
+use claude_history::path_filter::PathFilter;
 use claude_history::time_filter::TimeFilter;
 use cli::Args;
 use error::{AppError, Result};
@@ -105,8 +106,9 @@ fn run() -> Result<()> {
         std::io::stdout().is_terminal(),
     );
 
-    // Build time filter from CLI args
+    // Build filters from CLI args
     let time_filter = build_time_filter(&args)?;
+    let path_filter = build_path_filter(&args)?;
 
     // Handle --render flag: render a JSONL file in ledger format and exit
     if let Some(ref render_path) = args.render {
@@ -146,7 +148,12 @@ fn run() -> Result<()> {
     // Determine how to load conversations based on mode
     let (conversations, selected_path) = if args.global {
         // Global Search (-g) - use streaming loader for instant startup
-        let rx = history::load_all_conversations_streaming(show_last, args.debug, time_filter.clone());
+        let rx = history::load_all_conversations_streaming(
+            show_last,
+            args.debug,
+            time_filter.clone(),
+            path_filter.clone(),
+        );
 
         match tui::run_with_loader(rx, use_relative_time, tool_display, show_thinking)? {
             (tui::Action::Select(path), convs) => (convs, path),
@@ -182,7 +189,13 @@ fn run() -> Result<()> {
             ));
         }
 
-        let conversations = history::load_conversations(&projects_dir, show_last, args.debug, time_filter.as_ref())?;
+        let conversations = history::load_conversations(
+            &projects_dir,
+            show_last,
+            args.debug,
+            time_filter.as_ref(),
+            path_filter.as_ref(),
+        )?;
 
         if conversations.is_empty() {
             return Err(AppError::NoHistoryFound("selected scope".to_string()));
@@ -314,6 +327,20 @@ fn build_time_filter(args: &Args) -> Result<Option<TimeFilter>> {
     }
 
     Ok(Some(filter))
+}
+
+/// Build a PathFilter from CLI arguments.
+///
+/// Returns None if no path filtering options are specified.
+fn build_path_filter(args: &Args) -> Result<Option<PathFilter>> {
+    // If no path args specified, return None
+    if args.include_path.is_empty() && args.exclude_path.is_empty() {
+        return Ok(None);
+    }
+
+    PathFilter::from_patterns(&args.include_path, &args.exclude_path)
+        .map(Some)
+        .map_err(|e| AppError::InvalidArgs(format!("Invalid path filter pattern: {}", e)))
 }
 
 fn resume_with_claude(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod tool_format;
 mod tui;
 
 use clap::Parser;
+use claude_history::time_filter::TimeFilter;
 use cli::Args;
 use error::{AppError, Result};
 use std::io::IsTerminal;
@@ -104,6 +105,9 @@ fn run() -> Result<()> {
         std::io::stdout().is_terminal(),
     );
 
+    // Build time filter from CLI args
+    let time_filter = build_time_filter(&args)?;
+
     // Handle --render flag: render a JSONL file in ledger format and exit
     if let Some(ref render_path) = args.render {
         let display_options = display::DisplayOptions {
@@ -142,7 +146,7 @@ fn run() -> Result<()> {
     // Determine how to load conversations based on mode
     let (conversations, selected_path) = if args.global {
         // Global Search (-g) - use streaming loader for instant startup
-        let rx = history::load_all_conversations_streaming(show_last, args.debug);
+        let rx = history::load_all_conversations_streaming(show_last, args.debug, time_filter.clone());
 
         match tui::run_with_loader(rx, use_relative_time, tool_display, show_thinking)? {
             (tui::Action::Select(path), convs) => (convs, path),
@@ -178,7 +182,7 @@ fn run() -> Result<()> {
             ));
         }
 
-        let conversations = history::load_conversations(&projects_dir, show_last, args.debug)?;
+        let conversations = history::load_conversations(&projects_dir, show_last, args.debug, time_filter.as_ref())?;
 
         if conversations.is_empty() {
             return Err(AppError::NoHistoryFound("selected scope".to_string()));
@@ -278,6 +282,38 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build a TimeFilter from CLI arguments.
+///
+/// Returns None if no time filtering options are specified.
+fn build_time_filter(args: &Args) -> Result<Option<TimeFilter>> {
+    // If no time args specified, return None
+    if args.since.is_none() && args.after.is_none() && args.before.is_none() {
+        return Ok(None);
+    }
+
+    let mut filter = TimeFilter::new();
+
+    if let Some(ref since) = args.since {
+        filter = filter
+            .with_since(since)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --since value: {}", e)))?;
+    }
+
+    if let Some(ref after) = args.after {
+        filter = filter
+            .with_after(after)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --after value: {}", e)))?;
+    }
+
+    if let Some(ref before) = args.before {
+        filter = filter
+            .with_before(before)
+            .map_err(|e| AppError::InvalidArgs(format!("Invalid --before value: {}", e)))?;
+    }
+
+    Ok(Some(filter))
 }
 
 fn resume_with_claude(

--- a/src/path_filter.rs
+++ b/src/path_filter.rs
@@ -1,0 +1,466 @@
+//! Path-based filtering for conversation project directories.
+//!
+//! This module provides filtering of conversations based on their project
+//! directory paths using regex patterns for include/exclude matching.
+//!
+//! # Overview
+//!
+//! Path filtering allows users to:
+//! - Include only conversations from specific project paths
+//! - Exclude conversations from certain paths (e.g., test directories)
+//! - Combine multiple include/exclude patterns
+//!
+//! # Matching Logic
+//!
+//! - **Include patterns**: If any include patterns are specified, at least one
+//!   must match for the path to be included. Empty include list means "include all".
+//! - **Exclude patterns**: If any exclude pattern matches, the path is excluded.
+//! - Both conditions must be satisfied: included AND not excluded.
+//!
+//! # Example
+//!
+//! ```rust
+//! use claude_history::path_filter::PathFilter;
+//! use std::path::Path;
+//!
+//! // Include only work projects, exclude test directories
+//! let filter = PathFilter::new()
+//!     .with_include("/home/user/work/")
+//!     .unwrap()
+//!     .with_exclude("test")
+//!     .unwrap();
+//!
+//! assert!(filter.matches(Path::new("/home/user/work/myproject")));
+//! assert!(!filter.matches(Path::new("/home/user/work/myproject-test")));
+//! assert!(!filter.matches(Path::new("/home/user/personal/hobby")));
+//! ```
+
+use regex::Regex;
+use std::fmt;
+use std::path::Path;
+
+/// Errors that can occur when building a PathFilter.
+#[derive(Debug, Clone)]
+pub enum PathFilterError {
+    /// Invalid regex pattern
+    InvalidPattern(String),
+}
+
+impl fmt::Display for PathFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PathFilterError::InvalidPattern(msg) => write!(f, "invalid regex pattern: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for PathFilterError {}
+
+/// Filter for matching project paths using regex patterns.
+///
+/// # Include/Exclude Logic
+///
+/// The filter uses the following logic to determine if a path matches:
+///
+/// 1. If include patterns are specified, at least one must match
+/// 2. No exclude pattern may match
+/// 3. Both conditions must be true
+///
+/// # Example
+///
+/// ```rust
+/// use claude_history::path_filter::PathFilter;
+/// use std::path::Path;
+///
+/// // Filter for Rust projects, excluding vendor directories
+/// let filter = PathFilter::new()
+///     .with_include("rust")
+///     .unwrap()
+///     .with_exclude("vendor")
+///     .unwrap();
+///
+/// assert!(filter.matches(Path::new("/projects/rust-app")));
+/// assert!(!filter.matches(Path::new("/projects/rust-app/vendor")));
+/// assert!(!filter.matches(Path::new("/projects/python-app")));
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct PathFilter {
+    include_patterns: Vec<Regex>,
+    exclude_patterns: Vec<Regex>,
+}
+
+impl PathFilter {
+    /// Create a new empty PathFilter that matches all paths.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    /// use std::path::Path;
+    ///
+    /// let filter = PathFilter::new();
+    /// assert!(filter.matches(Path::new("/any/path")));
+    /// assert!(!filter.is_active());
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a PathFilter from include and exclude pattern strings.
+    ///
+    /// # Arguments
+    ///
+    /// * `include_patterns` - Regex patterns; path must match at least one (if any specified)
+    /// * `exclude_patterns` - Regex patterns; path must not match any
+    ///
+    /// # Errors
+    ///
+    /// Returns `PathFilterError::InvalidPattern` if any pattern is not valid regex.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    /// use std::path::Path;
+    ///
+    /// let filter = PathFilter::from_patterns(
+    ///     &["work", "projects"],
+    ///     &["test", "tmp"],
+    /// ).unwrap();
+    ///
+    /// assert!(filter.matches(Path::new("/home/user/work/app")));
+    /// assert!(!filter.matches(Path::new("/home/user/work/app-test")));
+    /// ```
+    pub fn from_patterns(
+        include_patterns: &[impl AsRef<str>],
+        exclude_patterns: &[impl AsRef<str>],
+    ) -> Result<Self, PathFilterError> {
+        let mut filter = Self::new();
+
+        for pattern in include_patterns {
+            filter = filter.with_include(pattern.as_ref())?;
+        }
+
+        for pattern in exclude_patterns {
+            filter = filter.with_exclude(pattern.as_ref())?;
+        }
+
+        Ok(filter)
+    }
+
+    /// Add an include pattern (builder pattern).
+    ///
+    /// Paths must match at least one include pattern (if any are specified).
+    ///
+    /// # Errors
+    ///
+    /// Returns `PathFilterError::InvalidPattern` if the pattern is not valid regex.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    /// use std::path::Path;
+    ///
+    /// let filter = PathFilter::new()
+    ///     .with_include("/work/")
+    ///     .unwrap()
+    ///     .with_include("/projects/")
+    ///     .unwrap();
+    ///
+    /// // Matches either pattern
+    /// assert!(filter.matches(Path::new("/home/user/work/app")));
+    /// assert!(filter.matches(Path::new("/home/user/projects/app")));
+    /// assert!(!filter.matches(Path::new("/home/user/personal/app")));
+    /// ```
+    pub fn with_include(mut self, pattern: &str) -> Result<Self, PathFilterError> {
+        let regex = Regex::new(pattern)
+            .map_err(|e| PathFilterError::InvalidPattern(e.to_string()))?;
+        self.include_patterns.push(regex);
+        Ok(self)
+    }
+
+    /// Add an exclude pattern (builder pattern).
+    ///
+    /// Paths matching any exclude pattern are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PathFilterError::InvalidPattern` if the pattern is not valid regex.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    /// use std::path::Path;
+    ///
+    /// let filter = PathFilter::new()
+    ///     .with_exclude("node_modules")
+    ///     .unwrap()
+    ///     .with_exclude("target")
+    ///     .unwrap();
+    ///
+    /// assert!(filter.matches(Path::new("/projects/app/src")));
+    /// assert!(!filter.matches(Path::new("/projects/app/node_modules")));
+    /// assert!(!filter.matches(Path::new("/projects/rust/target")));
+    /// ```
+    pub fn with_exclude(mut self, pattern: &str) -> Result<Self, PathFilterError> {
+        let regex = Regex::new(pattern)
+            .map_err(|e| PathFilterError::InvalidPattern(e.to_string()))?;
+        self.exclude_patterns.push(regex);
+        Ok(self)
+    }
+
+    /// Check if a path matches the filter criteria.
+    ///
+    /// # Matching Rules
+    ///
+    /// 1. If include patterns exist, at least one must match
+    /// 2. No exclude pattern may match
+    /// 3. Both conditions must be satisfied
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    /// use std::path::Path;
+    ///
+    /// let filter = PathFilter::new()
+    ///     .with_include("work")
+    ///     .unwrap()
+    ///     .with_exclude("test")
+    ///     .unwrap();
+    ///
+    /// // Included and not excluded
+    /// assert!(filter.matches(Path::new("/home/user/work/app")));
+    ///
+    /// // Excluded (even though it matches include)
+    /// assert!(!filter.matches(Path::new("/home/user/work/test")));
+    ///
+    /// // Not included
+    /// assert!(!filter.matches(Path::new("/home/user/personal")));
+    /// ```
+    pub fn matches(&self, path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+
+        // If include patterns specified, at least one must match
+        let include_ok = self.include_patterns.is_empty()
+            || self.include_patterns.iter().any(|p| p.is_match(&path_str));
+
+        // All exclude patterns must NOT match
+        let exclude_ok = !self.exclude_patterns.iter().any(|p| p.is_match(&path_str));
+
+        include_ok && exclude_ok
+    }
+
+    /// Check if the filter has any patterns configured.
+    ///
+    /// Returns `false` if no include or exclude patterns are set,
+    /// meaning the filter will match all paths.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use claude_history::path_filter::PathFilter;
+    ///
+    /// let empty = PathFilter::new();
+    /// assert!(!empty.is_active());
+    ///
+    /// let with_include = PathFilter::new()
+    ///     .with_include("work")
+    ///     .unwrap();
+    /// assert!(with_include.is_active());
+    /// ```
+    pub fn is_active(&self) -> bool {
+        !self.include_patterns.is_empty() || !self.exclude_patterns.is_empty()
+    }
+
+    /// Get the number of include patterns.
+    pub fn include_count(&self) -> usize {
+        self.include_patterns.len()
+    }
+
+    /// Get the number of exclude patterns.
+    pub fn exclude_count(&self) -> usize {
+        self.exclude_patterns.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== PathFilter construction tests ====================
+
+    #[test]
+    fn new_filter_matches_everything() {
+        let filter = PathFilter::new();
+        assert!(filter.matches(Path::new("/any/path")));
+        assert!(filter.matches(Path::new("/another/path/here")));
+        assert!(!filter.is_active());
+    }
+
+    #[test]
+    fn from_patterns_creates_filter() {
+        let filter = PathFilter::from_patterns(&["work"], &["test"]).unwrap();
+        assert!(filter.is_active());
+        assert_eq!(filter.include_count(), 1);
+        assert_eq!(filter.exclude_count(), 1);
+    }
+
+    #[test]
+    fn invalid_regex_returns_error() {
+        let result = PathFilter::new().with_include("[invalid");
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, PathFilterError::InvalidPattern(_)));
+    }
+
+    // ==================== Include pattern tests ====================
+
+    #[test]
+    fn single_include_pattern() {
+        let filter = PathFilter::new().with_include("work").unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/work/project")));
+        assert!(filter.matches(Path::new("/work/app")));
+        assert!(!filter.matches(Path::new("/home/user/personal")));
+    }
+
+    #[test]
+    fn multiple_include_patterns_or_logic() {
+        let filter = PathFilter::new()
+            .with_include("work")
+            .unwrap()
+            .with_include("projects")
+            .unwrap();
+
+        // Either pattern matches
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+        assert!(filter.matches(Path::new("/home/user/projects/app")));
+
+        // Neither matches
+        assert!(!filter.matches(Path::new("/home/user/personal")));
+    }
+
+    #[test]
+    fn include_pattern_with_regex_special_chars() {
+        // Test regex anchors
+        let filter = PathFilter::new().with_include("^/home/user/").unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/work")));
+        assert!(!filter.matches(Path::new("/other/home/user/work")));
+    }
+
+    // ==================== Exclude pattern tests ====================
+
+    #[test]
+    fn single_exclude_pattern() {
+        let filter = PathFilter::new().with_exclude("test").unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+        assert!(!filter.matches(Path::new("/home/user/work/app-test")));
+        assert!(!filter.matches(Path::new("/home/user/test/app")));
+    }
+
+    #[test]
+    fn multiple_exclude_patterns_and_logic() {
+        let filter = PathFilter::new()
+            .with_exclude("test")
+            .unwrap()
+            .with_exclude("tmp")
+            .unwrap();
+
+        // Neither excluded
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+
+        // First pattern excludes
+        assert!(!filter.matches(Path::new("/home/user/test")));
+
+        // Second pattern excludes
+        assert!(!filter.matches(Path::new("/home/user/tmp")));
+    }
+
+    #[test]
+    fn exclude_common_directories() {
+        let filter = PathFilter::new()
+            .with_exclude("node_modules")
+            .unwrap()
+            .with_exclude("target")
+            .unwrap()
+            .with_exclude("\\.git")
+            .unwrap();
+
+        assert!(filter.matches(Path::new("/projects/app/src")));
+        assert!(!filter.matches(Path::new("/projects/app/node_modules")));
+        assert!(!filter.matches(Path::new("/projects/rust/target")));
+        assert!(!filter.matches(Path::new("/projects/app/.git")));
+    }
+
+    // ==================== Combined include/exclude tests ====================
+
+    #[test]
+    fn include_and_exclude_combined() {
+        let filter = PathFilter::new()
+            .with_include("work")
+            .unwrap()
+            .with_exclude("test")
+            .unwrap();
+
+        // Matches include, not excluded
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+
+        // Matches include but also excluded
+        assert!(!filter.matches(Path::new("/home/user/work/app-test")));
+
+        // Doesn't match include
+        assert!(!filter.matches(Path::new("/home/user/personal/app")));
+    }
+
+    #[test]
+    fn exclude_takes_precedence() {
+        let filter = PathFilter::new()
+            .with_include("work")
+            .unwrap()
+            .with_exclude("work/test")
+            .unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+        assert!(!filter.matches(Path::new("/home/user/work/test")));
+    }
+
+    // ==================== Edge case tests ====================
+
+    #[test]
+    fn empty_path() {
+        let filter = PathFilter::new().with_include("work").unwrap();
+        assert!(!filter.matches(Path::new("")));
+    }
+
+    #[test]
+    fn case_sensitive_matching() {
+        let filter = PathFilter::new().with_include("Work").unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/Work/app")));
+        assert!(!filter.matches(Path::new("/home/user/work/app")));
+    }
+
+    #[test]
+    fn case_insensitive_with_regex_flag() {
+        let filter = PathFilter::new().with_include("(?i)work").unwrap();
+
+        assert!(filter.matches(Path::new("/home/user/Work/app")));
+        assert!(filter.matches(Path::new("/home/user/work/app")));
+        assert!(filter.matches(Path::new("/home/user/WORK/app")));
+    }
+
+    // ==================== Error display tests ====================
+
+    #[test]
+    fn error_display() {
+        let err = PathFilterError::InvalidPattern("test error".to_string());
+        assert!(err.to_string().contains("invalid regex pattern"));
+        assert!(err.to_string().contains("test error"));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,63 @@
+//! Boolean query parsing and evaluation for conversation search.
+//!
+//! This module provides a simple boolean query language for searching
+//! conversation content with AND, OR, and NOT operators.
+//!
+//! # Syntax
+//!
+//! The query language supports:
+//! - **Terms**: Words or quoted phrases (`foo`, `"hello world"`)
+//! - **AND**: `&&` operator (`foo && bar`)
+//! - **OR**: `||` operator (`foo || bar`)
+//! - **NOT**: `!` operator (`!foo`)
+//! - **Grouping**: Parentheses for precedence (`(foo || bar) && !baz`)
+//!
+//! # Operator Precedence
+//!
+//! From lowest to highest:
+//! 1. `||` (OR)
+//! 2. `&&` (AND)
+//! 3. `!` (NOT)
+//!
+//! # Examples
+//!
+//! ```rust
+//! use claude_history::query::{parse_query, evaluate};
+//!
+//! // Simple term search
+//! let query = parse_query("rust").unwrap();
+//! assert!(evaluate(&query, "I love rust programming"));
+//! assert!(!evaluate(&query, "I love python programming"));
+//!
+//! // AND query - both terms must match
+//! let query = parse_query("rust && programming").unwrap();
+//! assert!(evaluate(&query, "rust programming is fun"));
+//! assert!(!evaluate(&query, "rust is a language"));
+//!
+//! // OR query - either term matches
+//! let query = parse_query("rust || python").unwrap();
+//! assert!(evaluate(&query, "I use rust"));
+//! assert!(evaluate(&query, "I use python"));
+//! assert!(!evaluate(&query, "I use javascript"));
+//!
+//! // NOT query - term must not match
+//! let query = parse_query("programming && !javascript").unwrap();
+//! assert!(evaluate(&query, "rust programming"));
+//! assert!(!evaluate(&query, "javascript programming"));
+//!
+//! // Quoted phrase - exact phrase match
+//! let query = parse_query(r#""hello world""#).unwrap();
+//! assert!(evaluate(&query, "say hello world today"));
+//! assert!(!evaluate(&query, "hello there world"));
+//!
+//! // Complex query with grouping
+//! let query = parse_query("(rust || go) && !java").unwrap();
+//! assert!(evaluate(&query, "rust is great"));
+//! assert!(evaluate(&query, "go is great"));
+//! assert!(!evaluate(&query, "java is great"));
+//! assert!(!evaluate(&query, "rust and java together"));
+//! ```
+
+mod parser;
+
+pub use parser::{evaluate, parse_query, QueryError, QueryExpr};

--- a/src/query/parser.rs
+++ b/src/query/parser.rs
@@ -1,0 +1,599 @@
+//! Recursive descent parser for boolean queries.
+//!
+//! Grammar:
+//! ```text
+//! expr      = or_expr
+//! or_expr   = and_expr ("||" and_expr)*
+//! and_expr  = not_expr ("&&" not_expr)*
+//! not_expr  = "!" primary | primary
+//! primary   = "(" expr ")" | quoted_string | word
+//! ```
+
+use std::fmt;
+
+/// Error type for query parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryError {
+    /// Empty query string
+    EmptyQuery,
+    /// Unexpected end of input
+    UnexpectedEnd,
+    /// Unexpected character at position
+    UnexpectedChar(usize, char),
+    /// Unclosed parenthesis
+    UnclosedParen,
+    /// Unclosed quote
+    UnclosedQuote,
+    /// Empty term (e.g., "" or just whitespace)
+    EmptyTerm,
+    /// Missing operand for operator
+    MissingOperand(String),
+}
+
+impl fmt::Display for QueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            QueryError::EmptyQuery => write!(f, "query cannot be empty"),
+            QueryError::UnexpectedEnd => write!(f, "unexpected end of query"),
+            QueryError::UnexpectedChar(pos, c) => {
+                write!(f, "unexpected character '{}' at position {}", c, pos)
+            }
+            QueryError::UnclosedParen => write!(f, "unclosed parenthesis"),
+            QueryError::UnclosedQuote => write!(f, "unclosed quote"),
+            QueryError::EmptyTerm => write!(f, "empty search term"),
+            QueryError::MissingOperand(op) => write!(f, "missing operand for '{}'", op),
+        }
+    }
+}
+
+impl std::error::Error for QueryError {}
+
+/// Abstract syntax tree for boolean queries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryExpr {
+    /// A search term (word or phrase)
+    Term(String),
+    /// Logical AND of two expressions
+    And(Box<QueryExpr>, Box<QueryExpr>),
+    /// Logical OR of two expressions
+    Or(Box<QueryExpr>, Box<QueryExpr>),
+    /// Logical NOT of an expression
+    Not(Box<QueryExpr>),
+}
+
+impl QueryExpr {
+    /// Create an AND expression.
+    pub fn and(left: QueryExpr, right: QueryExpr) -> Self {
+        QueryExpr::And(Box::new(left), Box::new(right))
+    }
+
+    /// Create an OR expression.
+    pub fn or(left: QueryExpr, right: QueryExpr) -> Self {
+        QueryExpr::Or(Box::new(left), Box::new(right))
+    }
+
+    /// Create a NOT expression.
+    pub fn not(expr: QueryExpr) -> Self {
+        QueryExpr::Not(Box::new(expr))
+    }
+
+    /// Create a Term expression.
+    pub fn term(s: &str) -> Self {
+        QueryExpr::Term(s.to_string())
+    }
+}
+
+/// Parser state for recursive descent parsing.
+struct Parser<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    fn remaining(&self) -> &'a str {
+        &self.input[self.pos..]
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.remaining().chars().next()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while let Some(c) = self.peek_char() {
+            if c.is_whitespace() {
+                self.pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn expect_char(&mut self, expected: char) -> Result<(), QueryError> {
+        self.skip_whitespace();
+        match self.peek_char() {
+            Some(c) if c == expected => {
+                self.pos += c.len_utf8();
+                Ok(())
+            }
+            Some(c) => Err(QueryError::UnexpectedChar(self.pos, c)),
+            None => Err(QueryError::UnexpectedEnd),
+        }
+    }
+
+    fn try_consume(&mut self, s: &str) -> bool {
+        self.skip_whitespace();
+        if self.remaining().starts_with(s) {
+            self.pos += s.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn at_end(&self) -> bool {
+        self.skip_whitespace_peek();
+        self.pos >= self.input.len()
+    }
+
+    fn skip_whitespace_peek(&self) -> usize {
+        let mut pos = self.pos;
+        for c in self.input[pos..].chars() {
+            if c.is_whitespace() {
+                pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        pos
+    }
+
+    /// Parse the complete expression.
+    fn parse_expr(&mut self) -> Result<QueryExpr, QueryError> {
+        self.parse_or_expr()
+    }
+
+    /// Parse OR expressions: and_expr ("||" and_expr)*
+    fn parse_or_expr(&mut self) -> Result<QueryExpr, QueryError> {
+        let mut left = self.parse_and_expr()?;
+
+        while self.try_consume("||") {
+            let right = self.parse_and_expr()?;
+            left = QueryExpr::or(left, right);
+        }
+
+        Ok(left)
+    }
+
+    /// Parse AND expressions: not_expr ("&&" not_expr)*
+    fn parse_and_expr(&mut self) -> Result<QueryExpr, QueryError> {
+        let mut left = self.parse_not_expr()?;
+
+        while self.try_consume("&&") {
+            let right = self.parse_not_expr()?;
+            left = QueryExpr::and(left, right);
+        }
+
+        Ok(left)
+    }
+
+    /// Parse NOT expressions: "!" primary | primary
+    fn parse_not_expr(&mut self) -> Result<QueryExpr, QueryError> {
+        self.skip_whitespace();
+
+        if self.try_consume("!") {
+            let expr = self.parse_not_expr()?;
+            Ok(QueryExpr::not(expr))
+        } else {
+            self.parse_primary()
+        }
+    }
+
+    /// Parse primary expressions: "(" expr ")" | quoted_string | word
+    fn parse_primary(&mut self) -> Result<QueryExpr, QueryError> {
+        self.skip_whitespace();
+
+        match self.peek_char() {
+            None => Err(QueryError::UnexpectedEnd),
+            Some('(') => {
+                self.pos += 1;
+                let expr = self.parse_expr()?;
+                self.expect_char(')')?;
+                Ok(expr)
+            }
+            Some('"') => self.parse_quoted_string(),
+            Some(c) if is_word_char(c) => self.parse_word(),
+            Some(c) => Err(QueryError::UnexpectedChar(self.pos, c)),
+        }
+    }
+
+    /// Parse a quoted string: "..."
+    fn parse_quoted_string(&mut self) -> Result<QueryExpr, QueryError> {
+        self.pos += 1; // skip opening quote
+
+        let start = self.pos;
+
+        for (i, c) in self.input[start..].char_indices() {
+            if c == '"' {
+                let term = &self.input[start..start + i];
+                self.pos = start + i + 1; // skip closing quote
+
+                if term.is_empty() {
+                    return Err(QueryError::EmptyTerm);
+                }
+
+                return Ok(QueryExpr::Term(term.to_string()));
+            }
+        }
+
+        Err(QueryError::UnclosedQuote)
+    }
+
+    /// Parse a word (unquoted term).
+    fn parse_word(&mut self) -> Result<QueryExpr, QueryError> {
+        let start = self.pos;
+
+        while let Some(c) = self.peek_char() {
+            if is_word_char(c) {
+                self.pos += c.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        let term = &self.input[start..self.pos];
+        if term.is_empty() {
+            return Err(QueryError::EmptyTerm);
+        }
+
+        Ok(QueryExpr::Term(term.to_string()))
+    }
+}
+
+/// Check if a character is valid in an unquoted word.
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '/'
+}
+
+/// Parse a query string into an expression tree.
+///
+/// # Arguments
+///
+/// * `input` - The query string to parse
+///
+/// # Returns
+///
+/// A `QueryExpr` tree on success, or a `QueryError` on failure.
+///
+/// # Example
+///
+/// ```rust
+/// use claude_history::query::parse_query;
+///
+/// let query = parse_query("rust && !java").unwrap();
+/// ```
+pub fn parse_query(input: &str) -> Result<QueryExpr, QueryError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(QueryError::EmptyQuery);
+    }
+
+    let mut parser = Parser::new(trimmed);
+    let expr = parser.parse_expr()?;
+
+    // Ensure we consumed all input
+    parser.skip_whitespace();
+    if !parser.at_end() {
+        if let Some(c) = parser.peek_char() {
+            return Err(QueryError::UnexpectedChar(parser.pos, c));
+        }
+    }
+
+    Ok(expr)
+}
+
+/// Evaluate a query expression against text content.
+///
+/// Matching is case-insensitive. Terms match if the text contains
+/// the term as a substring.
+///
+/// # Arguments
+///
+/// * `expr` - The query expression to evaluate
+/// * `text` - The text content to search
+///
+/// # Returns
+///
+/// `true` if the query matches the text, `false` otherwise.
+///
+/// # Example
+///
+/// ```rust
+/// use claude_history::query::{parse_query, evaluate};
+///
+/// let query = parse_query("rust && programming").unwrap();
+/// assert!(evaluate(&query, "Rust programming is great"));
+/// assert!(!evaluate(&query, "Rust is a language"));
+/// ```
+pub fn evaluate(expr: &QueryExpr, text: &str) -> bool {
+    let text_lower = text.to_lowercase();
+
+    match expr {
+        QueryExpr::Term(term) => {
+            let term_lower = term.to_lowercase();
+            text_lower.contains(&term_lower)
+        }
+        QueryExpr::And(left, right) => evaluate(left, text) && evaluate(right, text),
+        QueryExpr::Or(left, right) => evaluate(left, text) || evaluate(right, text),
+        QueryExpr::Not(inner) => !evaluate(inner, text),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== Parser tests ====================
+
+    #[test]
+    fn parse_single_word() {
+        let expr = parse_query("rust").unwrap();
+        assert_eq!(expr, QueryExpr::term("rust"));
+    }
+
+    #[test]
+    fn parse_quoted_phrase() {
+        let expr = parse_query(r#""hello world""#).unwrap();
+        assert_eq!(expr, QueryExpr::term("hello world"));
+    }
+
+    #[test]
+    fn parse_and_expression() {
+        let expr = parse_query("rust && python").unwrap();
+        assert_eq!(
+            expr,
+            QueryExpr::and(QueryExpr::term("rust"), QueryExpr::term("python"))
+        );
+    }
+
+    #[test]
+    fn parse_or_expression() {
+        let expr = parse_query("rust || python").unwrap();
+        assert_eq!(
+            expr,
+            QueryExpr::or(QueryExpr::term("rust"), QueryExpr::term("python"))
+        );
+    }
+
+    #[test]
+    fn parse_not_expression() {
+        let expr = parse_query("!java").unwrap();
+        assert_eq!(expr, QueryExpr::not(QueryExpr::term("java")));
+    }
+
+    #[test]
+    fn parse_complex_expression() {
+        // (rust || go) && !java
+        let expr = parse_query("(rust || go) && !java").unwrap();
+        assert_eq!(
+            expr,
+            QueryExpr::and(
+                QueryExpr::or(QueryExpr::term("rust"), QueryExpr::term("go")),
+                QueryExpr::not(QueryExpr::term("java"))
+            )
+        );
+    }
+
+    #[test]
+    fn parse_chained_and() {
+        let expr = parse_query("a && b && c").unwrap();
+        // Left-associative: ((a && b) && c)
+        assert_eq!(
+            expr,
+            QueryExpr::and(
+                QueryExpr::and(QueryExpr::term("a"), QueryExpr::term("b")),
+                QueryExpr::term("c")
+            )
+        );
+    }
+
+    #[test]
+    fn parse_chained_or() {
+        let expr = parse_query("a || b || c").unwrap();
+        // Left-associative: ((a || b) || c)
+        assert_eq!(
+            expr,
+            QueryExpr::or(
+                QueryExpr::or(QueryExpr::term("a"), QueryExpr::term("b")),
+                QueryExpr::term("c")
+            )
+        );
+    }
+
+    #[test]
+    fn parse_operator_precedence() {
+        // a || b && c should be a || (b && c) because && binds tighter
+        let expr = parse_query("a || b && c").unwrap();
+        assert_eq!(
+            expr,
+            QueryExpr::or(
+                QueryExpr::term("a"),
+                QueryExpr::and(QueryExpr::term("b"), QueryExpr::term("c"))
+            )
+        );
+    }
+
+    #[test]
+    fn parse_double_not() {
+        let expr = parse_query("!!foo").unwrap();
+        assert_eq!(expr, QueryExpr::not(QueryExpr::not(QueryExpr::term("foo"))));
+    }
+
+    #[test]
+    fn parse_with_extra_whitespace() {
+        let expr = parse_query("  rust   &&   python  ").unwrap();
+        assert_eq!(
+            expr,
+            QueryExpr::and(QueryExpr::term("rust"), QueryExpr::term("python"))
+        );
+    }
+
+    #[test]
+    fn parse_word_with_special_chars() {
+        let expr = parse_query("my-project_name.rs").unwrap();
+        assert_eq!(expr, QueryExpr::term("my-project_name.rs"));
+    }
+
+    #[test]
+    fn parse_path_like_term() {
+        let expr = parse_query("/home/user/project").unwrap();
+        assert_eq!(expr, QueryExpr::term("/home/user/project"));
+    }
+
+    // ==================== Parser error tests ====================
+
+    #[test]
+    fn parse_empty_query_error() {
+        assert!(matches!(parse_query(""), Err(QueryError::EmptyQuery)));
+        assert!(matches!(parse_query("   "), Err(QueryError::EmptyQuery)));
+    }
+
+    #[test]
+    fn parse_unclosed_paren_error() {
+        assert!(matches!(
+            parse_query("(foo && bar"),
+            Err(QueryError::UnexpectedEnd)
+        ));
+    }
+
+    #[test]
+    fn parse_unclosed_quote_error() {
+        assert!(matches!(
+            parse_query(r#""hello world"#),
+            Err(QueryError::UnclosedQuote)
+        ));
+    }
+
+    #[test]
+    fn parse_empty_quoted_term_error() {
+        assert!(matches!(parse_query(r#""""#), Err(QueryError::EmptyTerm)));
+    }
+
+    #[test]
+    fn parse_unexpected_char_error() {
+        // Unexpected closing paren
+        assert!(matches!(
+            parse_query("foo)"),
+            Err(QueryError::UnexpectedChar(_, ')'))
+        ));
+    }
+
+    // ==================== Evaluation tests ====================
+
+    #[test]
+    fn evaluate_term_match() {
+        let expr = parse_query("rust").unwrap();
+        assert!(evaluate(&expr, "I love rust programming"));
+        assert!(!evaluate(&expr, "I love python programming"));
+    }
+
+    #[test]
+    fn evaluate_term_case_insensitive() {
+        let expr = parse_query("RUST").unwrap();
+        assert!(evaluate(&expr, "rust is great"));
+        assert!(evaluate(&expr, "Rust is great"));
+        assert!(evaluate(&expr, "RUST is great"));
+    }
+
+    #[test]
+    fn evaluate_quoted_phrase() {
+        let expr = parse_query(r#""hello world""#).unwrap();
+        assert!(evaluate(&expr, "say hello world today"));
+        assert!(!evaluate(&expr, "hello there world"));
+    }
+
+    #[test]
+    fn evaluate_and() {
+        let expr = parse_query("rust && programming").unwrap();
+        assert!(evaluate(&expr, "rust programming is fun"));
+        assert!(!evaluate(&expr, "rust is a language"));
+        assert!(!evaluate(&expr, "python programming is fun"));
+    }
+
+    #[test]
+    fn evaluate_or() {
+        let expr = parse_query("rust || python").unwrap();
+        assert!(evaluate(&expr, "I use rust"));
+        assert!(evaluate(&expr, "I use python"));
+        assert!(evaluate(&expr, "I use rust and python"));
+        assert!(!evaluate(&expr, "I use javascript"));
+    }
+
+    #[test]
+    fn evaluate_not() {
+        let expr = parse_query("!java").unwrap();
+        assert!(evaluate(&expr, "I use rust"));
+        assert!(!evaluate(&expr, "I use java"));
+    }
+
+    #[test]
+    fn evaluate_and_not() {
+        let expr = parse_query("programming && !javascript").unwrap();
+        assert!(evaluate(&expr, "rust programming"));
+        assert!(!evaluate(&expr, "javascript programming"));
+        // "just rust" doesn't contain "programming"
+        assert!(!evaluate(&expr, "just rust"));
+    }
+
+    #[test]
+    fn evaluate_complex_query() {
+        // (rust || go) && !java
+        let expr = parse_query("(rust || go) && !java").unwrap();
+        assert!(evaluate(&expr, "rust is great"));
+        assert!(evaluate(&expr, "go is great"));
+        assert!(!evaluate(&expr, "java is great"));
+        assert!(!evaluate(&expr, "rust and java together"));
+        assert!(!evaluate(&expr, "go and java together"));
+    }
+
+    #[test]
+    fn evaluate_double_not() {
+        let expr = parse_query("!!rust").unwrap();
+        assert!(evaluate(&expr, "rust is great"));
+        assert!(!evaluate(&expr, "python is great"));
+    }
+
+    #[test]
+    fn evaluate_nested_groups() {
+        // ((foo && bar) || (baz && qux))
+        let expr = parse_query("((foo && bar) || (baz && qux))").unwrap();
+        assert!(evaluate(&expr, "foo bar here"));
+        assert!(evaluate(&expr, "baz qux there"));
+        // Has foo but not bar, has baz but not qux
+        assert!(!evaluate(&expr, "foo baz"));
+        // Has bar but not foo, has qux but not baz
+        assert!(!evaluate(&expr, "bar qux"));
+    }
+
+    // ==================== Real-world query tests ====================
+
+    #[test]
+    fn evaluate_file_search_pattern() {
+        let expr = parse_query(r#""error" && (rust || python) && !test"#).unwrap();
+        assert!(evaluate(&expr, "error handling in rust code"));
+        assert!(evaluate(&expr, "python error logging"));
+        assert!(!evaluate(&expr, "rust test error"));
+        assert!(!evaluate(&expr, "error in javascript"));
+    }
+
+    #[test]
+    fn evaluate_project_filter() {
+        let expr = parse_query("api && !deprecated && !legacy").unwrap();
+        assert!(evaluate(&expr, "new api endpoint"));
+        assert!(!evaluate(&expr, "deprecated api endpoint"));
+        assert!(!evaluate(&expr, "legacy api code"));
+    }
+}

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -778,3 +778,299 @@ fn print_content(content: &serde_json::Value, include_tools: bool, include_think
         _ => {}
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // === Exit Codes ===
+
+    #[test]
+    fn test_exit_codes_are_distinct() {
+        // Exit codes should be unique to allow scripts to distinguish error types
+        let codes = [
+            exit_codes::SUCCESS,
+            exit_codes::ERROR,
+            exit_codes::INVALID_ARGS,
+            exit_codes::NO_RESULTS,
+        ];
+        let unique: std::collections::HashSet<_> = codes.iter().collect();
+        assert_eq!(unique.len(), codes.len(), "Exit codes must be unique");
+    }
+
+    #[test]
+    fn test_exit_code_values() {
+        // Document expected exit code values for shell scripts
+        assert_eq!(exit_codes::SUCCESS, 0);
+        assert_eq!(exit_codes::ERROR, 1);
+        assert_eq!(exit_codes::INVALID_ARGS, 2);
+        assert_eq!(exit_codes::NO_RESULTS, 3);
+    }
+
+    // === Output Format ===
+
+    #[test]
+    fn test_output_format_default_is_human() {
+        // When no format flag is specified, default to human-readable
+        let cli = Cli {
+            human: false,
+            jsonl: false,
+            quiet: false,
+            command: Commands::Usage,
+        };
+        assert!(matches!(cli.output_format(), OutputFormat::Human));
+    }
+
+    #[test]
+    fn test_output_format_jsonl_flag() {
+        // --jsonl flag produces JSONL output
+        let cli = Cli {
+            human: false,
+            jsonl: true,
+            quiet: false,
+            command: Commands::Usage,
+        };
+        assert!(matches!(cli.output_format(), OutputFormat::Jsonl));
+    }
+
+    #[test]
+    fn test_output_format_human_flag() {
+        // --human flag produces human-readable output
+        let cli = Cli {
+            human: true,
+            jsonl: false,
+            quiet: false,
+            command: Commands::Usage,
+        };
+        assert!(matches!(cli.output_format(), OutputFormat::Human));
+    }
+
+    // === Field Extraction ===
+
+    fn sample_conversation_output() -> ConversationOutput {
+        ConversationOutput {
+            uuid: "abc123".to_string(),
+            path: "/home/user/.claude/projects/test/abc123.jsonl".to_string(),
+            cwd: Some("/home/user/project".to_string()),
+            timestamp: "2026-02-06T14:30:00Z".to_string(),
+            preview: "Fix the authentication bug".to_string(),
+            project: Some("my-project".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_get_field_uuid() {
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "uuid"), "abc123");
+    }
+
+    #[test]
+    fn test_get_field_path() {
+        let out = sample_conversation_output();
+        assert_eq!(
+            get_field(&out, "path"),
+            "/home/user/.claude/projects/test/abc123.jsonl"
+        );
+    }
+
+    #[test]
+    fn test_get_field_cwd() {
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "cwd"), "/home/user/project");
+    }
+
+    #[test]
+    fn test_get_field_cwd_none() {
+        // When cwd is None, return empty string
+        let mut out = sample_conversation_output();
+        out.cwd = None;
+        assert_eq!(get_field(&out, "cwd"), "");
+    }
+
+    #[test]
+    fn test_get_field_timestamp() {
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "timestamp"), "2026-02-06T14:30:00Z");
+    }
+
+    #[test]
+    fn test_get_field_preview() {
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "preview"), "Fix the authentication bug");
+    }
+
+    #[test]
+    fn test_get_field_project() {
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "project"), "my-project");
+    }
+
+    #[test]
+    fn test_get_field_project_none() {
+        // When project is None, return empty string
+        let mut out = sample_conversation_output();
+        out.project = None;
+        assert_eq!(get_field(&out, "project"), "");
+    }
+
+    #[test]
+    fn test_get_field_unknown() {
+        // Unknown field returns empty string
+        let out = sample_conversation_output();
+        assert_eq!(get_field(&out, "nonexistent"), "");
+    }
+
+    // === Field Filtering (JSONL) ===
+
+    #[test]
+    fn test_filter_fields_single() {
+        let out = sample_conversation_output();
+        let result = filter_fields(&out, &["uuid".to_string()]);
+
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert_eq!(obj.get("uuid").unwrap().as_str().unwrap(), "abc123");
+    }
+
+    #[test]
+    fn test_filter_fields_multiple() {
+        let out = sample_conversation_output();
+        let result = filter_fields(&out, &["uuid".to_string(), "cwd".to_string()]);
+
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("uuid").unwrap().as_str().unwrap(), "abc123");
+        assert_eq!(
+            obj.get("cwd").unwrap().as_str().unwrap(),
+            "/home/user/project"
+        );
+    }
+
+    #[test]
+    fn test_filter_fields_none_value() {
+        // When cwd is None, the JSON value should be null
+        let mut out = sample_conversation_output();
+        out.cwd = None;
+        let result = filter_fields(&out, &["cwd".to_string()]);
+
+        let obj = result.as_object().unwrap();
+        assert!(obj.get("cwd").unwrap().is_null());
+    }
+
+    #[test]
+    fn test_filter_fields_unknown_skipped() {
+        // Unknown fields are silently skipped
+        let out = sample_conversation_output();
+        let result = filter_fields(&out, &["uuid".to_string(), "nonexistent".to_string()]);
+
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key("uuid"));
+        assert!(!obj.contains_key("nonexistent"));
+    }
+
+    #[test]
+    fn test_filter_fields_all() {
+        // All valid fields can be selected
+        let out = sample_conversation_output();
+        let result = filter_fields(
+            &out,
+            &[
+                "uuid".to_string(),
+                "path".to_string(),
+                "cwd".to_string(),
+                "timestamp".to_string(),
+                "preview".to_string(),
+                "project".to_string(),
+            ],
+        );
+
+        let obj = result.as_object().unwrap();
+        assert_eq!(obj.len(), 6);
+    }
+
+    // === ConversationOutput From Conversion ===
+
+    #[test]
+    fn test_conversation_output_uuid_extraction() {
+        // UUID should be extracted from the file stem
+        use chrono::Local;
+        let conv = Conversation {
+            path: PathBuf::from("/home/user/.claude/projects/test/abc123-xyz.jsonl"),
+            index: 0,
+            timestamp: Local::now(),
+            preview: "Test".to_string(),
+            full_text: "Test content".to_string(),
+            project_name: None,
+            project_path: None,
+            cwd: None,
+            message_count: 1,
+            parse_errors: vec![],
+            summary: None,
+        };
+
+        let out = ConversationOutput::from(&conv);
+        // File stem is "abc123-xyz", which becomes the UUID
+        assert_eq!(out.uuid, "abc123-xyz");
+    }
+
+    #[test]
+    fn test_conversation_output_preserves_cwd() {
+        use chrono::Local;
+        let conv = Conversation {
+            path: PathBuf::from("/test.jsonl"),
+            index: 0,
+            timestamp: Local::now(),
+            preview: "Test".to_string(),
+            full_text: "".to_string(),
+            project_name: None,
+            project_path: None,
+            cwd: Some(PathBuf::from("/home/user/myproject")),
+            message_count: 1,
+            parse_errors: vec![],
+            summary: None,
+        };
+
+        let out = ConversationOutput::from(&conv);
+        assert_eq!(out.cwd.as_deref(), Some("/home/user/myproject"));
+    }
+
+    #[test]
+    fn test_conversation_output_timestamp_rfc3339() {
+        use chrono::{Local, TimeZone};
+        let timestamp = Local.with_ymd_and_hms(2026, 2, 6, 14, 30, 0).unwrap();
+        let conv = Conversation {
+            path: PathBuf::from("/test.jsonl"),
+            index: 0,
+            timestamp,
+            preview: "Test".to_string(),
+            full_text: "".to_string(),
+            project_name: None,
+            project_path: None,
+            cwd: None,
+            message_count: 1,
+            parse_errors: vec![],
+            summary: None,
+        };
+
+        let out = ConversationOutput::from(&conv);
+        // Should be valid RFC3339 format
+        assert!(out.timestamp.contains("2026-02-06"));
+        assert!(out.timestamp.contains("14:30:00"));
+    }
+
+    // === Sort Order Validation ===
+
+    #[test]
+    fn test_valid_sort_orders() {
+        // Document the valid sort order values
+        let valid_orders = ["newest", "oldest", "most-messages", "least-messages"];
+        for order in valid_orders {
+            // These should not panic in a match statement
+            match order {
+                "newest" | "oldest" | "most-messages" | "least-messages" => {}
+                _ => panic!("Unexpected sort order: {}", order),
+            }
+        }
+    }
+}

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -24,6 +24,9 @@ use claude_history::time_filter::TimeFilter;
 use error::{AppError, Result};
 use history::Conversation;
 use serde::Serialize;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 /// Exit code when no results are found
@@ -203,16 +206,7 @@ fn run() -> Result<()> {
 
     match cli.command {
         Commands::List(args) => run_list(args, format, cli.quiet),
-        Commands::Show(args) => {
-            if !cli.quiet {
-                eprintln!(
-                    "show command: identifier={}, tools={}, thinking={}",
-                    args.identifier, args.tools, args.thinking
-                );
-            }
-            // TODO: Implement show command
-            Ok(())
-        }
+        Commands::Show(args) => run_show(args, format),
         Commands::Usage => {
             if !cli.quiet {
                 eprintln!("usage command");
@@ -459,5 +453,205 @@ fn get_field(out: &ConversationOutput, field: &str) -> String {
         "preview" => out.preview.clone(),
         "project" => out.project.clone().unwrap_or_default(),
         _ => String::new(),
+    }
+}
+
+/// Find a conversation file by its UUID across all projects.
+///
+/// Searches all project directories for a file matching the given UUID.
+/// Matches if the file stem equals the uuid or starts with `{uuid}-`.
+fn find_conversation_by_id(uuid: &str) -> Result<PathBuf> {
+    let projects_root = history::get_claude_projects_root()?;
+
+    if !projects_root.exists() {
+        return Err(AppError::NoHistoryFound(format!(
+            "Projects directory does not exist: {}",
+            projects_root.display()
+        )));
+    }
+
+    // Iterate through all project directories
+    for entry in std::fs::read_dir(&projects_root)? {
+        let entry = entry?;
+        let project_path = entry.path();
+
+        if !project_path.is_dir() {
+            continue;
+        }
+
+        // Search for JSONL files in this project
+        for file_entry in std::fs::read_dir(&project_path)? {
+            let file_entry = file_entry?;
+            let file_path = file_entry.path();
+
+            if file_path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            if let Some(stem) = file_path.file_stem().and_then(|s| s.to_str()) {
+                // Match exact UUID or UUID prefix (for files like uuid-timestamp.jsonl)
+                if stem == uuid || stem.starts_with(&format!("{}-", uuid)) {
+                    return Ok(file_path);
+                }
+            }
+        }
+    }
+
+    Err(AppError::NoHistoryFound(format!(
+        "No conversation found with UUID: {}",
+        uuid
+    )))
+}
+
+/// Run the show command to display conversation content
+fn run_show(args: ShowArgs, format: OutputFormat) -> Result<()> {
+    // Resolve the conversation path
+    let path = if args.identifier.contains('/') || args.identifier.contains('.') {
+        // Treat as a file path
+        PathBuf::from(&args.identifier)
+    } else {
+        // Treat as a UUID and search for it
+        find_conversation_by_id(&args.identifier)?
+    };
+
+    // Check if file exists
+    if !path.exists() {
+        return Err(AppError::NoHistoryFound(format!(
+            "Conversation file not found: {}",
+            path.display()
+        )));
+    }
+
+    // Open and read the file
+    let file = File::open(&path)?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Parse the JSON line
+        let entry: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue, // Skip malformed lines
+        };
+
+        // Get message type
+        let msg_type = entry.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+        // Skip non-message types
+        if msg_type != "user" && msg_type != "assistant" {
+            continue;
+        }
+
+        // Get message content
+        let message = match entry.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+
+        let role = message.get("role").and_then(|r| r.as_str()).unwrap_or("");
+        let content = match message.get("content") {
+            Some(c) => c,
+            None => continue,
+        };
+
+        // Filter tool_use and tool_result unless --tools is specified
+        if !args.tools {
+            if let Some(blocks) = content.as_array() {
+                // Check if content is only tool_use/tool_result
+                let has_text = blocks.iter().any(|block| {
+                    block
+                        .get("type")
+                        .and_then(|t| t.as_str())
+                        .map(|t| t == "text" || (args.thinking && t == "thinking"))
+                        .unwrap_or(false)
+                });
+                if !has_text && !blocks.is_empty() {
+                    continue;
+                }
+            }
+        }
+
+        match format {
+            OutputFormat::Jsonl => {
+                // Print the raw line
+                println!("{}", line);
+            }
+            OutputFormat::Human => {
+                // Print role header and content
+                let header = match role {
+                    "user" => "## User",
+                    "assistant" => "## Assistant",
+                    _ => "## Unknown",
+                };
+                println!("\n{}\n", header);
+                print_content(content, args.tools, args.thinking);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Print content from a message, handling both string and array formats
+fn print_content(content: &serde_json::Value, include_tools: bool, include_thinking: bool) {
+    match content {
+        serde_json::Value::String(s) => {
+            println!("{}", s);
+        }
+        serde_json::Value::Array(blocks) => {
+            for block in blocks {
+                let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+                match block_type {
+                    "text" => {
+                        if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                            println!("{}", text);
+                        }
+                    }
+                    "thinking" if include_thinking => {
+                        if let Some(thinking) = block.get("thinking").and_then(|t| t.as_str()) {
+                            println!("<thinking>\n{}\n</thinking>", thinking);
+                        }
+                    }
+                    "tool_use" if include_tools => {
+                        if let Some(name) = block.get("name").and_then(|n| n.as_str()) {
+                            println!("<tool_use name=\"{}\">", name);
+                            if let Some(input) = block.get("input") {
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(input).unwrap_or_default()
+                                );
+                            }
+                            println!("</tool_use>");
+                        }
+                    }
+                    "tool_result" if include_tools => {
+                        println!("<tool_result>");
+                        if let Some(result_content) = block.get("content") {
+                            match result_content {
+                                serde_json::Value::String(s) => println!("{}", s),
+                                serde_json::Value::Array(items) => {
+                                    for item in items {
+                                        if let Some(text) =
+                                            item.get("text").and_then(|t| t.as_str())
+                                        {
+                                            println!("{}", text);
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                        println!("</tool_result>");
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
     }
 }

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -29,8 +29,13 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-/// Exit code when no results are found
-const EXIT_NO_RESULTS: u8 = 3;
+/// Exit codes for the CLI application
+mod exit_codes {
+    pub const SUCCESS: u8 = 0;
+    pub const ERROR: u8 = 1;
+    pub const INVALID_ARGS: u8 = 2;
+    pub const NO_RESULTS: u8 = 3;
+}
 
 /// Output format for query results
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -192,10 +197,14 @@ impl From<&Conversation> for ConversationOutput {
 
 fn main() -> ExitCode {
     match run() {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(()) => ExitCode::from(exit_codes::SUCCESS),
         Err(e) => {
             eprintln!("Error: {}", e);
-            ExitCode::from(1)
+            match e {
+                AppError::InvalidArgs(_) => ExitCode::from(exit_codes::INVALID_ARGS),
+                AppError::NoHistoryFound(_) => ExitCode::from(exit_codes::NO_RESULTS),
+                _ => ExitCode::from(exit_codes::ERROR),
+            }
         }
     }
 }
@@ -258,7 +267,7 @@ fn build_path_filter(args: &ListArgs) -> Result<Option<PathFilter>> {
 }
 
 /// Run the list command
-fn run_list(args: ListArgs, format: OutputFormat, quiet: bool) -> Result<()> {
+fn run_list(args: ListArgs, format: OutputFormat, _quiet: bool) -> Result<()> {
     // Build filters from args
     let time_filter = build_time_filter(&args)?;
     let path_filter = build_path_filter(&args)?;
@@ -288,10 +297,9 @@ fn run_list(args: ListArgs, format: OutputFormat, quiet: bool) -> Result<()> {
         let projects_dir = history::get_claude_projects_dir(&current_dir)?;
 
         if !projects_dir.exists() {
-            if !quiet {
-                eprintln!("No Claude history found for current directory");
-            }
-            std::process::exit(EXIT_NO_RESULTS as i32);
+            return Err(AppError::NoHistoryFound(
+                "No Claude history found for current directory".to_string(),
+            ));
         }
 
         history::load_conversations(
@@ -337,10 +345,7 @@ fn run_list(args: ListArgs, format: OutputFormat, quiet: bool) -> Result<()> {
 
     // Check if empty
     if conversations.is_empty() {
-        if !quiet {
-            eprintln!("No conversations found");
-        }
-        std::process::exit(EXIT_NO_RESULTS as i32);
+        return Err(AppError::NoHistoryFound("No conversations found".to_string()));
     }
 
     // Output results

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -1007,6 +1007,9 @@ mod tests {
             message_count: 1,
             parse_errors: vec![],
             summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
         };
 
         let out = ConversationOutput::from(&conv);
@@ -1029,6 +1032,9 @@ mod tests {
             message_count: 1,
             parse_errors: vec![],
             summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
         };
 
         let out = ConversationOutput::from(&conv);
@@ -1051,6 +1057,9 @@ mod tests {
             message_count: 1,
             parse_errors: vec![],
             summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
         };
 
         let out = ConversationOutput::from(&conv);

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -18,7 +18,16 @@ mod tool_format;
 mod tui;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use error::Result;
+use claude_history::path_filter::PathFilter;
+use claude_history::query::{evaluate, parse_query};
+use claude_history::time_filter::TimeFilter;
+use error::{AppError, Result};
+use history::Conversation;
+use serde::Serialize;
+use std::process::ExitCode;
+
+/// Exit code when no results are found
+const EXIT_NO_RESULTS: u8 = 3;
 
 /// Output format for query results
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -109,7 +118,7 @@ pub struct ListArgs {
     pub query: Option<String>,
 
     /// Fields to output (can be repeated)
-    /// Available: id, path, project, summary, message_count, first_ts, last_ts, duration
+    /// Available: uuid, path, project, cwd, timestamp, preview
     #[arg(long, short = 'f', action = clap::ArgAction::Append, value_name = "FIELD")]
     pub field: Vec<String>,
 
@@ -149,29 +158,57 @@ pub struct ShowArgs {
     pub ts_before: Option<String>,
 }
 
-fn main() {
-    if let Err(e) = run() {
-        eprintln!("Error: {}", e);
-        std::process::exit(1);
+/// Output structure for a conversation in JSON format
+#[derive(Serialize)]
+struct ConversationOutput {
+    uuid: String,
+    path: String,
+    cwd: Option<String>,
+    timestamp: String,
+    preview: String,
+    project: Option<String>,
+}
+
+impl From<&Conversation> for ConversationOutput {
+    fn from(conv: &Conversation) -> Self {
+        Self {
+            uuid: conv
+                .path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string(),
+            path: conv.path.display().to_string(),
+            cwd: conv.cwd.as_ref().map(|p| p.display().to_string()),
+            timestamp: conv.timestamp.to_rfc3339(),
+            preview: conv.preview.clone(),
+            project: conv.project_name.clone(),
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            ExitCode::from(1)
+        }
     }
 }
 
 fn run() -> Result<()> {
     let cli = Cli::parse();
+    let format = cli.output_format();
 
-    match &cli.command {
-        Commands::List(args) => {
-            if !cli.quiet {
-                eprintln!("list command: global={}, since={:?}, query={:?}, limit={:?}, sort={}",
-                    args.global, args.since, args.query, args.limit, args.sort);
-            }
-            // TODO: Implement list command
-            Ok(())
-        }
+    match cli.command {
+        Commands::List(args) => run_list(args, format, cli.quiet),
         Commands::Show(args) => {
             if !cli.quiet {
-                eprintln!("show command: identifier={}, tools={}, thinking={}",
-                    args.identifier, args.tools, args.thinking);
+                eprintln!(
+                    "show command: identifier={}, tools={}, thinking={}",
+                    args.identifier, args.tools, args.thinking
+                );
             }
             // TODO: Implement show command
             Ok(())
@@ -183,5 +220,244 @@ fn run() -> Result<()> {
             // TODO: Implement usage command
             Ok(())
         }
+    }
+}
+
+/// Build a time filter from command line arguments
+fn build_time_filter(args: &ListArgs) -> Result<Option<TimeFilter>> {
+    let mut filter = TimeFilter::new();
+    let mut has_filter = false;
+
+    if let Some(ref since) = args.since {
+        filter = filter.with_since(since).map_err(|e| {
+            AppError::InvalidArgs(format!("invalid --since value '{}': {}", since, e))
+        })?;
+        has_filter = true;
+    }
+
+    if let Some(ref after) = args.after {
+        filter = filter.with_after(after).map_err(|e| {
+            AppError::InvalidArgs(format!("invalid --after value '{}': {}", after, e))
+        })?;
+        has_filter = true;
+    }
+
+    if let Some(ref before) = args.before {
+        filter = filter.with_before(before).map_err(|e| {
+            AppError::InvalidArgs(format!("invalid --before value '{}': {}", before, e))
+        })?;
+        has_filter = true;
+    }
+
+    if has_filter {
+        Ok(Some(filter))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Build a path filter from command line arguments
+fn build_path_filter(args: &ListArgs) -> Result<Option<PathFilter>> {
+    if args.include_path.is_empty() && args.exclude_path.is_empty() {
+        return Ok(None);
+    }
+
+    let filter = PathFilter::from_patterns(&args.include_path, &args.exclude_path).map_err(|e| {
+        AppError::InvalidArgs(format!("invalid path pattern: {}", e))
+    })?;
+
+    Ok(Some(filter))
+}
+
+/// Run the list command
+fn run_list(args: ListArgs, format: OutputFormat, quiet: bool) -> Result<()> {
+    // Build filters from args
+    let time_filter = build_time_filter(&args)?;
+    let path_filter = build_path_filter(&args)?;
+
+    // Parse content query if provided
+    let query_expr = if let Some(ref query_str) = args.query {
+        Some(parse_query(query_str).map_err(|e| {
+            AppError::InvalidArgs(format!("invalid query '{}': {}", query_str, e))
+        })?)
+    } else {
+        None
+    };
+
+    // Load conversations based on global flag
+    let mut conversations = if args.global {
+        history::load_all_conversations(
+            false, // show_last
+            None,  // debug_level
+            time_filter.as_ref(),
+            path_filter.as_ref(),
+        )?
+    } else {
+        // Load from current directory's project
+        let current_dir = std::env::current_dir().map_err(|e| {
+            AppError::Io(e)
+        })?;
+        let projects_dir = history::get_claude_projects_dir(&current_dir)?;
+
+        if !projects_dir.exists() {
+            if !quiet {
+                eprintln!("No Claude history found for current directory");
+            }
+            std::process::exit(EXIT_NO_RESULTS as i32);
+        }
+
+        history::load_conversations(
+            &projects_dir,
+            false, // show_last
+            None,  // debug_level
+            time_filter.as_ref(),
+            path_filter.as_ref(),
+        )?
+    };
+
+    // Apply content query filter
+    if let Some(ref expr) = query_expr {
+        conversations.retain(|conv| evaluate(expr, &conv.full_text));
+    }
+
+    // Apply sort
+    match args.sort.as_str() {
+        "newest" => {
+            conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        }
+        "oldest" => {
+            conversations.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        }
+        "most-messages" => {
+            conversations.sort_by(|a, b| b.message_count.cmp(&a.message_count));
+        }
+        "least-messages" => {
+            conversations.sort_by(|a, b| a.message_count.cmp(&b.message_count));
+        }
+        other => {
+            return Err(AppError::InvalidArgs(format!(
+                "invalid sort order '{}': expected newest, oldest, most-messages, or least-messages",
+                other
+            )));
+        }
+    }
+
+    // Apply limit
+    if let Some(limit) = args.limit {
+        conversations.truncate(limit);
+    }
+
+    // Check if empty
+    if conversations.is_empty() {
+        if !quiet {
+            eprintln!("No conversations found");
+        }
+        std::process::exit(EXIT_NO_RESULTS as i32);
+    }
+
+    // Output results
+    output_list(&conversations, &args.field, format);
+
+    Ok(())
+}
+
+/// Output the list of conversations
+fn output_list(conversations: &[Conversation], fields: &[String], format: OutputFormat) {
+    for conv in conversations {
+        let out = ConversationOutput::from(conv);
+
+        match format {
+            OutputFormat::Jsonl => {
+                let value = if fields.is_empty() {
+                    serde_json::to_value(&out).unwrap()
+                } else {
+                    filter_fields(&out, fields)
+                };
+                println!("{}", serde_json::to_string(&value).unwrap());
+            }
+            OutputFormat::Human => {
+                if fields.is_empty() {
+                    // Default human output with relative time
+                    let relative_time = chrono_humanize::HumanTime::from(conv.timestamp);
+                    println!(
+                        "{} ({}) - {}",
+                        out.uuid,
+                        relative_time,
+                        out.preview
+                    );
+                } else {
+                    // Custom field output
+                    let values: Vec<String> = fields
+                        .iter()
+                        .map(|f| get_field(&out, f))
+                        .collect();
+                    println!("{}", values.join("\t"));
+                }
+            }
+        }
+    }
+}
+
+/// Filter output to specific fields
+fn filter_fields(out: &ConversationOutput, fields: &[String]) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+
+    for field in fields {
+        match field.as_str() {
+            "uuid" => {
+                map.insert("uuid".to_string(), serde_json::Value::String(out.uuid.clone()));
+            }
+            "path" => {
+                map.insert("path".to_string(), serde_json::Value::String(out.path.clone()));
+            }
+            "cwd" => {
+                map.insert(
+                    "cwd".to_string(),
+                    out.cwd
+                        .as_ref()
+                        .map(|s| serde_json::Value::String(s.clone()))
+                        .unwrap_or(serde_json::Value::Null),
+                );
+            }
+            "timestamp" => {
+                map.insert(
+                    "timestamp".to_string(),
+                    serde_json::Value::String(out.timestamp.clone()),
+                );
+            }
+            "preview" => {
+                map.insert(
+                    "preview".to_string(),
+                    serde_json::Value::String(out.preview.clone()),
+                );
+            }
+            "project" => {
+                map.insert(
+                    "project".to_string(),
+                    out.project
+                        .as_ref()
+                        .map(|s| serde_json::Value::String(s.clone()))
+                        .unwrap_or(serde_json::Value::Null),
+                );
+            }
+            _ => {
+                // Unknown field, skip silently
+            }
+        }
+    }
+
+    serde_json::Value::Object(map)
+}
+
+/// Get a single field value as a string
+fn get_field(out: &ConversationOutput, field: &str) -> String {
+    match field {
+        "uuid" => out.uuid.clone(),
+        "path" => out.path.clone(),
+        "cwd" => out.cwd.clone().unwrap_or_default(),
+        "timestamp" => out.timestamp.clone(),
+        "preview" => out.preview.clone(),
+        "project" => out.project.clone().unwrap_or_default(),
+        _ => String::new(),
     }
 }

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -207,13 +207,7 @@ fn run() -> Result<()> {
     match cli.command {
         Commands::List(args) => run_list(args, format, cli.quiet),
         Commands::Show(args) => run_show(args, format),
-        Commands::Usage => {
-            if !cli.quiet {
-                eprintln!("usage command");
-            }
-            // TODO: Implement usage command
-            Ok(())
-        }
+        Commands::Usage => run_usage(format),
     }
 }
 
@@ -593,6 +587,130 @@ fn run_show(args: ShowArgs, format: OutputFormat) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Run the usage command to display documentation for LLM agents
+fn run_usage(_format: OutputFormat) -> Result<()> {
+    print!(r#"# claude-history-query
+
+Non-interactive CLI for querying Claude Code conversation history.
+Provides scriptable, pipeable access to conversation data for shell scripts
+and LLM agents without requiring a TUI.
+
+## Commands
+
+### list
+
+List conversations matching criteria.
+
+```
+claude-history-query list [OPTIONS]
+```
+
+**Options:**
+
+* `-g, --global` - Search all conversations globally (not just current directory)
+* `-s, --since <DURATION>` - Show conversations since duration ago (e.g., 2d, 1w, 3h)
+* `--after <DATE>` - Show conversations after date (YYYY-MM-DD)
+* `--before <DATE>` - Show conversations before date (YYYY-MM-DD)
+* `--include-path <PATTERN>` - Include paths matching regex (can be repeated)
+* `--exclude-path <PATTERN>` - Exclude paths matching regex (can be repeated)
+* `--query <QUERY>` - Boolean search query (e.g., 'rust && !deprecated')
+* `-f, --field <FIELD>` - Fields to output (can be repeated)
+* `-n, --limit <COUNT>` - Maximum number of results to return
+* `--sort <ORDER>` - Sort order: newest, oldest, most-messages, least-messages
+
+### show
+
+Show conversation content.
+
+```
+claude-history-query show <IDENTIFIER> [OPTIONS]
+```
+
+**Arguments:**
+
+* `<IDENTIFIER>` - Conversation identifier (path, UUID, or index from list)
+
+**Options:**
+
+* `--format <FORMAT>` - Output format for messages
+* `-t, --tools` - Include tool calls in output
+* `--thinking` - Include thinking blocks in output
+* `--ts-after <TIMESTAMP>` - Only show messages after this timestamp (ISO 8601 or Unix)
+* `--ts-before <TIMESTAMP>` - Only show messages before this timestamp (ISO 8601 or Unix)
+
+## Output Formats
+
+* `--human` - Human-readable output (default). Shows relative timestamps and formatted text.
+* `--jsonl` - JSON Lines format. One JSON object per line, suitable for parsing.
+
+## Field Names
+
+Available fields for `--field` option:
+
+* `uuid` - Conversation unique identifier
+* `path` - Full path to conversation file
+* `cwd` - Working directory where conversation was started
+* `timestamp` - ISO 8601 timestamp of last activity
+* `preview` - First line of the first user message
+* `project` - Project name derived from working directory
+
+## Common Patterns
+
+### Resume a conversation
+
+```bash
+# Get the UUID of the most recent conversation
+UUID=$(claude-history-query list -n 1 --jsonl | jq -r '.uuid')
+claude --resume "$UUID"
+```
+
+### Search and resume with fzf
+
+```bash
+claude-history-query list -g | fzf | cut -d' ' -f1 | xargs -I{{}} claude --resume {{}}
+```
+
+### Export conversations to backup
+
+```bash
+claude-history-query list -g --jsonl > backup.jsonl
+```
+
+### Delete old conversations
+
+```bash
+claude-history-query list --before 2024-01-01 -f path | xargs rm
+```
+
+### Find conversations about a topic
+
+```bash
+claude-history-query list -g --query "docker && kubernetes"
+```
+
+### Get recent conversations from current project
+
+```bash
+claude-history-query list --since 1w
+```
+
+### Show conversation content as JSONL
+
+```bash
+claude-history-query show <UUID> --jsonl
+```
+
+## Exit Codes
+
+* `0` - Success
+* `1` - General error (I/O, parsing, etc.)
+* `2` - Invalid arguments
+* `3` - No results found
+
+"#);
     Ok(())
 }
 

--- a/src/query_main.rs
+++ b/src/query_main.rs
@@ -1,0 +1,187 @@
+//! claude-history-query: Non-interactive CLI for querying Claude Code conversation history.
+//!
+//! This binary provides scriptable, pipeable access to conversation data without requiring
+//! a TUI. It outputs JSONL or human-readable formats suitable for shell pipelines.
+
+mod claude;
+mod cli;
+mod config;
+mod debug;
+mod debug_log;
+mod display;
+mod error;
+mod history;
+mod markdown;
+mod pager;
+mod syntax;
+mod tool_format;
+mod tui;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use error::Result;
+
+/// Output format for query results
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable output (default)
+    #[default]
+    Human,
+    /// JSON Lines format (one JSON object per line)
+    Jsonl,
+}
+
+/// Non-interactive CLI for querying Claude Code conversation history.
+///
+/// Provides scriptable access to conversation data without requiring a TUI.
+/// Outputs JSONL or human-readable formats suitable for shell pipelines.
+#[derive(Parser, Debug)]
+#[command(name = "claude-history-query")]
+#[command(version)]
+#[command(about = "Non-interactive CLI for querying Claude Code conversation history")]
+pub struct Cli {
+    /// Output in human-readable format (default)
+    #[arg(long, global = true, group = "output_format")]
+    pub human: bool,
+
+    /// Output in JSON Lines format
+    #[arg(long, global = true, group = "output_format")]
+    pub jsonl: bool,
+
+    /// Suppress all non-error output (exit code only)
+    #[arg(long, short = 'q', global = true)]
+    pub quiet: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+impl Cli {
+    /// Determine the output format from flags
+    pub fn output_format(&self) -> OutputFormat {
+        if self.jsonl {
+            OutputFormat::Jsonl
+        } else {
+            OutputFormat::Human
+        }
+    }
+}
+
+/// Available subcommands
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// List conversations matching criteria
+    List(ListArgs),
+    /// Show conversation content
+    Show(ShowArgs),
+    /// Show usage statistics
+    Usage,
+}
+
+/// Arguments for the list subcommand
+#[derive(Parser, Debug)]
+pub struct ListArgs {
+    /// Search all conversations globally (not just current directory)
+    #[arg(long, short = 'g')]
+    pub global: bool,
+
+    /// Show conversations since duration ago (e.g., 2d, 1w, 3h)
+    #[arg(long, short = 's', value_name = "DURATION")]
+    pub since: Option<String>,
+
+    /// Show conversations after date (YYYY-MM-DD)
+    #[arg(long, value_name = "DATE")]
+    pub after: Option<String>,
+
+    /// Show conversations before date (YYYY-MM-DD)
+    #[arg(long, value_name = "DATE")]
+    pub before: Option<String>,
+
+    /// Include paths matching regex (can be repeated)
+    #[arg(long, action = clap::ArgAction::Append, value_name = "PATTERN")]
+    pub include_path: Vec<String>,
+
+    /// Exclude paths matching regex (can be repeated)
+    #[arg(long, action = clap::ArgAction::Append, value_name = "PATTERN")]
+    pub exclude_path: Vec<String>,
+
+    /// Boolean search query (e.g., 'rust && !deprecated')
+    #[arg(long, value_name = "QUERY")]
+    pub query: Option<String>,
+
+    /// Fields to output (can be repeated)
+    /// Available: id, path, project, summary, message_count, first_ts, last_ts, duration
+    #[arg(long, short = 'f', action = clap::ArgAction::Append, value_name = "FIELD")]
+    pub field: Vec<String>,
+
+    /// Maximum number of results to return
+    #[arg(long, short = 'n', value_name = "COUNT")]
+    pub limit: Option<usize>,
+
+    /// Sort order: newest, oldest, most-messages, least-messages
+    #[arg(long, value_name = "ORDER", default_value = "newest")]
+    pub sort: String,
+}
+
+/// Arguments for the show subcommand
+#[derive(Parser, Debug)]
+pub struct ShowArgs {
+    /// Conversation identifier (path, ID, or index from list)
+    pub identifier: String,
+
+    /// Output format for messages
+    #[arg(long, value_name = "FORMAT")]
+    pub format: Option<String>,
+
+    /// Include tool calls in output
+    #[arg(long, short = 't')]
+    pub tools: bool,
+
+    /// Include thinking blocks in output
+    #[arg(long)]
+    pub thinking: bool,
+
+    /// Only show messages after this timestamp (ISO 8601 or Unix)
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub ts_after: Option<String>,
+
+    /// Only show messages before this timestamp (ISO 8601 or Unix)
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub ts_before: Option<String>,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::List(args) => {
+            if !cli.quiet {
+                eprintln!("list command: global={}, since={:?}, query={:?}, limit={:?}, sort={}",
+                    args.global, args.since, args.query, args.limit, args.sort);
+            }
+            // TODO: Implement list command
+            Ok(())
+        }
+        Commands::Show(args) => {
+            if !cli.quiet {
+                eprintln!("show command: identifier={}, tools={}, thinking={}",
+                    args.identifier, args.tools, args.thinking);
+            }
+            // TODO: Implement show command
+            Ok(())
+        }
+        Commands::Usage => {
+            if !cli.quiet {
+                eprintln!("usage command");
+            }
+            // TODO: Implement usage command
+            Ok(())
+        }
+    }
+}

--- a/src/time_filter.rs
+++ b/src/time_filter.rs
@@ -1,0 +1,677 @@
+//! Time-based filtering for Claude conversations.
+//!
+//! This module provides functionality to filter conversations by timestamp,
+//! supporting both human-friendly duration strings and explicit date ranges.
+//!
+//! # Duration Syntax
+//!
+//! Durations are specified as a number followed by a unit:
+//! - `h` - hours (e.g., `3h` = 3 hours ago)
+//! - `d` - days (e.g., `2d` = 2 days ago)
+//! - `w` - weeks (e.g., `1w` = 1 week ago)
+//! - `m` - months, approximately 30 days (e.g., `1m` = ~30 days ago)
+//!
+//! # Examples
+//!
+//! ```
+//! use claude_history::time_filter::{TimeFilter, parse_duration};
+//! use chrono::{Duration, Local};
+//!
+//! // Parse a duration string
+//! let duration = parse_duration("2d").unwrap();
+//! assert_eq!(duration, Duration::days(2));
+//!
+//! // Create a filter for "last 2 days"
+//! let filter = TimeFilter::from_since("2d").unwrap();
+//! assert!(filter.after.is_some());
+//! assert!(filter.before.is_none());
+//!
+//! // Check if a timestamp matches
+//! let recent = Local::now() - Duration::hours(1);
+//! assert!(filter.matches(recent));
+//!
+//! let old = Local::now() - Duration::days(10);
+//! assert!(!filter.matches(old));
+//! ```
+
+use chrono::{DateTime, Duration, Local, NaiveDate};
+use std::fmt;
+
+/// Error type for time filter parsing failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeFilterError {
+    /// Duration string is empty
+    EmptyDuration,
+    /// Duration has no numeric part (e.g., "d" instead of "2d")
+    MissingNumber,
+    /// Duration has no unit part (e.g., "2" instead of "2d")
+    MissingUnit,
+    /// The numeric part couldn't be parsed
+    InvalidNumber(String),
+    /// The unit is not recognized (must be h, d, w, or m)
+    InvalidUnit(char),
+    /// Date string couldn't be parsed (expected YYYY-MM-DD)
+    InvalidDate(String),
+}
+
+impl fmt::Display for TimeFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyDuration => write!(f, "duration string is empty"),
+            Self::MissingNumber => write!(f, "duration must start with a number (e.g., '2d')"),
+            Self::MissingUnit => {
+                write!(f, "duration must end with a unit: h, d, w, or m (e.g., '2d')")
+            }
+            Self::InvalidNumber(s) => write!(f, "invalid number in duration: '{}'", s),
+            Self::InvalidUnit(c) => {
+                write!(f, "invalid unit '{}', expected: h (hours), d (days), w (weeks), m (months)", c)
+            }
+            Self::InvalidDate(s) => write!(f, "invalid date '{}', expected format: YYYY-MM-DD", s),
+        }
+    }
+}
+
+impl std::error::Error for TimeFilterError {}
+
+/// A filter for matching conversations by timestamp.
+///
+/// Conversations match if their timestamp is:
+/// - After `after` (if specified), AND
+/// - Before `before` (if specified)
+///
+/// # Examples
+///
+/// ```
+/// use claude_history::time_filter::TimeFilter;
+/// use chrono::{Duration, Local};
+///
+/// // Filter for conversations in the last week
+/// let filter = TimeFilter::from_since("1w").unwrap();
+///
+/// let yesterday = Local::now() - Duration::days(1);
+/// assert!(filter.matches(yesterday));
+///
+/// let last_month = Local::now() - Duration::days(30);
+/// assert!(!filter.matches(last_month));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct TimeFilter {
+    /// Only include conversations after this timestamp
+    pub after: Option<DateTime<Local>>,
+    /// Only include conversations before this timestamp
+    pub before: Option<DateTime<Local>>,
+}
+
+impl TimeFilter {
+    /// Create a new empty filter (matches all timestamps).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    /// use chrono::Local;
+    ///
+    /// let filter = TimeFilter::new();
+    /// assert!(filter.matches(Local::now()));
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a filter from a "since" duration string.
+    ///
+    /// The filter will match conversations from `now - duration` until now.
+    ///
+    /// # Arguments
+    ///
+    /// * `since` - A duration string like "2d", "1w", "3h"
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    /// use chrono::{Duration, Local};
+    ///
+    /// let filter = TimeFilter::from_since("2d").unwrap();
+    ///
+    /// // Recent conversations match
+    /// let recent = Local::now() - Duration::hours(6);
+    /// assert!(filter.matches(recent));
+    ///
+    /// // Old conversations don't match
+    /// let old = Local::now() - Duration::days(5);
+    /// assert!(!filter.matches(old));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `TimeFilterError` if the duration string is invalid.
+    pub fn from_since(since: &str) -> Result<Self, TimeFilterError> {
+        let duration = parse_duration(since)?;
+        Ok(Self {
+            after: Some(Local::now() - duration),
+            before: None,
+        })
+    }
+
+    /// Create a filter from an "after" date string.
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - A date string in YYYY-MM-DD format
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    ///
+    /// let filter = TimeFilter::from_after("2026-01-15").unwrap();
+    /// assert!(filter.after.is_some());
+    /// ```
+    pub fn from_after(date: &str) -> Result<Self, TimeFilterError> {
+        let datetime = parse_date(date)?;
+        Ok(Self {
+            after: Some(datetime),
+            before: None,
+        })
+    }
+
+    /// Create a filter from a "before" date string.
+    ///
+    /// # Arguments
+    ///
+    /// * `date` - A date string in YYYY-MM-DD format
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    ///
+    /// let filter = TimeFilter::from_before("2026-02-01").unwrap();
+    /// assert!(filter.before.is_some());
+    /// ```
+    pub fn from_before(date: &str) -> Result<Self, TimeFilterError> {
+        let datetime = parse_date(date)?;
+        Ok(Self {
+            after: None,
+            before: Some(datetime),
+        })
+    }
+
+    /// Set the "after" bound from a date string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    ///
+    /// let filter = TimeFilter::new()
+    ///     .with_after("2026-01-15").unwrap()
+    ///     .with_before("2026-02-01").unwrap();
+    ///
+    /// assert!(filter.after.is_some());
+    /// assert!(filter.before.is_some());
+    /// ```
+    pub fn with_after(mut self, date: &str) -> Result<Self, TimeFilterError> {
+        self.after = Some(parse_date(date)?);
+        Ok(self)
+    }
+
+    /// Set the "before" bound from a date string.
+    pub fn with_before(mut self, date: &str) -> Result<Self, TimeFilterError> {
+        self.before = Some(parse_date(date)?);
+        Ok(self)
+    }
+
+    /// Set the "after" bound from a "since" duration string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    ///
+    /// let filter = TimeFilter::new().with_since("1w").unwrap();
+    /// assert!(filter.after.is_some());
+    /// ```
+    pub fn with_since(mut self, since: &str) -> Result<Self, TimeFilterError> {
+        let duration = parse_duration(since)?;
+        self.after = Some(Local::now() - duration);
+        Ok(self)
+    }
+
+    /// Check if a timestamp matches this filter.
+    ///
+    /// A timestamp matches if it is:
+    /// - Greater than or equal to `after` (if specified), AND
+    /// - Less than or equal to `before` (if specified)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    /// use chrono::{Duration, Local, TimeZone};
+    ///
+    /// // Filter: after 2026-01-15, before 2026-02-01
+    /// let filter = TimeFilter::new()
+    ///     .with_after("2026-01-15").unwrap()
+    ///     .with_before("2026-02-01").unwrap();
+    ///
+    /// // January 20 is in range
+    /// let jan_20 = Local.with_ymd_and_hms(2026, 1, 20, 12, 0, 0).unwrap();
+    /// assert!(filter.matches(jan_20));
+    ///
+    /// // January 10 is before the range
+    /// let jan_10 = Local.with_ymd_and_hms(2026, 1, 10, 12, 0, 0).unwrap();
+    /// assert!(!filter.matches(jan_10));
+    ///
+    /// // February 10 is after the range
+    /// let feb_10 = Local.with_ymd_and_hms(2026, 2, 10, 12, 0, 0).unwrap();
+    /// assert!(!filter.matches(feb_10));
+    /// ```
+    pub fn matches(&self, timestamp: DateTime<Local>) -> bool {
+        if let Some(after) = self.after {
+            if timestamp < after {
+                return false;
+            }
+        }
+        if let Some(before) = self.before {
+            if timestamp > before {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Check if this filter has any constraints.
+    ///
+    /// Returns `false` if both `after` and `before` are `None`,
+    /// meaning the filter matches all timestamps.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use claude_history::time_filter::TimeFilter;
+    ///
+    /// let empty = TimeFilter::new();
+    /// assert!(!empty.is_active());
+    ///
+    /// let with_since = TimeFilter::from_since("1d").unwrap();
+    /// assert!(with_since.is_active());
+    /// ```
+    pub fn is_active(&self) -> bool {
+        self.after.is_some() || self.before.is_some()
+    }
+}
+
+/// Parse a duration string into a `chrono::Duration`.
+///
+/// # Format
+///
+/// A duration is a positive integer followed by a unit character:
+/// - `h` - hours
+/// - `d` - days
+/// - `w` - weeks (7 days)
+/// - `m` - months (approximately 30 days)
+///
+/// # Examples
+///
+/// ```
+/// use claude_history::time_filter::parse_duration;
+/// use chrono::Duration;
+///
+/// assert_eq!(parse_duration("3h").unwrap(), Duration::hours(3));
+/// assert_eq!(parse_duration("2d").unwrap(), Duration::days(2));
+/// assert_eq!(parse_duration("1w").unwrap(), Duration::weeks(1));
+/// assert_eq!(parse_duration("1m").unwrap(), Duration::days(30));
+/// ```
+///
+/// # Errors
+///
+/// Returns `TimeFilterError` if:
+/// - The string is empty
+/// - There's no numeric part
+/// - There's no unit part
+/// - The number can't be parsed
+/// - The unit is not recognized
+///
+/// ```
+/// use claude_history::time_filter::{parse_duration, TimeFilterError};
+///
+/// assert!(matches!(parse_duration(""), Err(TimeFilterError::EmptyDuration)));
+/// assert!(matches!(parse_duration("d"), Err(TimeFilterError::MissingNumber)));
+/// assert!(matches!(parse_duration("2"), Err(TimeFilterError::MissingUnit)));
+/// assert!(matches!(parse_duration("2x"), Err(TimeFilterError::InvalidUnit('x'))));
+/// ```
+pub fn parse_duration(s: &str) -> Result<Duration, TimeFilterError> {
+    let s = s.trim();
+
+    if s.is_empty() {
+        return Err(TimeFilterError::EmptyDuration);
+    }
+
+    // Find where the number ends and unit begins
+    let unit_pos = s
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_digit())
+        .map(|(i, _)| i);
+
+    let (num_str, unit_str) = match unit_pos {
+        None => return Err(TimeFilterError::MissingUnit),
+        Some(0) => return Err(TimeFilterError::MissingNumber),
+        Some(i) => (&s[..i], &s[i..]),
+    };
+
+    let n: i64 = num_str
+        .parse()
+        .map_err(|_| TimeFilterError::InvalidNumber(num_str.to_string()))?;
+
+    // Unit should be exactly one character
+    let unit = unit_str.chars().next().ok_or(TimeFilterError::MissingUnit)?;
+
+    match unit {
+        'h' => Ok(Duration::hours(n)),
+        'd' => Ok(Duration::days(n)),
+        'w' => Ok(Duration::weeks(n)),
+        'm' => Ok(Duration::days(n * 30)), // Approximate month
+        _ => Err(TimeFilterError::InvalidUnit(unit)),
+    }
+}
+
+/// Parse a date string in YYYY-MM-DD format into a `DateTime<Local>`.
+///
+/// The time is set to midnight (00:00:00) in the local timezone.
+///
+/// # Examples
+///
+/// ```
+/// use claude_history::time_filter::parse_date;
+/// use chrono::{Datelike, Timelike};
+///
+/// let dt = parse_date("2026-01-15").unwrap();
+/// assert_eq!(dt.year(), 2026);
+/// assert_eq!(dt.month(), 1);
+/// assert_eq!(dt.day(), 15);
+/// assert_eq!(dt.hour(), 0);
+/// assert_eq!(dt.minute(), 0);
+/// ```
+///
+/// # Errors
+///
+/// Returns `TimeFilterError::InvalidDate` if the string doesn't match YYYY-MM-DD format.
+///
+/// ```
+/// use claude_history::time_filter::{parse_date, TimeFilterError};
+///
+/// assert!(matches!(parse_date("01-15-2026"), Err(TimeFilterError::InvalidDate(_))));
+/// assert!(matches!(parse_date("2026/01/15"), Err(TimeFilterError::InvalidDate(_))));
+/// assert!(matches!(parse_date("not-a-date"), Err(TimeFilterError::InvalidDate(_))));
+/// ```
+pub fn parse_date(s: &str) -> Result<DateTime<Local>, TimeFilterError> {
+    let naive_date = NaiveDate::parse_from_str(s.trim(), "%Y-%m-%d")
+        .map_err(|_| TimeFilterError::InvalidDate(s.to_string()))?;
+
+    // Convert to DateTime at midnight local time
+    let naive_datetime = naive_date.and_hms_opt(0, 0, 0).ok_or_else(|| {
+        TimeFilterError::InvalidDate(format!("{} (failed to create midnight time)", s))
+    })?;
+
+    Ok(naive_datetime
+        .and_local_timezone(Local)
+        .single()
+        .ok_or_else(|| TimeFilterError::InvalidDate(format!("{} (ambiguous local time)", s)))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, TimeZone, Timelike};
+
+    // ==================== parse_duration tests ====================
+
+    #[test]
+    fn parse_duration_hours() {
+        assert_eq!(parse_duration("1h").unwrap(), Duration::hours(1));
+        assert_eq!(parse_duration("24h").unwrap(), Duration::hours(24));
+        assert_eq!(parse_duration("100h").unwrap(), Duration::hours(100));
+    }
+
+    #[test]
+    fn parse_duration_days() {
+        assert_eq!(parse_duration("1d").unwrap(), Duration::days(1));
+        assert_eq!(parse_duration("7d").unwrap(), Duration::days(7));
+        assert_eq!(parse_duration("30d").unwrap(), Duration::days(30));
+    }
+
+    #[test]
+    fn parse_duration_weeks() {
+        assert_eq!(parse_duration("1w").unwrap(), Duration::weeks(1));
+        assert_eq!(parse_duration("2w").unwrap(), Duration::weeks(2));
+        assert_eq!(parse_duration("4w").unwrap(), Duration::weeks(4));
+    }
+
+    #[test]
+    fn parse_duration_months() {
+        // Months are approximated as 30 days
+        assert_eq!(parse_duration("1m").unwrap(), Duration::days(30));
+        assert_eq!(parse_duration("3m").unwrap(), Duration::days(90));
+    }
+
+    #[test]
+    fn parse_duration_with_whitespace() {
+        assert_eq!(parse_duration("  2d  ").unwrap(), Duration::days(2));
+    }
+
+    #[test]
+    fn parse_duration_empty_returns_error() {
+        assert!(matches!(
+            parse_duration(""),
+            Err(TimeFilterError::EmptyDuration)
+        ));
+        assert!(matches!(
+            parse_duration("   "),
+            Err(TimeFilterError::EmptyDuration)
+        ));
+    }
+
+    #[test]
+    fn parse_duration_missing_number_returns_error() {
+        assert!(matches!(
+            parse_duration("d"),
+            Err(TimeFilterError::MissingNumber)
+        ));
+        assert!(matches!(
+            parse_duration("h"),
+            Err(TimeFilterError::MissingNumber)
+        ));
+    }
+
+    #[test]
+    fn parse_duration_missing_unit_returns_error() {
+        assert!(matches!(
+            parse_duration("2"),
+            Err(TimeFilterError::MissingUnit)
+        ));
+        assert!(matches!(
+            parse_duration("100"),
+            Err(TimeFilterError::MissingUnit)
+        ));
+    }
+
+    #[test]
+    fn parse_duration_invalid_unit_returns_error() {
+        assert!(matches!(
+            parse_duration("2x"),
+            Err(TimeFilterError::InvalidUnit('x'))
+        ));
+        assert!(matches!(
+            parse_duration("2y"),
+            Err(TimeFilterError::InvalidUnit('y'))
+        ));
+        assert!(matches!(
+            parse_duration("2D"), // Case sensitive
+            Err(TimeFilterError::InvalidUnit('D'))
+        ));
+    }
+
+    // ==================== parse_date tests ====================
+
+    #[test]
+    fn parse_date_valid() {
+        let dt = parse_date("2026-01-15").unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 1);
+        assert_eq!(dt.day(), 15);
+        assert_eq!(dt.hour(), 0);
+        assert_eq!(dt.minute(), 0);
+        assert_eq!(dt.second(), 0);
+    }
+
+    #[test]
+    fn parse_date_with_whitespace() {
+        let dt = parse_date("  2026-02-28  ").unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 2);
+        assert_eq!(dt.day(), 28);
+    }
+
+    #[test]
+    fn parse_date_invalid_format() {
+        assert!(matches!(
+            parse_date("01-15-2026"),
+            Err(TimeFilterError::InvalidDate(_))
+        ));
+        assert!(matches!(
+            parse_date("2026/01/15"),
+            Err(TimeFilterError::InvalidDate(_))
+        ));
+        assert!(matches!(
+            parse_date("January 15, 2026"),
+            Err(TimeFilterError::InvalidDate(_))
+        ));
+    }
+
+    #[test]
+    fn parse_date_invalid_values() {
+        // Invalid month
+        assert!(matches!(
+            parse_date("2026-13-01"),
+            Err(TimeFilterError::InvalidDate(_))
+        ));
+        // Invalid day
+        assert!(matches!(
+            parse_date("2026-01-32"),
+            Err(TimeFilterError::InvalidDate(_))
+        ));
+    }
+
+    // ==================== TimeFilter tests ====================
+
+    #[test]
+    fn time_filter_new_matches_everything() {
+        let filter = TimeFilter::new();
+        assert!(!filter.is_active());
+
+        // Should match any timestamp
+        assert!(filter.matches(Local::now()));
+        assert!(filter.matches(Local::now() - Duration::days(1000)));
+        assert!(filter.matches(Local::now() + Duration::days(1000)));
+    }
+
+    #[test]
+    fn time_filter_from_since() {
+        let filter = TimeFilter::from_since("1d").unwrap();
+        assert!(filter.is_active());
+        assert!(filter.after.is_some());
+        assert!(filter.before.is_none());
+
+        // Recent should match
+        let recent = Local::now() - Duration::hours(6);
+        assert!(filter.matches(recent));
+
+        // Old should not match
+        let old = Local::now() - Duration::days(5);
+        assert!(!filter.matches(old));
+    }
+
+    #[test]
+    fn time_filter_from_after() {
+        let filter = TimeFilter::from_after("2026-01-15").unwrap();
+        assert!(filter.is_active());
+
+        let jan_20 = Local.with_ymd_and_hms(2026, 1, 20, 12, 0, 0).unwrap();
+        assert!(filter.matches(jan_20));
+
+        let jan_10 = Local.with_ymd_and_hms(2026, 1, 10, 12, 0, 0).unwrap();
+        assert!(!filter.matches(jan_10));
+    }
+
+    #[test]
+    fn time_filter_from_before() {
+        let filter = TimeFilter::from_before("2026-02-01").unwrap();
+        assert!(filter.is_active());
+
+        let jan_20 = Local.with_ymd_and_hms(2026, 1, 20, 12, 0, 0).unwrap();
+        assert!(filter.matches(jan_20));
+
+        let feb_10 = Local.with_ymd_and_hms(2026, 2, 10, 12, 0, 0).unwrap();
+        assert!(!filter.matches(feb_10));
+    }
+
+    #[test]
+    fn time_filter_range() {
+        // After 2026-01-15, before 2026-02-01
+        let filter = TimeFilter::new()
+            .with_after("2026-01-15")
+            .unwrap()
+            .with_before("2026-02-01")
+            .unwrap();
+
+        assert!(filter.is_active());
+
+        // In range
+        let jan_20 = Local.with_ymd_and_hms(2026, 1, 20, 12, 0, 0).unwrap();
+        assert!(filter.matches(jan_20));
+
+        // Before range
+        let jan_10 = Local.with_ymd_and_hms(2026, 1, 10, 12, 0, 0).unwrap();
+        assert!(!filter.matches(jan_10));
+
+        // After range
+        let feb_10 = Local.with_ymd_and_hms(2026, 2, 10, 12, 0, 0).unwrap();
+        assert!(!filter.matches(feb_10));
+
+        // Boundary: exactly at "after" should match (>=)
+        let jan_15 = Local.with_ymd_and_hms(2026, 1, 15, 0, 0, 0).unwrap();
+        assert!(filter.matches(jan_15));
+
+        // Boundary: exactly at "before" should match (<=)
+        let feb_1 = Local.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
+        assert!(filter.matches(feb_1));
+    }
+
+    #[test]
+    fn time_filter_with_since() {
+        let filter = TimeFilter::new().with_since("2d").unwrap();
+        assert!(filter.is_active());
+
+        // Recent matches
+        let recent = Local::now() - Duration::hours(12);
+        assert!(filter.matches(recent));
+
+        // Old doesn't match
+        let old = Local::now() - Duration::days(5);
+        assert!(!filter.matches(old));
+    }
+
+    #[test]
+    fn time_filter_error_display() {
+        assert_eq!(
+            TimeFilterError::EmptyDuration.to_string(),
+            "duration string is empty"
+        );
+        assert_eq!(
+            TimeFilterError::InvalidUnit('x').to_string(),
+            "invalid unit 'x', expected: h (hours), d (days), w (weeks), m (months)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new binary `claude-history-query` optimized for programmatic use by shell scripts and LLM agents. Follows UNIX philosophy with JSONL output, explicit format flags, and composability with standard tools.

> **Note:** This PR builds on #6 (filter features). Please merge #6 first, then this PR can be rebased.

## New Binary: `claude-history-query`

### Commands

* `list` - List conversations with filters (time, path, content query)
* `show <UUID|PATH>` - Display conversation content
* `usage` - Self-documenting help optimized for LLM discovery

### Key Features

* `--human` (default) and `--jsonl` output formats
* Field selection with `--field uuid --field cwd`
* Exit codes: 0=success, 1=error, 2=invalid args, 3=no results
* UUID resolution across all project directories
* Composable with `jq`, `fzf`, `xargs`

### Example Workflows

```bash
# Resume most recent conversation
claude --resume "$(claude-history-query list --limit 1 --field uuid)"

# Search and resume interactively
claude --resume "$(claude-history-query list -g --field uuid | fzf)"

# Export to JSONL
claude-history-query list --since 1w --jsonl > backup.jsonl

# Find conversations about a topic
claude-history-query list -g --query "docker && kubernetes"

# Delete old conversations
claude-history-query list --before 2024-01-01 -f path | xargs rm
```

## Design Documents

* `docs/plans/2026-02-06-claude-history-query-design.md` - CLI design
* `docs/plans/2026-02-06-claude-history-query-implementation.md` - Implementation plan

## Test Plan

* [x] All 115 tests pass (23 new tests for query binary)
* [x] `list` command with JSONL output
* [x] Field selection (`--field uuid --field cwd`)
* [x] Resume workflow: `claude --resume "$(... --field uuid)"`
* [x] `show` command with UUID resolution
* [x] `usage` command outputs documentation
* [x] Exit codes: 0 on success, 2 on invalid args, 3 on no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)