### PR TITLE
Fix Windows compilation and home directory resolution

### DIFF
--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -6,10 +6,9 @@ use std::path::PathBuf;
 
 /// Get the debug log file path (~/.local/state/claude-history/debug.log)
 fn get_debug_log_path() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
+    let home = home::home_dir()?;
     Some(
-        PathBuf::from(home)
-            .join(".local")
+        home.join(".local")
             .join("state")
             .join("claude-history")
             .join("debug.log"),

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -88,13 +88,13 @@ pub fn get_claude_projects_root() -> Result<PathBuf> {
     let claude_dir = if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         PathBuf::from(config_dir)
     } else {
-        let home_dir = std::env::var("HOME").map_err(|_| {
+        let home_dir = home::home_dir().ok_or_else(|| {
             AppError::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                "HOME environment variable not set",
+                "Could not determine home directory",
             ))
         })?;
-        PathBuf::from(home_dir).join(".claude")
+        home_dir.join(".claude")
     };
 
     Ok(claude_dir.join("projects"))

--- a/src/update.rs
+++ b/src/update.rs
@@ -148,8 +148,6 @@ fn verify_checksum(file: &Path, expected_line: &str) -> Result<()> {
 
 /// Replace the current binary with the new one, with rollback on failure.
 fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     let exe_dir = current_exe
         .parent()
         .ok_or_else(|| AppError::UpdateError("Could not determine binary directory".to_string()))?;
@@ -158,8 +156,13 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
     let staged = exe_dir.join(format!(".{BIN_NAME}.new"));
     std::fs::copy(new_binary, &staged)
         .map_err(|e| AppError::UpdateError(format!("Failed to copy new binary: {e}")))?;
-    std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
-        .map_err(|e| AppError::UpdateError(format!("Failed to set permissions: {e}")))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| AppError::UpdateError(format!("Failed to set permissions: {e}")))?;
+    }
 
     // Rename current -> .old, then staged -> current
     let backup = exe_dir.join(format!(".{BIN_NAME}.old"));


### PR DESCRIPTION
- Wrap Unix-only PermissionsExt in #[cfg(unix)] in update.rs
- Replace std::env::var("HOME") with home::home_dir() in history/mod.rs and debug_log.rs so the tool works on Windows