### PR TITLE
add CCS (Claude Code Switch) integration for multi-profile support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serde_yaml",
  "syntect",
  "tempfile",
  "terminal-light",
@@ -2775,6 +2776,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,6 +3470,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ release-dynamic-ort = ["dep:ort", "fastembed/ort-load-dynamic"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 bincode = "1.3"
 blake3 = "1.8"
 colored = "3.0"

--- a/src/agent/search.rs
+++ b/src/agent/search.rs
@@ -1201,6 +1201,7 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -1,5 +1,6 @@
 use crate::agent;
 use crate::agent::diagnostic::{AgentError, AgentErrorKind, AgentWarning, AgentWarningKind};
+use crate::ccs;
 use crate::cli::{self, AgentCommand, AgentOutlineArgs, AgentReadArgs};
 use crate::config;
 use crate::config::{AgentConfig, AgentScopeConfig};
@@ -158,7 +159,8 @@ impl AgentService {
         // Resolved before loading so an inverted range fails without paying for
         // a full corpus parse.
         let time = args.time.resolve()?;
-        let mut conversations = history::load_all_conversations(false, None)?;
+        let mut conversations =
+            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
         conversations.retain(|conversation| {
             !project_is_excluded(&conversation.path, &agent_config.exclude_projects)
                 && time.matches(conversation.timestamp)
@@ -598,6 +600,7 @@ fn conversation_from_agent_transcript(
         model: None,
         total_tokens: 0,
         duration_minutes: None,
+        source_label: None,
     }
 }
 
@@ -1111,7 +1114,8 @@ pub(crate) fn resolve_agent_read_args(
     let keys = if let Some(keys) = keys {
         keys
     } else {
-        let conversations = history::load_all_conversations(false, None)?;
+        let conversations =
+            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
         loaded_keys = agent::refs::conversation_keys_from_conversations(&conversations)?;
         &loaded_keys
     };
@@ -1185,7 +1189,8 @@ pub(crate) fn resolve_agent_conversation_arg(
     let keys = if let Some(keys) = keys {
         keys
     } else {
-        let conversations = history::load_all_conversations(false, None)?;
+        let conversations =
+            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
         loaded_keys = agent::refs::conversation_keys_from_conversations(&conversations)?;
         &loaded_keys
     };

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -78,6 +78,15 @@ fn configured_scope(
     }
 }
 
+/// Session-head markers used to exclude machine-generated sessions (e.g. ICM
+/// persistent-memory background jobs) from loading. Agent subcommands load
+/// history outside the main `run()` flow, so they resolve the markers here.
+fn default_exclude_markers() -> Vec<String> {
+    config::load_config()
+        .map(|config| config.exclude_markers())
+        .unwrap_or_default()
+}
+
 fn project_is_excluded(path: &Path, excluded: &[String]) -> bool {
     path.parent()
         .and_then(Path::file_name)
@@ -159,8 +168,12 @@ impl AgentService {
         // Resolved before loading so an inverted range fails without paying for
         // a full corpus parse.
         let time = args.time.resolve()?;
-        let mut conversations =
-            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
+        let mut conversations = history::load_all_conversations(
+            false,
+            None,
+            ccs::discover_ccs().as_ref(),
+            &default_exclude_markers(),
+        )?;
         conversations.retain(|conversation| {
             !project_is_excluded(&conversation.path, &agent_config.exclude_projects)
                 && time.matches(conversation.timestamp)
@@ -1114,8 +1127,12 @@ pub(crate) fn resolve_agent_read_args(
     let keys = if let Some(keys) = keys {
         keys
     } else {
-        let conversations =
-            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
+        let conversations = history::load_all_conversations(
+            false,
+            None,
+            ccs::discover_ccs().as_ref(),
+            &default_exclude_markers(),
+        )?;
         loaded_keys = agent::refs::conversation_keys_from_conversations(&conversations)?;
         &loaded_keys
     };
@@ -1189,8 +1206,12 @@ pub(crate) fn resolve_agent_conversation_arg(
     let keys = if let Some(keys) = keys {
         keys
     } else {
-        let conversations =
-            history::load_all_conversations(false, None, ccs::discover_ccs().as_ref())?;
+        let conversations = history::load_all_conversations(
+            false,
+            None,
+            ccs::discover_ccs().as_ref(),
+            &default_exclude_markers(),
+        )?;
         loaded_keys = agent::refs::conversation_keys_from_conversations(&conversations)?;
         &loaded_keys
     };

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -216,6 +216,11 @@ impl AgentService {
         let (mut keys, mut base_warnings) =
             discover_agent_keys(current_project_dir_name.as_deref())?;
         keys.retain(|key| !project_is_excluded(&key.path, &agent_config.exclude_projects));
+        // Key discovery walks the projects directory itself, so sessions the
+        // loader excluded by head marker are absent from `conversations` and
+        // would otherwise be reported — and re-parsed — as skipped transcripts.
+        let excluded_sessions = history::excluded_session_paths(ccs::discover_ccs().as_ref());
+        keys.retain(|key| !excluded_sessions.contains(&key.path));
         if time.is_active() {
             // Key discovery walks the projects directory independently, so
             // without this every conversation outside the window would be

--- a/src/ccs.rs
+++ b/src/ccs.rs
@@ -93,7 +93,15 @@ pub struct ProjectRoot {
 }
 
 /// Attempt to discover CCS configuration. Returns None if CCS is not installed.
+///
+/// An explicit `CLAUDE_CONFIG_DIR` pins one Claude config dir (that is how CCS
+/// itself activates a profile), so multi-root aggregation is skipped and only
+/// that root is loaded.
 pub fn discover_ccs() -> Option<CcsInfo> {
+    if std::env::var_os("CLAUDE_CONFIG_DIR").is_some() {
+        return None;
+    }
+
     let home = home::home_dir()?;
     let config_path = home.join(".ccs").join("config.yaml");
     if !config_path.exists() {

--- a/src/ccs.rs
+++ b/src/ccs.rs
@@ -1,0 +1,207 @@
+//! CCS (Claude Code Switch) integration.
+//!
+//! Discovers CCS configuration and enumerates instance project roots
+//! for unified conversation loading across all CCS profiles.
+
+use crate::error::{AppError, Result};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+
+/// Minimal representation of ~/.ccs/config.yaml (only fields we need)
+#[derive(Deserialize)]
+struct CcsConfigFile {
+    default: Option<String>,
+    #[serde(default)]
+    accounts: HashMap<String, CcsAccount>,
+}
+
+#[derive(Deserialize)]
+struct CcsAccount {
+    #[allow(dead_code)]
+    context_mode: Option<String>,
+    #[allow(dead_code)]
+    context_group: Option<String>,
+}
+
+/// A resolved CCS profile with its config dir and projects root
+#[derive(Clone, Debug)]
+pub struct CcsProfile {
+    pub name: String,
+    /// Instance config directory, e.g. ~/.ccs/instances/team
+    pub config_dir: PathBuf,
+    /// Canonical (symlink-resolved) projects root
+    pub canonical_root: PathBuf,
+}
+
+/// CCS discovery result
+#[derive(Clone, Debug)]
+pub struct CcsInfo {
+    pub default_profile: Option<String>,
+    pub profiles: Vec<CcsProfile>,
+}
+
+impl CcsInfo {
+    /// Get the config_dir for a profile by name
+    pub fn profile_config_dir(&self, name: &str) -> Option<&PathBuf> {
+        self.profiles
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| &p.config_dir)
+    }
+
+    /// Build a mapping from session UUID to CCS profile name(s).
+    ///
+    /// Scans each instance's `session-env/` directory for UUID-named subdirectories,
+    /// which correspond to sessions that were run under that profile.
+    /// A session used across multiple profiles will have all profile names joined.
+    pub fn build_session_profile_map(&self) -> HashMap<String, String> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for profile in &self.profiles {
+            let session_env_dir = profile.config_dir.join("session-env");
+            let Ok(entries) = std::fs::read_dir(&session_env_dir) else {
+                continue;
+            };
+            for entry in entries {
+                let Ok(entry) = entry else { continue };
+                if !entry.path().is_dir() {
+                    continue;
+                }
+                if let Some(name) = entry.file_name().to_str()
+                    && name.contains('-')
+                    && name.len() > 30
+                {
+                    map.entry(name.to_string())
+                        .or_default()
+                        .push(profile.name.clone());
+                }
+            }
+        }
+        map.into_iter()
+            .map(|(uuid, profiles)| (uuid, profiles.join(",")))
+            .collect()
+    }
+}
+
+/// A unique project root to scan for conversations
+#[derive(Clone, Debug)]
+pub struct ProjectRoot {
+    /// Canonical filesystem path
+    pub path: PathBuf,
+    /// Key for cache namespacing
+    pub cache_key: String,
+}
+
+/// Attempt to discover CCS configuration. Returns None if CCS is not installed.
+pub fn discover_ccs() -> Option<CcsInfo> {
+    let home = home::home_dir()?;
+    let config_path = home.join(".ccs").join("config.yaml");
+    if !config_path.exists() {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config: CcsConfigFile = serde_yaml::from_str(&content).ok()?;
+
+    let instances_dir = home.join(".ccs").join("instances");
+    let mut profiles = Vec::new();
+
+    for name in config.accounts.keys() {
+        let instance_dir = instances_dir.join(name);
+        let projects_dir = instance_dir.join("projects");
+
+        if !projects_dir.exists() {
+            continue;
+        }
+
+        let canonical_root = std::fs::canonicalize(&projects_dir).unwrap_or(projects_dir);
+
+        profiles.push(CcsProfile {
+            name: name.clone(),
+            config_dir: instance_dir,
+            canonical_root,
+        });
+    }
+
+    // Sort profiles so the default one comes first
+    if let Some(ref default_name) = config.default {
+        profiles.sort_by(|a, b| {
+            let a_is_default = &a.name == default_name;
+            let b_is_default = &b.name == default_name;
+            b_is_default.cmp(&a_is_default)
+        });
+    }
+
+    if profiles.is_empty() {
+        return None;
+    }
+
+    Some(CcsInfo {
+        default_profile: config.default,
+        profiles,
+    })
+}
+
+/// Get all unique project roots to scan for conversations.
+///
+/// With CCS: returns deduplicated roots from all CCS instances.
+/// Without CCS: returns the single default root.
+pub fn get_all_project_roots(ccs_info: Option<&CcsInfo>) -> Result<Vec<ProjectRoot>> {
+    if let Some(info) = ccs_info {
+        let mut seen = HashSet::new();
+        let mut roots = Vec::new();
+
+        for profile in &info.profiles {
+            if seen.insert(profile.canonical_root.clone()) {
+                let cache_key = make_cache_key(&profile.canonical_root);
+                roots.push(ProjectRoot {
+                    path: profile.canonical_root.clone(),
+                    cache_key,
+                });
+            }
+        }
+
+        // Also include the default ~/.claude/projects if it exists and isn't already covered
+        if let Some(default_root) = default_projects_root()
+            && default_root.exists()
+        {
+            let canonical = std::fs::canonicalize(&default_root).unwrap_or(default_root.clone());
+            if seen.insert(canonical.clone()) {
+                roots.push(ProjectRoot {
+                    path: canonical,
+                    cache_key: "default".to_string(),
+                });
+            }
+        }
+
+        if roots.is_empty() {
+            return Err(AppError::ProjectsDirNotFound(
+                "No CCS project roots found".to_string(),
+            ));
+        }
+
+        Ok(roots)
+    } else {
+        // No CCS — fall back to default root
+        let root = crate::history::get_claude_projects_root()?;
+        Ok(vec![ProjectRoot {
+            path: root,
+            cache_key: "default".to_string(),
+        }])
+    }
+}
+
+/// Get the default ~/.claude/projects path (ignoring CLAUDE_CONFIG_DIR)
+fn default_projects_root() -> Option<PathBuf> {
+    home::home_dir().map(|h| h.join(".claude").join("projects"))
+}
+
+/// Generate a cache key from a canonical root path
+fn make_cache_key(path: &std::path::Path) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    path.to_string_lossy().hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -474,6 +474,14 @@ pub struct Args {
     #[arg(long = "clear-semantic-cache", hide = true)]
     pub clear_semantic_cache: bool,
 
+    /// CCS profile name to use when resuming a conversation
+    #[arg(
+        long,
+        value_name = "NAME",
+        help = "CCS profile to use when resuming a conversation"
+    )]
+    pub profile: Option<String>,
+
     /// Input JSONL file to view directly (skips conversation selection)
     #[arg(
         value_name = "FILE",

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,26 @@ pub struct ConfigFile {
     pub tui: Option<TuiConfig>,
     pub search: Option<SearchConfig>,
     pub agent: Option<AgentConfig>,
+    pub filter: Option<FilterConfig>,
+}
+
+impl ConfigFile {
+    /// Effective list of first-line substrings used to exclude machine-generated
+    /// sessions from loading. ICM (persistent-memory) background sessions are
+    /// excluded by default; set `[filter] exclude_icm = false` to keep them, and
+    /// add extra substrings via `[filter] exclude_markers = [...]`.
+    pub fn exclude_markers(&self) -> Vec<String> {
+        let filter = self.filter.as_ref();
+        let exclude_icm = filter.and_then(|f| f.exclude_icm).unwrap_or(true);
+        let mut markers = Vec::new();
+        if exclude_icm {
+            markers.push(crate::history::ICM_SESSION_MARKER.to_string());
+        }
+        if let Some(extra) = filter.and_then(|f| f.exclude_markers.as_ref()) {
+            markers.extend(extra.iter().cloned());
+        }
+        markers
+    }
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -216,6 +236,15 @@ subagents = true
 
         assert!(keys.rename.matches(KeyCode::Char('r'), KeyModifiers::ALT));
     }
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FilterConfig {
+    /// Exclude ICM persistent-memory background sessions from loading. Default: true.
+    pub exclude_icm: Option<bool>,
+    /// Additional first-line substrings; sessions whose head contains any are excluded.
+    pub exclude_markers: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -34,6 +34,11 @@ pub struct CacheEntry {
     /// Avoids re-parsing known-empty files on every startup.
     #[serde(default)]
     pub is_empty: bool,
+    /// If true, this file was classified as a machine-generated session to exclude
+    /// (e.g. ICM memory jobs). Negative-caches the head-marker check so the file's
+    /// head is not re-read on every startup.
+    #[serde(default)]
+    pub excluded: bool,
     pub preview_first: String,
     pub preview_last: String,
     pub full_text: String,
@@ -182,6 +187,7 @@ pub fn empty_entry(file_size: u64, mtime: SystemTime) -> CacheEntry {
         mtime_secs: duration_since_epoch.as_secs(),
         mtime_nsecs: duration_since_epoch.subsec_nanos(),
         is_empty: true,
+        excluded: false,
         preview_first: String::new(),
         preview_last: String::new(),
         full_text: String::new(),
@@ -201,6 +207,15 @@ pub fn empty_entry(file_size: u64, mtime: SystemTime) -> CacheEntry {
     }
 }
 
+/// Build a negative-cache entry for a file excluded by head-marker classification
+/// (e.g. an ICM memory session). Stores only metadata so the head is not re-read.
+pub fn excluded_entry(file_size: u64, mtime: SystemTime) -> CacheEntry {
+    CacheEntry {
+        excluded: true,
+        ..empty_entry(file_size, mtime)
+    }
+}
+
 /// Create a CacheEntry from a parsed Conversation
 pub fn entry_from_conversation(
     conv: &Conversation,
@@ -213,6 +228,7 @@ pub fn entry_from_conversation(
         mtime_secs: duration_since_epoch.as_secs(),
         mtime_nsecs: duration_since_epoch.subsec_nanos(),
         is_empty: false,
+        excluded: false,
         preview_first: conv.preview_first.clone(),
         preview_last: conv.preview_last.clone(),
         full_text: conv.full_text.clone(),

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -65,10 +65,17 @@ pub struct CachedParseError {
 }
 
 /// Get the cache directory for per-project cache files.
-/// Respects CLAUDE_CONFIG_DIR to namespace caches per config root.
-fn cache_dir() -> Option<PathBuf> {
+/// When a cache_key is provided, uses it for namespacing.
+/// Falls back to CLAUDE_CONFIG_DIR-based namespacing, then default.
+fn cache_dir_with_key(cache_key: Option<&str>) -> Option<PathBuf> {
     let base = home::home_dir()?.join(".cache").join("claude-history");
-    if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+    if let Some(key) = cache_key {
+        if key == "default" {
+            Some(base.join("projects"))
+        } else {
+            Some(base.join(format!("roots-{}", key)).join("projects"))
+        }
+    } else if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         // Namespace by config dir to avoid cross-config cache collisions
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         std::hash::Hash::hash(&config_dir, &mut hasher);
@@ -79,15 +86,38 @@ fn cache_dir() -> Option<PathBuf> {
     }
 }
 
+/// Get the cache directory (legacy, no explicit cache_key)
+fn cache_dir() -> Option<PathBuf> {
+    cache_dir_with_key(None)
+}
+
 /// Get the cache file path for a specific project
 fn cache_path_for_project(project_dir_name: &str) -> Option<PathBuf> {
     cache_dir().map(|d| d.join(format!("{}.bin", project_dir_name)))
 }
 
+/// Get the cache file path for a specific project under a given cache_key
+fn cache_path_for_project_keyed(project_dir_name: &str, cache_key: &str) -> Option<PathBuf> {
+    cache_dir_with_key(Some(cache_key)).map(|d| d.join(format!("{}.bin", project_dir_name)))
+}
+
 /// Read a project's cache file, returning entries keyed by session filename.
 /// Returns None on any failure (missing, corrupt, version mismatch).
+#[allow(dead_code)]
 pub fn read_project_cache(project_dir_name: &str) -> Option<HashMap<String, CacheEntry>> {
-    let path = cache_path_for_project(project_dir_name)?;
+    read_project_cache_keyed(project_dir_name, None)
+}
+
+/// Read a project's cache file with explicit cache_key for namespacing.
+pub fn read_project_cache_keyed(
+    project_dir_name: &str,
+    cache_key: Option<&str>,
+) -> Option<HashMap<String, CacheEntry>> {
+    let path = if let Some(key) = cache_key {
+        cache_path_for_project_keyed(project_dir_name, key)?
+    } else {
+        cache_path_for_project(project_dir_name)?
+    };
     let data = std::fs::read(&path).ok()?;
     if data.len() < 12 {
         return None;
@@ -104,8 +134,22 @@ pub fn read_project_cache(project_dir_name: &str) -> Option<HashMap<String, Cach
 
 /// Write a project's cache file atomically (temp file + rename).
 /// Uses tempfile for safe concurrent writes. Silently ignores failures.
+#[allow(dead_code)]
 pub fn write_project_cache(project_dir_name: &str, entries: HashMap<String, CacheEntry>) {
-    let Some(path) = cache_path_for_project(project_dir_name) else {
+    write_project_cache_keyed(project_dir_name, entries, None);
+}
+
+/// Write a project's cache file with explicit cache_key for namespacing.
+pub fn write_project_cache_keyed(
+    project_dir_name: &str,
+    entries: HashMap<String, CacheEntry>,
+    cache_key: Option<&str>,
+) {
+    let Some(path) = (if let Some(key) = cache_key {
+        cache_path_for_project_keyed(project_dir_name, key)
+    } else {
+        cache_path_for_project(project_dir_name)
+    }) else {
         return;
     };
     let Some(parent) = path.parent() else {
@@ -241,6 +285,7 @@ pub fn conversation_from_entry(entry: &CacheEntry, path: PathBuf, show_last: boo
         model: entry.model.clone(),
         total_tokens: entry.total_tokens,
         duration_minutes: entry.duration_minutes,
+        source_label: None,
     }
 }
 
@@ -282,6 +327,7 @@ mod tests {
             model: Some("claude-opus-4-5-20251101".to_string()),
             total_tokens: 1500,
             duration_minutes: Some(10),
+            source_label: None,
         }
     }
 

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -647,10 +647,10 @@ fn load_conversations_keyed(
     let cached_entries =
         cache::read_project_cache_keyed(project_dir_name, Some(cache_key)).unwrap_or_default();
 
-    // Find all JSONL files and capture metadata in one pass
+    // Find all JSONL files and capture metadata in one pass (stat only — no reads).
+    // ICM/marker classification happens later, only for cache misses.
     let mut files_with_meta = Vec::new();
     let mut skipped_agent_files = 0;
-    let mut skipped_excluded_files = 0;
 
     for entry in read_dir(projects_dir)? {
         let entry = entry?;
@@ -665,13 +665,6 @@ fn load_conversations_keyed(
                 continue;
             }
 
-            // Skip machine-generated sessions (e.g. ICM memory jobs) identified by a
-            // marker in their head, before parsing/caching/holding them in memory.
-            if head_contains_marker(&path, exclude_markers) {
-                skipped_excluded_files += 1;
-                continue;
-            }
-
             let metadata = entry.metadata().ok();
             let modified = metadata.as_ref().and_then(|m| m.modified().ok());
             let file_size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -683,10 +676,9 @@ fn load_conversations_keyed(
     debug::info(
         debug_level,
         &format!(
-            "Found {} conversation files ({} agent files skipped, {} excluded by marker)",
+            "Found {} conversation files ({} agent files skipped)",
             files_with_meta.len(),
-            skipped_agent_files,
-            skipped_excluded_files
+            skipped_agent_files
         ),
     );
 
@@ -697,7 +689,11 @@ fn load_conversations_keyed(
     // Partition into cache hits and misses
     let mut dirty = false;
     let mut conversations: Vec<Conversation> = Vec::with_capacity(files_with_meta.len());
-    let mut files_to_parse: Vec<(PathBuf, Option<SystemTime>, u64)> = Vec::new();
+    let mut files_to_classify: Vec<(PathBuf, Option<SystemTime>, u64)> = Vec::new();
+    // Files known to be excluded (e.g. ICM sessions), carried forward in the cache
+    // so their heads are never re-read. (filename, file_size, mtime)
+    let mut excluded_files: Vec<(String, u64, SystemTime)> = Vec::new();
+    let mut skipped_excluded_files = 0usize;
 
     for (path, modified, file_size) in &files_with_meta {
         let filename = path
@@ -709,7 +705,11 @@ fn load_conversations_keyed(
             && let Some(entry) = cached_entries.get(filename)
             && cache::entry_matches(entry, *file_size, *mtime)
         {
-            if entry.is_empty {
+            if entry.excluded {
+                // Negative cache hit — file was previously classified as excluded
+                skipped_excluded_files += 1;
+                excluded_files.push((filename.to_owned(), *file_size, *mtime));
+            } else if entry.is_empty {
                 // Negative cache hit — file was previously parsed and yielded nothing
                 debug::debug(debug_level, &format!("Cache hit (empty) {}", filename));
             } else {
@@ -722,7 +722,7 @@ fn load_conversations_keyed(
             }
         } else {
             dirty = true;
-            files_to_parse.push((path.clone(), *modified, *file_size));
+            files_to_classify.push((path.clone(), *modified, *file_size));
         }
     }
 
@@ -731,12 +731,42 @@ fn load_conversations_keyed(
         dirty = true;
     }
 
+    // Classify cache misses by head marker (parallel reads). Only genuinely new
+    // files are read here; known files (incl. excluded ones) come from the cache.
+    let mut files_to_parse: Vec<(PathBuf, Option<SystemTime>, u64)> = Vec::new();
+    if !files_to_classify.is_empty() {
+        let classified: Vec<(PathBuf, Option<SystemTime>, u64, bool)> = files_to_classify
+            .into_par_iter()
+            .map(|(path, modified, file_size)| {
+                let is_excluded = head_contains_marker(&path, exclude_markers);
+                (path, modified, file_size, is_excluded)
+            })
+            .collect();
+
+        for (path, modified, file_size, is_excluded) in classified {
+            if is_excluded {
+                skipped_excluded_files += 1;
+                if let Some(mtime) = modified {
+                    let filename = path
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .unwrap_or("unknown")
+                        .to_owned();
+                    excluded_files.push((filename, file_size, mtime));
+                }
+            } else {
+                files_to_parse.push((path, modified, file_size));
+            }
+        }
+    }
+
     debug::info(
         debug_level,
         &format!(
-            "Cache: {} hits, {} misses",
+            "Cache: {} hits, {} to parse, {} excluded",
             conversations.len(),
-            files_to_parse.len()
+            files_to_parse.len(),
+            skipped_excluded_files
         ),
     );
 
@@ -833,6 +863,12 @@ fn load_conversations_keyed(
             {
                 new_cache.insert(filename.to_owned(), cache::empty_entry(*file_size, *mtime));
             }
+        }
+
+        // Add negative cache entries for excluded files (e.g. ICM sessions) so their
+        // heads are never re-read on subsequent startups.
+        for (filename, file_size, mtime) in &excluded_files {
+            new_cache.insert(filename.clone(), cache::excluded_entry(*file_size, *mtime));
         }
 
         cache::write_project_cache_keyed(project_dir_name, new_cache, Some(cache_key));

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -10,13 +10,14 @@ use super::path::{
 };
 use super::{Conversation, LoaderMessage, Project};
 use crate::agent::transcript::content_blocks_count_as_agent_message;
+use crate::ccs::{self, CcsInfo};
 use crate::claude::{LogEntry, extract_search_text_from_user, parse_agent_progress};
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
 use crate::time_filter::TimeFilter;
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, read_dir};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -46,37 +47,72 @@ pub struct DeleteEmptySummary {
     pub deleted: usize,
 }
 
-/// Load conversations from ALL projects globally
+/// Load conversations from ALL projects globally (across all CCS roots)
 #[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    ccs_info: Option<&CcsInfo>,
 ) -> Result<Vec<Conversation>> {
-    let root = super::get_claude_projects_root()?;
-    let projects = list_projects(&root)?;
+    let roots = ccs::get_all_project_roots(ccs_info)?;
+
+    // Build session UUID → profile name mapping from CCS session-env directories
+    let session_profile_map = ccs_info
+        .map(|info| info.build_session_profile_map())
+        .unwrap_or_default();
+
+    // Collect all projects from all roots, deduplicating by canonical project dir
+    let mut seen_canonical = HashSet::new();
+    let mut all_projects: Vec<(PathBuf, Project, String)> = Vec::new();
+
+    for root in &roots {
+        if !root.path.exists() {
+            continue;
+        }
+        if let Ok(projects) = list_projects(&root.path) {
+            for project in projects {
+                let project_dir = root.path.join(&project.name);
+                let canonical =
+                    std::fs::canonicalize(&project_dir).unwrap_or_else(|_| project_dir.clone());
+                if seen_canonical.insert(canonical) {
+                    all_projects.push((root.path.clone(), project, root.cache_key.clone()));
+                }
+            }
+        }
+    }
 
     debug::info(
         debug_level,
-        &format!("Loading global history from {} projects", projects.len()),
+        &format!(
+            "Loading global history from {} projects across {} roots",
+            all_projects.len(),
+            roots.len()
+        ),
     );
 
     // Load conversations from all projects in parallel
-    let mut all_conversations: Vec<Conversation> = projects
+    let mut all_conversations: Vec<Conversation> = all_projects
         .par_iter()
-        .flat_map(|project| {
+        .flat_map(|(root, project, cache_key)| {
             let project_dir = root.join(&project.name);
-            match load_conversations(&project_dir, show_last, &project.name, debug_level) {
+            match load_conversations_keyed(
+                &project_dir,
+                show_last,
+                &project.name,
+                debug_level,
+                cache_key,
+            ) {
                 Ok(mut convs) => {
-                    // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
-
-                    // Inject project info into each conversation
                     for conv in &mut convs {
-                        // Prefer the cwd extracted from the JSONL file (accurate), fall back to decoded path
                         let project_path =
                             conv.cwd.clone().unwrap_or_else(|| fallback_path.clone());
                         conv.project_name = Some(format_short_name_from_path(&project_path));
                         conv.project_path = Some(project_path);
+                        // Look up session UUID in CCS session-env mapping
+                        if let Some(uuid) = conv.path.file_stem().and_then(|s| s.to_str()) {
+                            conv.source_label = session_profile_map.get(uuid).cloned();
+                        }
                     }
                     convs
                 }
@@ -110,17 +146,18 @@ pub fn load_all_conversations(
     Ok(all_conversations)
 }
 
-/// Start loading all conversations in the background
+/// Start loading all conversations in the background (across all CCS roots)
 /// Returns a receiver that will receive LoaderMessage updates
 pub fn load_all_conversations_streaming(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time: TimeFilter,
+    ccs_info: Option<CcsInfo>,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level, time);
+        load_all_streaming_inner(tx, show_last, debug_level, time, ccs_info.as_ref());
     });
 
     rx
@@ -131,9 +168,9 @@ fn load_all_streaming_inner(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     time: TimeFilter,
+    ccs_info: Option<&CcsInfo>,
 ) {
-    // First, validate that the projects root exists (fatal if not)
-    let root = match super::get_claude_projects_root() {
+    let roots = match ccs::get_all_project_roots(ccs_info) {
         Ok(r) => r,
         Err(e) => {
             let _ = tx.send(LoaderMessage::Fatal(e));
@@ -141,99 +178,155 @@ fn load_all_streaming_inner(
         }
     };
 
-    if !root.exists() {
-        let _ = tx.send(LoaderMessage::Fatal(AppError::ProjectsDirNotFound(
-            root.display().to_string(),
-        )));
-        return;
-    }
+    // Build session UUID → profile name mapping from CCS session-env directories
+    let session_profile_map = ccs_info
+        .map(|info| info.build_session_profile_map())
+        .unwrap_or_default();
 
-    // List projects (fatal if this fails)
-    let projects = match list_projects(&root) {
-        Ok(p) => p,
-        Err(e) => {
-            let _ = tx.send(LoaderMessage::Fatal(e));
-            return;
+    // Collect all projects from all roots, deduplicating by canonical project dir
+    let mut seen_canonical = HashSet::new();
+    let mut all_projects: Vec<(PathBuf, Project, String)> = Vec::new();
+
+    for root in &roots {
+        if !root.path.exists() {
+            debug::warn(
+                debug_level,
+                &format!("Projects root does not exist: {}", root.path.display()),
+            );
+            continue;
         }
-    };
 
-    debug::info(
-        debug_level,
-        &format!("Loading global history from {} projects", projects.len()),
-    );
-
-    // Process projects in parallel and send batches as they complete
-    projects.par_iter().for_each(|project| {
-        let project_dir = root.join(&project.name);
-
-        match load_conversations(&project_dir, show_last, &project.name, debug_level) {
-            Ok(mut convs) => {
-                if convs.is_empty() {
-                    return;
-                }
-
-                let fallback_path = decode_project_dir_name_to_path(&project.name);
-
-                for conv in &mut convs {
-                    let project_path = conv.cwd.clone().unwrap_or_else(|| fallback_path.clone());
-                    conv.project_name = Some(format_short_name_from_path(&project_path));
-                    conv.project_path = Some(project_path);
-                }
-
-                // Filtered here rather than inside load_conversations, whose
-                // per-project cache is rebuilt from the vec it returns —
-                // dropping conversations earlier would evict their cache
-                // entries and force a re-parse on every later run.
-                if time.is_active() {
-                    convs.retain(|conv| time.matches(conv.timestamp));
-                    if convs.is_empty() {
-                        return;
+        match list_projects(&root.path) {
+            Ok(projects) => {
+                for project in projects {
+                    let project_dir = root.path.join(&project.name);
+                    let canonical =
+                        std::fs::canonicalize(&project_dir).unwrap_or_else(|_| project_dir.clone());
+                    if seen_canonical.insert(canonical) {
+                        all_projects.push((root.path.clone(), project, root.cache_key.clone()));
                     }
                 }
-
-                // Send batch, ignore error if receiver dropped
-                let _ = tx.send(LoaderMessage::Batch(convs));
             }
             Err(e) => {
                 debug::warn(
                     debug_level,
-                    &format!("Failed to load project {}: {}", project.display_name, e),
+                    &format!("Failed to list projects in {}: {}", root.path.display(), e),
                 );
-                let _ = tx.send(LoaderMessage::ProjectError);
             }
         }
-    });
+    }
+
+    if all_projects.is_empty() {
+        let root_paths: Vec<String> = roots.iter().map(|r| r.path.display().to_string()).collect();
+        let _ = tx.send(LoaderMessage::Fatal(AppError::ProjectsDirNotFound(
+            root_paths.join(", "),
+        )));
+        return;
+    }
+
+    debug::info(
+        debug_level,
+        &format!(
+            "Loading global history from {} projects across {} roots",
+            all_projects.len(),
+            roots.len()
+        ),
+    );
+
+    // Process projects in parallel and send batches as they complete
+    all_projects
+        .par_iter()
+        .for_each(|(root, project, cache_key)| {
+            let project_dir = root.join(&project.name);
+
+            match load_conversations_keyed(
+                &project_dir,
+                show_last,
+                &project.name,
+                debug_level,
+                cache_key,
+            ) {
+                Ok(mut convs) => {
+                    if convs.is_empty() {
+                        return;
+                    }
+
+                    let fallback_path = decode_project_dir_name_to_path(&project.name);
+
+                    for conv in &mut convs {
+                        let project_path =
+                            conv.cwd.clone().unwrap_or_else(|| fallback_path.clone());
+                        conv.project_name = Some(format_short_name_from_path(&project_path));
+                        conv.project_path = Some(project_path);
+                        if let Some(uuid) = conv.path.file_stem().and_then(|s| s.to_str()) {
+                            conv.source_label = session_profile_map.get(uuid).cloned();
+                        }
+                    }
+
+                    // Filtered here rather than inside load_conversations, whose
+                    // per-project cache is rebuilt from the vec it returns —
+                    // dropping conversations earlier would evict their cache
+                    // entries and force a re-parse on every later run.
+                    if time.is_active() {
+                        convs.retain(|conv| time.matches(conv.timestamp));
+                        if convs.is_empty() {
+                            return;
+                        }
+                    }
+
+                    // Send batch, ignore error if receiver dropped
+                    let _ = tx.send(LoaderMessage::Batch(convs));
+                }
+                Err(e) => {
+                    debug::warn(
+                        debug_level,
+                        &format!("Failed to load project {}: {}", project.display_name, e),
+                    );
+                    let _ = tx.send(LoaderMessage::ProjectError);
+                }
+            }
+        });
 
     let _ = tx.send(LoaderMessage::Done);
 }
 
-/// Find a session JSONL file by UUID across all projects.
+/// Find a session JSONL file by UUID across all projects and all roots.
 /// Returns the path to the `.jsonl` file if found.
 pub fn find_jsonl_by_uuid(uuid: &str) -> Result<Option<PathBuf>> {
     let matches = find_all_jsonl_by_uuid(uuid)?;
     Ok(matches.into_iter().next())
 }
 
-/// Find all session JSONL files by UUID across all projects.
+/// Find all session JSONL files by UUID across all projects and all roots.
 /// A session may exist in multiple project directories due to cross-project forking.
 fn find_all_jsonl_by_uuid(uuid: &str) -> Result<Vec<PathBuf>> {
-    let root = super::get_claude_projects_root()?;
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-
+    let ccs_info = ccs::discover_ccs();
+    let roots = ccs::get_all_project_roots(ccs_info.as_ref())?;
     let filename = format!("{}.jsonl", uuid);
     let mut matches = Vec::new();
+    let mut seen_canonical = HashSet::new();
 
-    for entry in read_dir(&root)? {
-        let entry = entry?;
-        let project_dir = entry.path();
-        if !project_dir.is_dir() {
+    for root in &roots {
+        if !root.path.exists() {
             continue;
         }
-        let candidate = project_dir.join(&filename);
-        if candidate.exists() {
-            matches.push(candidate);
+        let Ok(entries) = read_dir(&root.path) else {
+            continue;
+        };
+        for entry in entries {
+            let Ok(entry) = entry else { continue };
+            let project_dir = entry.path();
+            if !project_dir.is_dir() {
+                continue;
+            }
+            let candidate = project_dir.join(&filename);
+            if candidate.exists() {
+                let canonical =
+                    std::fs::canonicalize(&candidate).unwrap_or_else(|_| candidate.clone());
+                if seen_canonical.insert(canonical) {
+                    matches.push(candidate);
+                }
+            }
         }
     }
 
@@ -478,14 +571,33 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
 }
 
 /// Find and process all conversation files in one pass, using per-project cache
+#[allow(dead_code)]
 pub fn load_conversations(
     projects_dir: &Path,
     show_last: bool,
     project_dir_name: &str,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
+    load_conversations_keyed(
+        projects_dir,
+        show_last,
+        project_dir_name,
+        debug_level,
+        "default",
+    )
+}
+
+/// Find and process all conversation files in one pass, with explicit cache key
+fn load_conversations_keyed(
+    projects_dir: &Path,
+    show_last: bool,
+    project_dir_name: &str,
+    debug_level: Option<DebugLevel>,
+    cache_key: &str,
+) -> Result<Vec<Conversation>> {
     // Load existing cache for this project
-    let cached_entries = cache::read_project_cache(project_dir_name).unwrap_or_default();
+    let cached_entries =
+        cache::read_project_cache_keyed(project_dir_name, Some(cache_key)).unwrap_or_default();
 
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
@@ -666,7 +778,7 @@ pub fn load_conversations(
             }
         }
 
-        cache::write_project_cache(project_dir_name, new_cache);
+        cache::write_project_cache_keyed(project_dir_name, new_cache, Some(cache_key));
     }
 
     debug::info(

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -47,12 +47,46 @@ pub struct DeleteEmptySummary {
     pub deleted: usize,
 }
 
+/// First-line signature of ICM (persistent-memory) background sessions. These are
+/// machine-generated `claude -p` jobs spawned by ICM hooks on nearly every tool
+/// call to distill memory; each embeds the full system context (~85 KB) and they
+/// can number in the hundreds of thousands, dwarfing real conversations. We skip
+/// them up front so they never get parsed, cached, or held in memory.
+pub const ICM_SESSION_MARKER: &str =
+    "extract durable facts that an AI agent should remember across sessions";
+
+/// Read the first chunk of a file and report whether it contains any of the given
+/// marker substrings. Reads only a small head (markers appear within the first
+/// queue-operation line), so this is far cheaper than parsing the whole file.
+fn head_contains_marker(path: &Path, markers: &[String]) -> bool {
+    use std::io::Read;
+    if markers.is_empty() {
+        return false;
+    }
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut buf = [0u8; 8192];
+    let n = file.read(&mut buf).unwrap_or(0);
+    if n == 0 {
+        return false;
+    }
+    let head = &buf[..n];
+    markers.iter().any(|m| {
+        let needle = m.as_bytes();
+        !needle.is_empty()
+            && needle.len() <= head.len()
+            && head.windows(needle.len()).any(|w| w == needle)
+    })
+}
+
 /// Load conversations from ALL projects globally (across all CCS roots)
 #[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     ccs_info: Option<&CcsInfo>,
+    exclude_markers: &[String],
 ) -> Result<Vec<Conversation>> {
     let roots = ccs::get_all_project_roots(ccs_info)?;
 
@@ -101,6 +135,7 @@ pub fn load_all_conversations(
                 &project.name,
                 debug_level,
                 cache_key,
+                exclude_markers,
             ) {
                 Ok(mut convs) => {
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
@@ -153,11 +188,19 @@ pub fn load_all_conversations_streaming(
     debug_level: Option<DebugLevel>,
     time: TimeFilter,
     ccs_info: Option<CcsInfo>,
+    exclude_markers: Vec<String>,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level, time, ccs_info.as_ref());
+        load_all_streaming_inner(
+            tx,
+            show_last,
+            debug_level,
+            time,
+            ccs_info.as_ref(),
+            &exclude_markers,
+        );
     });
 
     rx
@@ -169,6 +212,7 @@ fn load_all_streaming_inner(
     debug_level: Option<DebugLevel>,
     time: TimeFilter,
     ccs_info: Option<&CcsInfo>,
+    exclude_markers: &[String],
 ) {
     let roots = match ccs::get_all_project_roots(ccs_info) {
         Ok(r) => r,
@@ -245,6 +289,7 @@ fn load_all_streaming_inner(
                 &project.name,
                 debug_level,
                 cache_key,
+                exclude_markers,
             ) {
                 Ok(mut convs) => {
                     if convs.is_empty() {
@@ -577,6 +622,7 @@ pub fn load_conversations(
     show_last: bool,
     project_dir_name: &str,
     debug_level: Option<DebugLevel>,
+    exclude_markers: &[String],
 ) -> Result<Vec<Conversation>> {
     load_conversations_keyed(
         projects_dir,
@@ -584,6 +630,7 @@ pub fn load_conversations(
         project_dir_name,
         debug_level,
         "default",
+        exclude_markers,
     )
 }
 
@@ -594,6 +641,7 @@ fn load_conversations_keyed(
     project_dir_name: &str,
     debug_level: Option<DebugLevel>,
     cache_key: &str,
+    exclude_markers: &[String],
 ) -> Result<Vec<Conversation>> {
     // Load existing cache for this project
     let cached_entries =
@@ -602,6 +650,7 @@ fn load_conversations_keyed(
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
     let mut skipped_agent_files = 0;
+    let mut skipped_excluded_files = 0;
 
     for entry in read_dir(projects_dir)? {
         let entry = entry?;
@@ -616,6 +665,13 @@ fn load_conversations_keyed(
                 continue;
             }
 
+            // Skip machine-generated sessions (e.g. ICM memory jobs) identified by a
+            // marker in their head, before parsing/caching/holding them in memory.
+            if head_contains_marker(&path, exclude_markers) {
+                skipped_excluded_files += 1;
+                continue;
+            }
+
             let metadata = entry.metadata().ok();
             let modified = metadata.as_ref().and_then(|m| m.modified().ok());
             let file_size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -627,9 +683,10 @@ fn load_conversations_keyed(
     debug::info(
         debug_level,
         &format!(
-            "Found {} conversation files ({} agent files skipped)",
+            "Found {} conversation files ({} agent files skipped, {} excluded by marker)",
             files_with_meta.len(),
-            skipped_agent_files
+            skipped_agent_files,
+            skipped_excluded_files
         ),
     );
 

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -80,6 +80,38 @@ fn head_contains_marker(path: &Path, markers: &[String]) -> bool {
     })
 }
 
+/// Paths classified as excluded sessions (e.g. ICM memory jobs) in the per-project
+/// caches, across all roots. Read from the caches the loader just refreshed, so
+/// callers that walk the projects tree on their own can drop the same files
+/// without re-reading any transcript head.
+pub fn excluded_session_paths(ccs_info: Option<&CcsInfo>) -> HashSet<PathBuf> {
+    let Ok(roots) = ccs::get_all_project_roots(ccs_info) else {
+        return HashSet::new();
+    };
+
+    let mut excluded = HashSet::new();
+    for root in &roots {
+        let Ok(projects) = list_projects(&root.path) else {
+            continue;
+        };
+        for project in projects {
+            let Some(entries) =
+                cache::read_project_cache_keyed(&project.name, Some(&root.cache_key))
+            else {
+                continue;
+            };
+            let project_dir = root.path.join(&project.name);
+            excluded.extend(
+                entries
+                    .iter()
+                    .filter(|(_, entry)| entry.excluded)
+                    .map(|(filename, _)| project_dir.join(filename)),
+            );
+        }
+    }
+    excluded
+}
+
 /// Load conversations from ALL projects globally (across all CCS roots)
 #[allow(dead_code)]
 pub fn load_all_conversations(

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -25,7 +25,8 @@ use std::time::SystemTime;
 // Re-export public API
 pub use loader::{
     DeleteEmptyScope, ICM_SESSION_MARKER, delete_empty_transcripts, delete_session_by_uuid,
-    find_jsonl_by_uuid, load_all_conversations, load_all_conversations_streaming,
+    excluded_session_paths, find_jsonl_by_uuid, load_all_conversations,
+    load_all_conversations_streaming,
 };
 pub(crate) use parser::{
     extract_skill_preview, is_clear_metadata_message, process_conversation_file,

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -79,6 +79,8 @@ pub struct Conversation {
     pub total_tokens: u64,
     /// Conversation duration in minutes (from first to last message)
     pub duration_minutes: Option<u64>,
+    /// Source label indicating where this conversation was loaded from (e.g., CCS profile name)
+    pub source_label: Option<String>,
 }
 
 pub struct Project {

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -24,8 +24,8 @@ use std::time::SystemTime;
 
 // Re-export public API
 pub use loader::{
-    DeleteEmptyScope, delete_empty_transcripts, delete_session_by_uuid, find_jsonl_by_uuid,
-    load_all_conversations, load_all_conversations_streaming,
+    DeleteEmptyScope, ICM_SESSION_MARKER, delete_empty_transcripts, delete_session_by_uuid,
+    find_jsonl_by_uuid, load_all_conversations, load_all_conversations_streaming,
 };
 pub(crate) use parser::{
     extract_skill_preview, is_clear_metadata_message, process_conversation_file,

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -480,6 +480,7 @@ pub fn process_conversation_reader<R: BufRead>(
         model: extracted_model,
         total_tokens,
         duration_minutes,
+        source_label: None,
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,11 @@ fn run() -> Result<()> {
 
     let config = config::load_config()?;
 
+    // Session-head markers used to exclude machine-generated sessions (e.g. ICM
+    // persistent-memory background jobs) from loading. Computed before `config`
+    // fields are consumed below.
+    let exclude_markers = config.exclude_markers();
+
     // Merge CLI arguments with config file settings. CLI takes precedence.
     let display_config = config.display.unwrap_or_default();
 
@@ -246,8 +251,12 @@ fn run() -> Result<()> {
 
     // Handle --debug-search flag: debug search result scoring
     if let Some(ref query) = args.debug_search {
-        let mut conversations =
-            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
+        let mut conversations = history::load_all_conversations(
+            show_last,
+            args.debug,
+            ccs_info.as_ref(),
+            &exclude_markers,
+        )?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
@@ -327,8 +336,12 @@ fn run() -> Result<()> {
     }
 
     if let Some(ref query) = args.debug_semantic_search {
-        let mut conversations =
-            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
+        let mut conversations = history::load_all_conversations(
+            show_last,
+            args.debug,
+            ccs_info.as_ref(),
+            &exclude_markers,
+        )?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::debug_search(query, &conversations, args.local);
@@ -342,8 +355,12 @@ fn run() -> Result<()> {
                 "--generate-semantic-cache cannot be combined with a time filter".to_string(),
             ));
         }
-        let mut conversations =
-            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
+        let mut conversations = history::load_all_conversations(
+            show_last,
+            args.debug,
+            ccs_info.as_ref(),
+            &exclude_markers,
+        )?;
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::generate_cache(&conversations, args.local);
     }
@@ -354,8 +371,12 @@ fn run() -> Result<()> {
 
     // Handle --semantic-search flag
     if let Some(ref query) = args.semantic_search {
-        let mut conversations =
-            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
+        let mut conversations = history::load_all_conversations(
+            show_last,
+            args.debug,
+            ccs_info.as_ref(),
+            &exclude_markers,
+        )?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::run(query, &conversations, args.semantic_top, args.local);
@@ -422,6 +443,7 @@ fn run() -> Result<()> {
         args.debug,
         time_filter,
         ccs_info.clone(),
+        exclude_markers,
     );
 
     // An empty result is far more often the time filter than an empty history,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod ccs;
 mod claude;
 mod cli;
 mod config;
@@ -218,6 +219,9 @@ fn run() -> Result<()> {
         std::io::stdout().is_terminal(),
     );
 
+    // Discover CCS (early, before any loading)
+    let ccs_info = ccs::discover_ccs();
+
     // Handle --delete flag: delete a session by UUID and exit
     if let Some(ref session_id) = args.delete {
         match history::delete_session_by_uuid(session_id) {
@@ -242,7 +246,8 @@ fn run() -> Result<()> {
 
     // Handle --debug-search flag: debug search result scoring
     if let Some(ref query) = args.debug_search {
-        let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        let mut conversations =
+            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
@@ -322,7 +327,8 @@ fn run() -> Result<()> {
     }
 
     if let Some(ref query) = args.debug_semantic_search {
-        let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        let mut conversations =
+            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::debug_search(query, &conversations, args.local);
@@ -336,7 +342,8 @@ fn run() -> Result<()> {
                 "--generate-semantic-cache cannot be combined with a time filter".to_string(),
             ));
         }
-        let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        let mut conversations =
+            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::generate_cache(&conversations, args.local);
     }
@@ -347,7 +354,8 @@ fn run() -> Result<()> {
 
     // Handle --semantic-search flag
     if let Some(ref query) = args.semantic_search {
-        let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        let mut conversations =
+            history::load_all_conversations(show_last, args.debug, ccs_info.as_ref())?;
         conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::run(query, &conversations, args.semantic_top, args.local);
@@ -408,8 +416,13 @@ fn run() -> Result<()> {
     // --local starts with workspace filter on; default is global (filter off)
     let workspace_filter = use_local;
 
-    // Always use streaming global loader for all conversations
-    let rx = history::load_all_conversations_streaming(show_last, args.debug, time_filter);
+    // Always use streaming global loader for all conversations (across all CCS roots)
+    let rx = history::load_all_conversations_streaming(
+        show_last,
+        args.debug,
+        time_filter,
+        ccs_info.clone(),
+    );
 
     // An empty result is far more often the time filter than an empty history,
     // so say which when a filter is in play.
@@ -431,20 +444,36 @@ fn run() -> Result<()> {
         tui::TuiSearchOptions {
             default_mode: tui_search_mode(search_mode),
         },
+        ccs_info.clone(),
+        args.profile.clone(),
     )
     .map_err(describe_empty)?
     {
         (tui::Action::Select(path), convs) => (convs, path),
-        (tui::Action::Resume(path), convs) => {
+        (tui::Action::Resume(path, profile), convs) => {
             let conv = convs.iter().find(|c| c.path == path);
             let project_path = conv.and_then(|c| c.project_path.as_ref());
-            resume_with_claude(&path, project_path, default_args, false)?;
+            resume_with_claude(
+                &path,
+                project_path,
+                default_args,
+                false,
+                profile.as_deref(),
+                ccs_info.as_ref(),
+            )?;
             return Ok(());
         }
-        (tui::Action::ForkResume(path), convs) => {
+        (tui::Action::ForkResume(path, profile), convs) => {
             let conv = convs.iter().find(|c| c.path == path);
             let project_path = conv.and_then(|c| c.project_path.as_ref());
-            resume_with_claude(&path, project_path, default_args, true)?;
+            resume_with_claude(
+                &path,
+                project_path,
+                default_args,
+                true,
+                profile.as_deref(),
+                ccs_info.as_ref(),
+            )?;
             return Ok(());
         }
         (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
@@ -487,11 +516,19 @@ fn run() -> Result<()> {
             }
         }
         let project_path = conv.and_then(|c| c.project_path.as_ref());
+        // Use --profile flag or CCS default
+        let profile = args.profile.as_deref().or_else(|| {
+            ccs_info
+                .as_ref()
+                .and_then(|info| info.default_profile.as_deref())
+        });
         resume_with_claude(
             &selected_path,
             project_path,
             default_args,
             args.fork_session,
+            profile,
+            ccs_info.as_ref(),
         )?;
         return Ok(());
     }
@@ -926,6 +963,7 @@ mod agent_command_tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 
@@ -1316,6 +1354,7 @@ mod agent_command_tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         };
         let input = agent::search::AgentConversationInput {
             conversation: &conversation,
@@ -1596,6 +1635,8 @@ fn resume_with_claude(
     project_path: Option<&PathBuf>,
     default_args: &[String],
     fork_session: bool,
+    profile: Option<&str>,
+    ccs_info: Option<&ccs::CcsInfo>,
 ) -> Result<()> {
     let conversation_id = selected_path
         .file_stem()
@@ -1618,6 +1659,10 @@ fn resume_with_claude(
         )
     })?;
 
+    // Resolve CCS profile's config_dir for CLAUDE_CONFIG_DIR
+    let profile_config_dir =
+        profile.and_then(|name| ccs_info.and_then(|info| info.profile_config_dir(name).cloned()));
+
     match resolve_claude_resume_action(selected_path, project_path, &cwd, fork_session)? {
         ClaudeResumeAction::CopyToCurrent { cwd_projects_dir } => {
             std::fs::create_dir_all(&cwd_projects_dir).map_err(AppError::Io)?;
@@ -1632,6 +1677,9 @@ fn resume_with_claude(
             command.args(["--resume", &conversation_id]);
             command.args(default_args);
             command.current_dir(&cwd);
+            if let Some(ref config_dir) = profile_config_dir {
+                command.env("CLAUDE_CONFIG_DIR", config_dir);
+            }
             run_claude_command(command)
         }
         ClaudeResumeAction::Run { current_dir } => {
@@ -1642,6 +1690,9 @@ fn resume_with_claude(
             }
             command.args(default_args);
             command.current_dir(current_dir);
+            if let Some(ref config_dir) = profile_config_dir {
+                command.env("CLAUDE_CONFIG_DIR", config_dir);
+            }
 
             run_claude_command(command)
         }

--- a/src/search/evidence.rs
+++ b/src/search/evidence.rs
@@ -378,6 +378,7 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 

--- a/src/search/test_fixtures.rs
+++ b/src/search/test_fixtures.rs
@@ -41,5 +41,6 @@ pub fn one_message_conversation(
         model: None,
         total_tokens: 0,
         duration_minutes: None,
+        source_label: None,
     }
 }

--- a/src/semantic/chunk.rs
+++ b/src/semantic/chunk.rs
@@ -263,6 +263,7 @@ mod tests {
             model: Some("claude-sonnet-4-6".to_string()),
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 

--- a/src/semantic/output.rs
+++ b/src/semantic/output.rs
@@ -101,6 +101,7 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 

--- a/src/semantic/test_fixtures.rs
+++ b/src/semantic/test_fixtures.rs
@@ -115,6 +115,7 @@ impl SemanticConversationFixture {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,3 +1,4 @@
+use crate::ccs::CcsInfo;
 use crate::config::KeyBindings;
 use crate::history::{Conversation, format_short_name_from_path, process_conversation_file};
 use crate::search::{self, SearchableConversation};
@@ -83,6 +84,10 @@ pub struct App {
     workspace_filter: bool,
     /// The encoded project directory name for the current workspace (for filtering)
     current_project_dir_name: Option<String>,
+    /// CCS discovery result (None if CCS not installed)
+    pub ccs_info: Option<CcsInfo>,
+    /// CLI override profile (from --profile flag)
+    pub override_profile: Option<String>,
     /// Exact project names hidden from list-mode display
     excluded_projects: HashSet<String>,
     /// Channel to send commands to the background search worker
@@ -116,6 +121,8 @@ struct AppParts {
     keys: KeyBindings,
     workspace_filter: bool,
     current_project_dir_name: Option<String>,
+    ccs_info: Option<CcsInfo>,
+    override_profile: Option<String>,
     excluded_projects: HashSet<String>,
     search_tx: mpsc::Sender<SearchCommand>,
     search_rx: mpsc::Receiver<SearchResponse>,
@@ -149,6 +156,8 @@ impl App {
             keys: parts.keys,
             workspace_filter: parts.workspace_filter,
             current_project_dir_name: parts.current_project_dir_name,
+            ccs_info: parts.ccs_info,
+            override_profile: parts.override_profile,
             excluded_projects: parts.excluded_projects,
             search_tx: parts.search_tx,
             search_rx: parts.search_rx,
@@ -248,6 +257,8 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            ccs_info: None,
+            override_profile: None,
             excluded_projects,
             search_tx,
             search_rx,
@@ -265,6 +276,8 @@ impl App {
         current_project_dir_name: Option<String>,
         exclude_projects: Vec<String>,
         search_options: TuiSearchOptions,
+        ccs_info: Option<CcsInfo>,
+        override_profile: Option<String>,
     ) -> Self {
         let conversations = Vec::new();
         let (search_tx, search_rx) = spawn_search_worker();
@@ -284,6 +297,8 @@ impl App {
             keys,
             workspace_filter,
             current_project_dir_name,
+            ccs_info,
+            override_profile,
             excluded_projects: exclude_projects.into_iter().collect(),
             search_tx,
             search_rx,
@@ -339,6 +354,8 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            ccs_info: None,
+            override_profile: None,
             excluded_projects: HashSet::new(),
             search_tx,
             search_rx,
@@ -349,6 +366,102 @@ impl App {
 
     pub fn keys(&self) -> &KeyBindings {
         &self.keys
+    }
+
+    pub fn ccs_info(&self) -> Option<&CcsInfo> {
+        self.ccs_info.as_ref()
+    }
+
+    /// Resolve resume/fork action, showing profile picker if needed.
+    /// Returns Some(Action) if profile is determined, None if picker dialog was opened.
+    fn resolve_resume_action(&mut self, is_fork: bool) -> Option<Action> {
+        let path = self.get_selected_path()?;
+
+        // Determine the profile to use
+        let profile = if let Some(ref name) = self.override_profile {
+            // CLI --profile override
+            Some(name.clone())
+        } else if let Some(ref info) = self.ccs_info {
+            if info.profiles.len() <= 1 {
+                // 0 or 1 profile: use default automatically
+                info.default_profile.clone()
+            } else {
+                // Multiple profiles: show picker
+                let default_idx = info
+                    .profiles
+                    .iter()
+                    .position(|p| Some(&p.name) == info.default_profile.as_ref())
+                    .unwrap_or(0);
+                let profile_names: Vec<String> =
+                    info.profiles.iter().map(|p| p.name.clone()).collect();
+                self.dialog_mode = DialogMode::ProfilePicker {
+                    selected: default_idx,
+                    profiles: profile_names,
+                    is_fork,
+                };
+                return None; // picker will handle the action
+            }
+        } else {
+            None // No CCS
+        };
+
+        if is_fork {
+            Some(Action::ForkResume(path, profile))
+        } else {
+            Some(Action::Resume(path, profile))
+        }
+    }
+
+    fn handle_profile_picker_key(&mut self, code: KeyCode) -> Option<Action> {
+        let (selected, profiles, is_fork) = match &mut self.dialog_mode {
+            DialogMode::ProfilePicker {
+                selected,
+                profiles,
+                is_fork,
+            } => (selected, profiles.clone(), *is_fork),
+            _ => return None,
+        };
+
+        match code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if *selected > 0 {
+                    *selected -= 1;
+                }
+                None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if *selected < profiles.len() - 1 {
+                    *selected += 1;
+                }
+                None
+            }
+            KeyCode::Enter => {
+                let profile_name = profiles[*selected].clone();
+                self.dialog_mode = DialogMode::None;
+                let path = self.get_selected_path()?;
+                if is_fork {
+                    Some(Action::ForkResume(path, Some(profile_name)))
+                } else {
+                    Some(Action::Resume(path, Some(profile_name)))
+                }
+            }
+            KeyCode::Char(c @ '1'..='9') => {
+                let idx = (c as usize - '1' as usize).min(profiles.len() - 1);
+                let profile_name = profiles[idx].clone();
+                self.dialog_mode = DialogMode::None;
+                let path = self.get_selected_path()?;
+                if is_fork {
+                    Some(Action::ForkResume(path, Some(profile_name)))
+                } else {
+                    Some(Action::Resume(path, Some(profile_name)))
+                }
+            }
+            KeyCode::Esc => {
+                self.dialog_mode = DialogMode::None;
+                None
+            }
+            _ => None,
+        }
     }
 
     /// Append a batch of conversations during loading

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -132,6 +132,7 @@ impl App {
                 return None;
             }
             DialogMode::Rename { .. } => return self.handle_rename_key(code, modifiers),
+            DialogMode::ProfilePicker { .. } => return self.handle_profile_picker_key(code),
             DialogMode::None => {}
         }
 
@@ -169,18 +170,16 @@ impl App {
             return None;
         }
         if self.keys.resume.matches(code, modifiers) {
-            return if self.single_file_mode {
-                None
-            } else {
-                self.get_selected_path().map(Action::Resume)
-            };
+            if !self.single_file_mode {
+                return self.resolve_resume_action(false);
+            }
+            return None;
         }
         if self.keys.fork.matches(code, modifiers) {
-            return if self.single_file_mode {
-                None
-            } else {
-                self.get_selected_path().map(Action::ForkResume)
-            };
+            if !self.single_file_mode {
+                return self.resolve_resume_action(true);
+            }
+            return None;
         }
 
         let state = match &mut self.app_mode {
@@ -448,10 +447,10 @@ impl App {
             return None;
         }
         if self.keys.resume.matches(code, modifiers) {
-            return self.get_selected_path().map(Action::Resume);
+            return self.resolve_resume_action(false);
         }
         if self.keys.fork.matches(code, modifiers) {
-            return self.get_selected_path().map(Action::ForkResume);
+            return self.resolve_resume_action(true);
         }
 
         match code {

--- a/src/tui/app/interaction_tests.rs
+++ b/src/tui/app/interaction_tests.rs
@@ -30,6 +30,7 @@ fn test_conversation(path: PathBuf, custom_title: Option<String>) -> Conversatio
         model: None,
         total_tokens: 0,
         duration_minutes: None,
+        source_label: None,
     }
 }
 

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -28,6 +28,7 @@ fn conversation(project: Option<&str>, project_dir: &str, uuid: &str, text: &str
         model: None,
         total_tokens: 0,
         duration_minutes: None,
+        source_label: None,
     }
 }
 
@@ -612,6 +613,8 @@ fn finish_loading_dispatches_buffered_semantic_query() {
         TuiSearchOptions {
             default_mode: ListSearchMode::Semantic,
         },
+        None,
+        None,
     );
     app.append_conversations(vec![conversation(
         Some("Visible"),
@@ -647,6 +650,8 @@ fn semantic_dispatch_after_loading_keeps_snapshot_aligned() {
         TuiSearchOptions {
             default_mode: ListSearchMode::Semantic,
         },
+        None,
+        None,
     );
     app.append_conversations(vec![conversation(
         Some("Visible"),
@@ -1311,6 +1316,8 @@ fn finish_loading_invalidates_stale_loading_search_response() {
         None,
         vec![],
         TuiSearchOptions::default(),
+        None,
+        None,
     );
 
     let (tx, rx) = mpsc::channel();
@@ -1349,6 +1356,8 @@ fn workspace_filter_without_project_context_keeps_rows() {
         None,
         vec![],
         TuiSearchOptions::default(),
+        None,
+        None,
     );
 
     app.append_conversations(vec![conversation(
@@ -1371,6 +1380,8 @@ fn exclude_projects_filters_incremental_loading() {
         None,
         vec!["Hidden".to_string()],
         TuiSearchOptions::default(),
+        None,
+        None,
     );
 
     app.append_conversations(vec![

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 pub enum Action {
     Select(PathBuf),
     Delete(PathBuf),
-    Resume(PathBuf),
-    ForkResume(PathBuf),
+    Resume(PathBuf, Option<String>),
+    ForkResume(PathBuf, Option<String>),
     Quit,
 }
 
@@ -33,6 +33,12 @@ pub enum DialogMode {
     SemanticDebug,
     /// Rename the selected conversation
     Rename { input: String, cursor: usize },
+    /// Profile picker for resume/fork (CCS multi-profile support)
+    ProfilePicker {
+        selected: usize,
+        profiles: Vec<String>,
+        is_fork: bool,
+    },
 }
 
 /// Main application mode

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,5 +1,6 @@
 use super::app::{Action, App, AppMode, DialogMode, TuiSearchOptions};
 use super::ui;
+use crate::ccs::CcsInfo;
 use crate::config::KeyBindings;
 use crate::debug_log;
 use crate::error::{AppError, Result};
@@ -183,6 +184,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub fn run_with_loader(
     rx: Receiver<LoaderMessage>,
     tool_display: ToolDisplayMode,
@@ -192,6 +194,8 @@ pub fn run_with_loader(
     current_project_dir_name: Option<String>,
     exclude_projects: Vec<String>,
     search_options: TuiSearchOptions,
+    ccs_info: Option<CcsInfo>,
+    override_profile: Option<String>,
 ) -> Result<(Action, Vec<Conversation>)> {
     let mut guard = TerminalGuard::new()?;
     let mut app = App::new_loading_with_options(
@@ -202,6 +206,8 @@ pub fn run_with_loader(
         current_project_dir_name,
         exclude_projects,
         search_options,
+        ccs_info,
+        override_profile,
     );
 
     loop {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -169,6 +169,11 @@ fn render_list_mode(frame: &mut Frame, app: &App) {
         ),
         DialogMode::SemanticDebug => render_semantic_debug_popup(frame, app),
         DialogMode::Rename { input, cursor } => render_rename_dialog(frame, input, *cursor),
+        DialogMode::ProfilePicker {
+            selected,
+            profiles,
+            is_fork,
+        } => render_profile_picker(frame, *selected, profiles, *is_fork),
         _ => {}
     }
 }
@@ -253,6 +258,17 @@ fn render_list_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(" semantic·", label_style),
             Span::styled(app.list_search_mode().label(), mode_style),
             Span::raw("  "),
+        ]);
+    }
+
+    // CCS profile badge
+    if let Some(info) = app.ccs_info()
+        && let Some(ref default_name) = info.default_profile
+    {
+        spans.extend([
+            Span::styled("[", label_style),
+            Span::styled(default_name.as_str(), key_style),
+            Span::styled("]  ", label_style),
         ]);
     }
 
@@ -505,6 +521,11 @@ fn render_view_mode(frame: &mut Frame, app: &App, state: &ViewState) {
         }
         DialogMode::SemanticDebug => render_semantic_debug_popup(frame, app),
         DialogMode::Rename { input, cursor } => render_rename_dialog(frame, input, *cursor),
+        DialogMode::ProfilePicker {
+            selected,
+            profiles,
+            is_fork,
+        } => render_profile_picker(frame, *selected, profiles, *is_fork),
         DialogMode::None => {}
     }
 }
@@ -1284,6 +1305,58 @@ fn render_export_menu(frame: &mut Frame, selected: usize, is_yank: bool) {
     frame.render_widget(menu_content, inner);
 }
 
+fn render_profile_picker(frame: &mut Frame, selected: usize, profiles: &[String], is_fork: bool) {
+    let title = if is_fork {
+        "Fork with profile"
+    } else {
+        "Resume with profile"
+    };
+
+    let area = frame.area();
+    let menu_width = 35u16;
+    let menu_height = profiles.len() as u16 + 4;
+
+    let menu_area = centered_modal_area(area, menu_width, menu_height);
+
+    frame.render_widget(Clear, menu_area);
+
+    let background = Block::default().style(Style::default().bg(rgb(th().overlay_bg)));
+    frame.render_widget(background, menu_area);
+
+    let block = Block::default()
+        .title(format!(" {} ", title))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(rgb(th().accent)));
+
+    let inner = block.inner(menu_area);
+    frame.render_widget(block, menu_area);
+
+    let mut lines = Vec::new();
+    for (i, name) in profiles.iter().enumerate() {
+        let style = if i == selected {
+            Style::default().fg(rgb(th().accent)).bold()
+        } else {
+            Style::default().fg(rgb(th().text_primary))
+        };
+        let prefix = if i == selected { "▶ " } else { "  " };
+        let label = format!("{}[{}] {}", prefix, i + 1, name);
+        lines.push(Line::styled(label, style));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::styled(
+        "  [Enter] Select  [Esc] Cancel",
+        Style::default().fg(rgb(th().text_muted)),
+    ));
+
+    if inner.is_empty() {
+        return;
+    }
+
+    let menu_content = Paragraph::new(lines);
+    frame.render_widget(menu_content, inner);
+}
+
 fn render_help_overlay(
     frame: &mut Frame,
     is_view_mode: bool,
@@ -1554,8 +1627,21 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 .map(|s| UnicodeWidthStr::width(s.as_str()))
                 .unwrap_or(0);
 
+            // CCS source label badge (e.g., " [team]")
+            let source_label_len = conv
+                .source_label
+                .as_ref()
+                .map(|l| UnicodeWidthStr::width(l.as_str()) + 3) // " [" + label + "]"
+                .unwrap_or(0);
+
             let available_for_summary = width.saturating_sub(
-                indicator_len + project_len + custom_title_len + right_len + min_padding + 4,
+                indicator_len
+                    + project_len
+                    + source_label_len
+                    + custom_title_len
+                    + right_len
+                    + min_padding
+                    + 4,
             );
 
             // Build summary part (dimmer, dynamically truncated based on available space)
@@ -1574,6 +1660,7 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
             // Calculate padding for right-aligned timestamp + message count
             let left_len = indicator_len
                 + project_len
+                + source_label_len
                 + custom_title_len
                 + summary_part
                     .as_ref()
@@ -1615,6 +1702,14 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 project_style,
                 highlight_style,
             ));
+
+            // Add CCS source label badge if present (e.g., [team])
+            if let Some(ref label) = conv.source_label {
+                header_spans.push(Span::styled(
+                    format!(" [{}]", label),
+                    Style::default().fg(rgb(th().text_muted)),
+                ));
+            }
 
             // Add custom title if present (with search highlighting)
             if let Some(ref title) = custom_title_part {
@@ -2724,6 +2819,7 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            source_label: None,
         }
     }
 


### PR DESCRIPTION
Load conversations from all CCS instance project roots with canonical path deduplication. When resuming, show a profile picker dialog if multiple CCS profiles exist, or use the default profile automatically. Each conversation displays a source badge (e.g., [team]) based on session-env directory lookup. Falls back to standard ~/.claude/projects behavior when CCS is not installed.
(CCS: Claude Code Switch. ref: https://github.com/kaitranntt/ccs)

- New src/ccs.rs module for CCS config parsing and instance discovery
- Multi-root conversation loading with per-root cache namespacing
- --profile CLI flag for explicit CCS profile selection on resume
- ProfilePicker dialog in TUI (Ctrl+R/Ctrl+F with multiple profiles)
- CCS profile badge in status bar and per-session source label in list
- serde_yaml dependency for ~/.ccs/config.yaml parsing

<img width="2518" height="2514" alt="CleanShot 2026-04-04 at 21 15 59@2x" src="https://github.com/user-attachments/assets/fc6c97d7-3ea7-4456-b32f-141bffa15c3d" />
<img width="2110" height="1446" alt="CleanShot 2026-04-04 at 21 16 29@2x" src="https://github.com/user-attachments/assets/bd5fdcbd-989d-4368-9f57-d0d43156a0c2" />
