### PR TITLE
Add `global` option to config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigFile {
+    pub global: Option<bool>,
     pub display: Option<DisplayConfig>,
     pub resume: Option<ResumeConfig>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,8 +139,10 @@ fn run() -> Result<()> {
         return Ok(());
     }
 
+    let use_global = resolve_bool_setting(args.global, false, config.global, false);
+
     // Determine how to load conversations based on mode
-    let (conversations, selected_path) = if args.global {
+    let (conversations, selected_path) = if use_global {
         // Global Search (-g) - use streaming loader for instant startup
         let rx = history::load_all_conversations_streaming(show_last, args.debug);
 


### PR DESCRIPTION
## Summary

- Adds a top-level `global` option in `config.toml`, so users who prefer global search can set it as a default without passing `-g` every time
- Placed at top level (not under `[display]`) since it controls search scope, not presentation
- Uses the existing `resolve_bool_setting` pattern for CLI/config merging

```toml
global = true
```

Closes #11