### PR TITLE
Add single message yank and message-level navigation

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -854,7 +854,8 @@ pub fn render_to_terminal(file_path: &Path, options: &DisplayOptions) -> Result<
         content_width,
     };
 
-    let rendered_lines = render_conversation(file_path, &render_options)?;
+    let render_result = render_conversation(file_path, &render_options)?;
+    let rendered_lines = render_result.lines;
 
     // Spawn pager if requested
     let mut pager_child = if options.use_pager {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,7 +6,7 @@ use crate::history::{
 };
 use crate::tui::search::{self, SearchableConversation};
 use crate::tui::ui;
-use crate::tui::viewer::ToolDisplayMode;
+use crate::tui::viewer::{MessageBoundary, ToolDisplayMode};
 use chrono::Local;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
@@ -84,6 +84,19 @@ pub struct ViewState {
     pub search_matches: Vec<usize>,
     /// Current match index
     pub current_match: usize,
+    /// Message boundaries mapping line ranges to messages
+    pub message_boundaries: Vec<MessageBoundary>,
+    /// Index of the currently focused message in message_boundaries
+    pub current_message: usize,
+}
+
+impl ViewState {
+    /// Find which message boundary contains the given line index
+    pub fn message_at_line(&self, line: usize) -> Option<usize> {
+        self.message_boundaries
+            .iter()
+            .position(|b| line >= b.start_line && line < b.end_line)
+    }
 }
 
 /// Search mode within view
@@ -257,6 +270,8 @@ impl App {
                 search_query: String::new(),
                 search_matches: Vec::new(),
                 current_match: 0,
+                message_boundaries: Vec::new(),
+                current_message: 0,
             }),
             status_message: None,
             tool_display,
@@ -737,7 +752,11 @@ impl App {
 
         // Delegate based on app mode
         match &self.app_mode {
-            AppMode::View(_) => self.handle_view_key(code, modifiers, viewport_height),
+            AppMode::View(_) => {
+                let result = self.handle_view_key(code, modifiers, viewport_height);
+                self.sync_current_message();
+                result
+            }
             AppMode::List => self.handle_list_key(code, modifiers, viewport_height),
         }
     }
@@ -967,6 +986,48 @@ impl App {
             // Open yank menu (copy to clipboard)
             KeyCode::Char('y') => {
                 self.dialog_mode = DialogMode::YankMenu { selected: 0 };
+                None
+            }
+
+            // Copy current message to clipboard
+            KeyCode::Char('c') if !modifiers.contains(KeyModifiers::CONTROL) => {
+                if let AppMode::View(ref state) = self.app_mode
+                    && let Some(boundary) = state.message_boundaries.get(state.current_message)
+                {
+                    let result = crate::tui::export::yank_single_message(
+                        &state.conversation_path,
+                        boundary.entry_index,
+                        crate::tui::export::ExportOptions {
+                            show_tools: state.tool_display.is_visible(),
+                            show_thinking: state.show_thinking,
+                        },
+                    );
+                    self.status_message = Some((result.message, std::time::Instant::now()));
+                }
+                None
+            }
+
+            // Jump to previous message
+            KeyCode::Char('K') => {
+                if let AppMode::View(ref mut state) = self.app_mode
+                    && state.current_message > 0
+                {
+                    state.current_message -= 1;
+                    state.scroll_offset =
+                        state.message_boundaries[state.current_message].start_line;
+                }
+                None
+            }
+
+            // Jump to next message
+            KeyCode::Char('J') => {
+                if let AppMode::View(ref mut state) = self.app_mode
+                    && state.current_message + 1 < state.message_boundaries.len()
+                {
+                    state.current_message += 1;
+                    state.scroll_offset =
+                        state.message_boundaries[state.current_message].start_line;
+                }
                 None
             }
 
@@ -1277,12 +1338,12 @@ impl App {
         };
 
         match render_conversation(&path, &options) {
-            Ok(rendered_lines) => {
-                let total_lines = rendered_lines.len();
+            Ok(result) => {
+                let total_lines = result.lines.len();
                 self.app_mode = AppMode::View(ViewState {
                     conversation_path: path,
                     scroll_offset: 0,
-                    rendered_lines,
+                    rendered_lines: result.lines,
                     total_lines,
                     tool_display: self.tool_display,
                     show_thinking: self.show_thinking,
@@ -1292,6 +1353,8 @@ impl App {
                     search_query: String::new(),
                     search_matches: Vec::new(),
                     current_match: 0,
+                    message_boundaries: result.message_boundaries,
+                    current_message: 0,
                 });
             }
             Err(e) => {
@@ -1417,10 +1480,11 @@ impl App {
                 content_width: state.content_width,
             };
 
-            if let Ok(lines) = render_conversation(&state.conversation_path, &options) {
+            if let Ok(result) = render_conversation(&state.conversation_path, &options) {
                 let old_scroll = state.scroll_offset;
-                state.total_lines = lines.len();
-                state.rendered_lines = lines;
+                state.total_lines = result.lines.len();
+                state.rendered_lines = result.lines;
+                state.message_boundaries = result.message_boundaries;
 
                 // Clamp scroll offset to new content bounds
                 let max_scroll = state.total_lines.saturating_sub(viewport_height);
@@ -1445,7 +1509,21 @@ impl App {
                             state.current_match.min(state.search_matches.len() - 1);
                     }
                 }
+
+                // Sync current message after re-render
+                if let Some(idx) = state.message_at_line(state.scroll_offset) {
+                    state.current_message = idx;
+                }
             }
+        }
+    }
+
+    /// Update current_message based on current scroll_offset
+    fn sync_current_message(&mut self) {
+        if let AppMode::View(ref mut state) = self.app_mode
+            && let Some(idx) = state.message_at_line(state.scroll_offset)
+        {
+            state.current_message = idx;
         }
     }
 

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -11,6 +11,7 @@
 
 use crate::claude::{self, ContentBlock, LogEntry, UserContent, UserMessage};
 use crate::tool_format;
+use arboard::Clipboard;
 use chrono::Local;
 use std::fs::{self, File};
 #[cfg(target_os = "linux")]
@@ -184,6 +185,113 @@ pub fn export_to_clipboard(
         },
         Err(e) => ExportResult { message: e },
     }
+}
+
+/// Copy a single message from a conversation to clipboard
+pub fn yank_single_message(
+    source_path: &Path,
+    entry_index: usize,
+    options: ExportOptions,
+) -> ExportResult {
+    let content = match generate_single_entry_plain(source_path, entry_index, options) {
+        Ok(c) if c.is_empty() => {
+            return ExportResult {
+                message: "No text content in this message".to_string(),
+            };
+        }
+        Ok(c) => c,
+        Err(e) => {
+            return ExportResult {
+                message: format!("Failed to read: {}", e),
+            };
+        }
+    };
+
+    match Clipboard::new() {
+        Ok(mut clipboard) => match clipboard.set_text(&content) {
+            Ok(_) => ExportResult {
+                message: "Message copied to clipboard".to_string(),
+            },
+            Err(e) => ExportResult {
+                message: format!("Clipboard error: {}", e),
+            },
+        },
+        Err(e) => ExportResult {
+            message: format!("Clipboard unavailable: {}", e),
+        },
+    }
+}
+
+/// Generate plain text for a single JSONL entry
+fn generate_single_entry_plain(
+    path: &Path,
+    entry_index: usize,
+    options: ExportOptions,
+) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut output = String::new();
+
+    for (i, line) in reader.lines().enumerate() {
+        let line = line?;
+        if i != entry_index {
+            continue;
+        }
+        if line.trim().is_empty() {
+            break;
+        }
+        if let Ok(entry) = serde_json::from_str::<LogEntry>(&line) {
+            match entry {
+                LogEntry::User { message, .. } => {
+                    if let Some(text) = extract_user_text(&message) {
+                        output.push_str(&text);
+                    }
+                    if options.show_tools
+                        && let UserContent::Blocks(blocks) = &message.content
+                    {
+                        for block in blocks {
+                            if let ContentBlock::ToolResult { content, .. } = block {
+                                let content_str = format_tool_result_for_export(content.as_ref());
+                                if !output.is_empty() {
+                                    output.push_str("\n\n");
+                                }
+                                output.push_str(&content_str);
+                            }
+                        }
+                    }
+                }
+                LogEntry::Assistant { message, .. } => {
+                    for block in &message.content {
+                        match block {
+                            ContentBlock::Text { text } => {
+                                if !output.is_empty() {
+                                    output.push_str("\n\n");
+                                }
+                                output.push_str(text);
+                            }
+                            ContentBlock::ToolUse { name, input, .. } if options.show_tools => {
+                                if !output.is_empty() {
+                                    output.push_str("\n\n");
+                                }
+                                output.push_str(&format_tool_call_for_export(name, input));
+                            }
+                            ContentBlock::Thinking { thinking, .. } if options.show_thinking => {
+                                if !output.is_empty() {
+                                    output.push_str("\n\n");
+                                }
+                                output.push_str(thinking);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        break;
+    }
+
+    Ok(output)
 }
 
 /// Generate content in the specified format

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -526,6 +526,12 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
     let visible_height = area.height as usize;
     let query_lower = state.search_query.to_lowercase();
 
+    // Determine the current message line range for the visual indicator
+    let current_msg_range = state
+        .message_boundaries
+        .get(state.current_message)
+        .map(|b| (b.start_line, b.end_line));
+
     let visible_lines: Vec<Line> = state
         .rendered_lines
         .iter()
@@ -536,7 +542,10 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
             let is_current_match = state.search_matches.get(state.current_match) == Some(&line_idx);
             let has_match = !query_lower.is_empty() && state.search_matches.contains(&line_idx);
 
-            let spans: Vec<Span> = if has_match && !query_lower.is_empty() {
+            let in_current_message =
+                current_msg_range.is_some_and(|(start, end)| line_idx >= start && line_idx < end);
+
+            let mut spans: Vec<Span> = if has_match && !query_lower.is_empty() {
                 highlight_line_matches(rendered, &query_lower, is_current_match)
             } else {
                 rendered
@@ -545,6 +554,16 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
                     .map(|(text, style)| styled_span(text, style))
                     .collect()
             };
+
+            // Prepend a subtle marker for the current message
+            if in_current_message {
+                spans.insert(
+                    0,
+                    Span::styled("▌", Style::default().fg(Color::Rgb(60, 160, 140))),
+                );
+            } else {
+                spans.insert(0, Span::raw(" "));
+            }
 
             Line::from(spans)
         })
@@ -957,7 +976,9 @@ fn render_help_overlay(
             ("T".into(), "Toggle thinking"),
             ("i".into(), "Toggle timing"),
             ("e".into(), "Export to file"),
+            ("c".into(), "Copy current message"),
             ("y".into(), "Copy to clipboard"),
+            ("J / K".into(), "Next / prev message"),
             ("p".into(), "Show file path"),
             ("Y".into(), "Copy path"),
             ("I".into(), "Copy session ID"),

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -63,6 +63,23 @@ impl ToolDisplayMode {
     }
 }
 
+/// Information about a rendered message's position in the line buffer
+#[derive(Clone, Debug)]
+pub struct MessageBoundary {
+    /// First line index of this message (inclusive)
+    pub start_line: usize,
+    /// Last line index of this message (exclusive)
+    pub end_line: usize,
+    /// The JSONL line index (0-based) this message came from
+    pub entry_index: usize,
+}
+
+/// Result of rendering a conversation
+pub struct RenderResult {
+    pub lines: Vec<RenderedLine>,
+    pub message_boundaries: Vec<MessageBoundary>,
+}
+
 /// Options for rendering a conversation
 pub struct RenderOptions {
     pub tool_display: ToolDisplayMode,
@@ -84,28 +101,63 @@ fn format_timestamp(iso_timestamp: &str) -> Option<String> {
 pub fn render_conversation(
     file_path: &Path,
     options: &RenderOptions,
-) -> std::io::Result<Vec<RenderedLine>> {
+) -> std::io::Result<RenderResult> {
     let file = File::open(file_path)?;
     let reader = BufReader::new(file);
     let mut lines = Vec::new();
+    let mut message_boundaries = Vec::new();
 
-    for line_result in reader.lines() {
+    for (entry_index, line_result) in reader.lines().enumerate() {
         let line = line_result?;
         if line.trim().is_empty() {
             continue;
         }
 
         if let Ok(entry) = serde_json::from_str::<LogEntry>(&line) {
+            let start = lines.len();
             render_entry(&mut lines, &entry, options);
+            let end = lines.len();
+            if start != end {
+                message_boundaries.push(MessageBoundary {
+                    start_line: start,
+                    end_line: end,
+                    entry_index,
+                });
+            }
         }
     }
 
     // Collapse consecutive empty lines into single empty lines.
     // Multiple render functions each add trailing empty lines, which can
     // result in double blanks when a tool result has empty output.
-    lines.dedup_by(|a, b| a.spans.is_empty() && b.spans.is_empty());
+    let mut removed = 0;
+    let mut prev_empty = false;
+    let mut i = 0;
+    while i < lines.len() {
+        let is_empty = lines[i].spans.is_empty();
+        if is_empty && prev_empty {
+            lines.remove(i);
+            // Adjust boundaries: shift end_line for boundaries that include this line,
+            // and shift start_line/end_line for boundaries after this line
+            for boundary in message_boundaries.iter_mut() {
+                if boundary.start_line > i + removed {
+                    boundary.start_line -= 1;
+                }
+                if boundary.end_line > i + removed {
+                    boundary.end_line -= 1;
+                }
+            }
+            removed += 1;
+        } else {
+            prev_empty = is_empty;
+            i += 1;
+        }
+    }
 
-    Ok(lines)
+    Ok(RenderResult {
+        lines,
+        message_boundaries,
+    })
 }
 
 fn render_entry(lines: &mut Vec<RenderedLine>, entry: &LogEntry, options: &RenderOptions) {


### PR DESCRIPTION
## Summary

- Add ability to copy a **single message** to clipboard (`c` key) instead of the entire conversation
- Add **message-level navigation** with `J`/`K` (next/prev message) — vim-style where lowercase = line scroll, uppercase = message jump
- Add **visual indicator** (teal `▌` marker) showing which message is currently focused
- Track message boundaries during rendering for precise message targeting

## Motivation

The existing yank (`y`) copies the entire conversation which includes too many messages and metadata. Users often want to copy just one specific message (e.g., a Claude response with a code snippet).

## Changes

| File | Change |
|------|--------|
| `viewer.rs` | `MessageBoundary` struct, `RenderResult`, boundary tracking with dedup-aware index adjustment |
| `app.rs` | `current_message` in ViewState, `J`/`K` navigation, `c` keybinding, `sync_current_message()` |
| `export.rs` | `yank_single_message()` for single entry plain text clipboard copy |
| `ui.rs` | Current message visual indicator, updated help overlay |
| `display.rs` | Adapt to `RenderResult` return type |

## New keybindings (view mode)

| Key | Action |
|-----|--------|
| `c` | Copy current message to clipboard |
| `J` | Jump to next message |
| `K` | Jump to previous message |

`J`/`K` chosen over `[`/`]` for international keyboard compatibility (Nordic layouts require AltGr for brackets).

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — 146 passed (1 pre-existing failure unrelated)
- [x] `cargo clippy` — zero warnings
- [x] Manual testing: navigation, copy, visual indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)