### PR TITLE
feat: resume-here, observer filtering, unlimited search index

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,10 @@ pub struct Args {
     #[arg(long, help = "Fork the session when resuming", requires = "resume")]
     pub fork_session: bool,
 
+    /// Resume in the current directory instead of the original project directory
+    #[arg(long, help = "Resume in the current working directory (keep workspace here)")]
+    pub here: bool,
+
     /// Print the selected conversation's file path and exit
     #[arg(long, short = 'p', help = "Print the selected conversation file path")]
     pub show_path: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct ResumeConfig {
 pub struct KeysConfig {
     pub resume: Option<KeyBinding>,
     pub fork: Option<KeyBinding>,
+    pub resume_here: Option<KeyBinding>,
     pub delete: Option<KeyBinding>,
 }
 
@@ -133,6 +134,7 @@ fn parse_key_binding(s: &str) -> std::result::Result<KeyBinding, String> {
 pub struct KeyBindings {
     pub resume: KeyBinding,
     pub fork: KeyBinding,
+    pub resume_here: KeyBinding,
     pub delete: KeyBinding,
 }
 
@@ -145,6 +147,10 @@ impl Default for KeyBindings {
             },
             fork: KeyBinding {
                 code: KeyCode::Char('f'),
+                modifiers: KeyModifiers::CONTROL,
+            },
+            resume_here: KeyBinding {
+                code: KeyCode::Char('h'),
                 modifiers: KeyModifiers::CONTROL,
             },
             delete: KeyBinding {
@@ -163,6 +169,7 @@ impl KeyBindings {
             Some(cfg) => Self {
                 resume: cfg.resume.unwrap_or(defaults.resume),
                 fork: cfg.fork.unwrap_or(defaults.fork),
+                resume_here: cfg.resume_here.unwrap_or(defaults.resume_here),
                 delete: cfg.delete.unwrap_or(defaults.delete),
             },
         }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -243,6 +243,14 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
                 return None;
             }
 
+            let name = path.file_name()?.to_string_lossy().to_string();
+
+            // Skip claude-mem observer session directories — these contain
+            // automated observation logs, not real user conversations.
+            if name.contains("claude-mem-observer-sessions") {
+                return None;
+            }
+
             // Check if project has any non-agent .jsonl files
             let has_conversations = read_dir(&path).ok()?.any(|e| {
                 e.ok()
@@ -259,7 +267,6 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
                 return None;
             }
 
-            let name = path.file_name()?.to_string_lossy().to_string();
             // Heuristic decode: convert encoded directory name back to readable path
             // The encoding replaces non-alphanumeric chars (except -) with -
             // So / becomes -, but _ also becomes -, and __ becomes --

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -97,6 +97,12 @@ pub(crate) fn process_conversation_reader<R: BufRead>(
                         if extracted_cwd.is_none()
                             && let Some(cwd_str) = cwd
                         {
+                            // Skip claude-mem observer sessions — they contain
+                            // automated observation logs, not real conversations.
+                            if cwd_str.contains("claude-mem") {
+                                return Ok(None);
+                            }
+
                             extracted_cwd = Some(PathBuf::from(cwd_str));
                         }
 

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -16,10 +16,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-/// Maximum characters for full_text search index per conversation.
-/// Set high enough to cover most conversations while preventing extreme outliers
-/// from causing excessive memory usage (~2MB per conversation is reasonable).
-const MAX_FULL_TEXT_CHARS: usize = 2 * 1024 * 1024;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -307,9 +303,6 @@ pub(crate) fn process_conversation_reader<R: BufRead>(
     let preview = normalize_whitespace(&preview);
     let full_text = normalize_whitespace(&full_text);
 
-    // Cap full_text to prevent search/highlighting lag from large tool outputs
-    let full_text = truncate_to_char_boundary(&full_text, MAX_FULL_TEXT_CHARS);
-
     // Sum token usage from deduplicated messages (all token types)
     let total_tokens: u64 = token_usage_by_msg
         .values()
@@ -448,18 +441,6 @@ pub(crate) fn is_clear_only_conversation(user_messages: &[String]) -> bool {
 /// Normalize whitespace in a string
 pub(crate) fn normalize_whitespace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<&str>>().join(" ")
-}
-
-/// Truncate a string to at most `max` bytes, on a char boundary
-fn truncate_to_char_boundary(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        return s.to_owned();
-    }
-    let mut end = max;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    s[..end].to_owned()
 }
 
 #[cfg(test)]

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -17,8 +17,9 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 /// Maximum characters for full_text search index per conversation.
-/// Prevents search/highlighting lag from conversations with large tool outputs.
-const MAX_FULL_TEXT_CHARS: usize = 256 * 1024;
+/// Set high enough to cover most conversations while preventing extreme outliers
+/// from causing excessive memory usage (~2MB per conversation is reasonable).
+const MAX_FULL_TEXT_CHARS: usize = 2 * 1024 * 1024;
 use std::path::PathBuf;
 use std::time::SystemTime;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,13 +207,19 @@ fn run() -> Result<()> {
         (tui::Action::Resume(path), convs) => {
             let conv = convs.iter().find(|c| c.path == path);
             let project_path = conv.and_then(|c| c.project_path.as_ref());
-            resume_with_claude(&path, project_path, default_args, false)?;
+            resume_with_claude(&path, project_path, default_args, false, false)?;
             return Ok(());
         }
         (tui::Action::ForkResume(path), convs) => {
             let conv = convs.iter().find(|c| c.path == path);
             let project_path = conv.and_then(|c| c.project_path.as_ref());
-            resume_with_claude(&path, project_path, default_args, true)?;
+            resume_with_claude(&path, project_path, default_args, true, false)?;
+            return Ok(());
+        }
+        (tui::Action::ResumeHere(path), convs) => {
+            let conv = convs.iter().find(|c| c.path == path);
+            let project_path = conv.and_then(|c| c.project_path.as_ref());
+            resume_with_claude(&path, project_path, default_args, false, true)?;
             return Ok(());
         }
         (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
@@ -261,6 +267,7 @@ fn run() -> Result<()> {
             project_path,
             default_args,
             args.fork_session,
+            args.here,
         )?;
         return Ok(());
     }
@@ -308,6 +315,7 @@ fn resume_with_claude(
     project_path: Option<&PathBuf>,
     default_args: &[String],
     fork_session: bool,
+    resume_here: bool,
 ) -> Result<()> {
     let conversation_id = selected_path
         .file_stem()
@@ -332,10 +340,13 @@ fn resume_with_claude(
         )
     })?;
 
-    // When the original project directory is gone (e.g. deleted worktree) or when
-    // forking cross-project, copy session files to CWD's project directory and
-    // resume from there.
-    let needs_copy = if project_dir.is_none() {
+    // When the original project directory is gone (e.g. deleted worktree), when
+    // forking cross-project, or when resume_here is requested from a different project,
+    // copy session files to CWD's project directory and resume from there.
+    let needs_copy = if resume_here {
+        let cwd_projects_dir = history::get_claude_projects_dir(&cwd)?;
+        cwd_projects_dir != conv_projects_dir
+    } else if project_dir.is_none() {
         true
     } else if fork_session {
         let cwd_projects_dir = history::get_claude_projects_dir(&cwd)?;
@@ -354,6 +365,20 @@ fn resume_with_claude(
             &cwd_projects_dir,
         )?;
 
+        let mut command = Command::new("claude");
+        command.args(["--resume", &conversation_id]);
+        // Cross-project resume requires --fork-session: the original .jsonl
+        // contains cwd entries pointing to the source project, so Claude Code
+        // cannot continue the same session in a different project context.
+        // Forking creates a clean new session inheriting the conversation history.
+        command.arg("--fork-session");
+        command.args(default_args);
+        command.current_dir(&cwd);
+        return run_claude_command(command);
+    }
+
+    // resume_here but same project dir: no copy needed, just use CWD
+    if resume_here {
         let mut command = Command::new("claude");
         command.args(["--resume", &conversation_id]);
         command.args(default_args);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -23,6 +23,7 @@ pub enum Action {
     Delete(PathBuf),
     Resume(PathBuf),
     ForkResume(PathBuf),
+    ResumeHere(PathBuf),
     Quit,
 }
 
@@ -1157,6 +1158,13 @@ impl App {
                 self.get_selected_path().map(Action::ForkResume)
             };
         }
+        if self.keys.resume_here.matches(code, modifiers) {
+            return if self.single_file_mode {
+                None
+            } else {
+                self.get_selected_path().map(Action::ResumeHere)
+            };
+        }
 
         let state = match &mut self.app_mode {
             AppMode::View(s) => s,
@@ -1648,6 +1656,9 @@ impl App {
         }
         if self.keys.fork.matches(code, modifiers) {
             return self.get_selected_path().map(Action::ForkResume);
+        }
+        if self.keys.resume_here.matches(code, modifiers) {
+            return self.get_selected_path().map(Action::ResumeHere);
         }
 
         // Normal handling when ready

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -195,6 +195,8 @@ fn render_list_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(" resume  ", action_label),
         Span::styled(keys.fork.short_label(), action_key),
         Span::styled(" fork  ", action_label),
+        Span::styled(keys.resume_here.short_label(), action_key),
+        Span::styled(" here  ", action_label),
         Span::styled(keys.delete.short_label(), action_key),
         Span::styled(" delete  ", action_label),
     ];
@@ -673,6 +675,8 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
             Span::styled(" resume  ", label_style),
             Span::styled(app.keys().fork.short_label(), key_style),
             Span::styled(" fork  ", label_style),
+            Span::styled(app.keys().resume_here.short_label(), key_style),
+            Span::styled(" here  ", label_style),
             Span::styled(app.keys().delete.short_label(), key_style),
             Span::styled(" del  ", label_style),
             Span::styled("q", key_style),
@@ -1051,6 +1055,7 @@ fn render_help_overlay(
             ("I".into(), "Copy session ID"),
             (keys.resume.help_label(), "Resume"),
             (keys.fork.help_label(), "Fork resume"),
+            (keys.resume_here.help_label(), "Resume here (CWD)"),
             (keys.delete.help_label(), "Delete"),
             ("q / Esc".into(), exit_text),
         ]
@@ -1070,6 +1075,7 @@ fn render_help_overlay(
             ("Ctrl+W".into(), "Delete word"),
             (keys.resume.help_label(), "Resume"),
             (keys.fork.help_label(), "Fork resume"),
+            (keys.resume_here.help_label(), "Resume here (CWD)"),
             (keys.delete.help_label(), "Delete"),
             ("Esc".into(), "Quit"),
         ]


### PR DESCRIPTION
## Summary

- **Resume Here (`--here` / Ctrl+H)**: Resume any session in the current working directory instead of the original project directory. Cross-project resume automatically uses `--fork-session` and copies session files to CWD's project dir.
- **Observer session filtering**: Two-layer filtering hides claude-mem observer sessions — project directories containing `claude-mem-observer-sessions` are skipped, and individual conversations with `cwd` pointing to `claude-mem` paths are excluded.
- **Unlimited search index**: Removed the `MAX_FULL_TEXT_CHARS` truncation entirely so long conversations (8MB+) are fully searchable.

## Motivation

When working across multiple git worktrees or project directories, resuming a session from another project previously required navigating to the original directory. The `--here` flag and Ctrl+H keybinding allow resuming any session while keeping the workspace in the current directory — session files are copied to CWD's project dir and `--fork-session` is applied automatically to avoid cwd mismatch issues.

Claude-mem observer sessions (automated memory agent logs) were polluting the conversation list and search results. Two-layer filtering removes them at both the project directory level and individual conversation level.

The search index truncation (originally 256KB) caused keywords in long conversations to be invisible to search. Removing the limit ensures full-text coverage for all conversations regardless of size.

## Changes

| File | What |
|------|------|
| `src/cli.rs` | Add `--here` CLI flag |
| `src/config.rs` | Add `resume_here` keybinding (default: Ctrl+H) |
| `src/main.rs` | `ResumeHere` action handling, cross-project copy + fork logic |
| `src/tui/app.rs` | `ResumeHere` action variant, Ctrl+H key handler in list and view modes |
| `src/tui/ui.rs` | Status bar and help overlay entries for "here" shortcut |
| `src/history/loader.rs` | Skip `claude-mem-observer-sessions` project dirs in `list_projects()` |
| `src/history/parser.rs` | Filter conversations with claude-mem cwd; remove `MAX_FULL_TEXT_CHARS` truncation and `truncate_to_char_boundary` |

## How it works

### Resume Here
1. User selects a conversation from any project and presses Ctrl+H (or uses `--here --resume`)
2. If CWD's project dir differs from the conversation's project dir:
   - Session `.jsonl` and subdirectory are copied to CWD's project dir
   - `claude --resume <id> --fork-session` is invoked with `current_dir` set to CWD
3. If same project dir: just resumes with CWD (no copy needed)

### Observer filtering
1. **Project level**: `list_projects()` skips directories containing `claude-mem-observer-sessions`
2. **Conversation level**: `process_conversation_reader()` returns `Ok(None)` if the first `cwd` field contains `claude-mem`

## Test plan

- [ ] `claude-history --here --resume` resumes in CWD for cross-project sessions
- [ ] Ctrl+H in TUI triggers resume-here for selected conversation
- [ ] Observer sessions no longer appear in TUI list or search results
- [ ] Long conversations (8MB+) are fully searchable with no keyword misses
- [ ] Normal resume (Ctrl+R) and fork resume (Ctrl+F) still work unchanged
- [ ] Same-project Ctrl+H resumes without copying files