### PR TITLE
fix: respect CLAUDE_CLI_NAME env var when resuming conversations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -399,6 +399,13 @@ fn run() -> Result<()> {
     Ok(())
 }
 
+/// Return the CLI binary name to use when resuming a conversation.
+/// Respects the `CLAUDE_CLI_NAME` environment variable so that custom
+/// installations (e.g. `claude-internal`) work correctly.
+fn claude_cli_name() -> String {
+    std::env::var("CLAUDE_CLI_NAME").unwrap_or_else(|_| "claude".to_string())
+}
+
 fn resume_with_claude(
     selected_path: &Path,
     project_path: Option<&PathBuf>,
@@ -450,14 +457,14 @@ fn resume_with_claude(
             &cwd_projects_dir,
         )?;
 
-        let mut command = Command::new("claude");
+        let mut command = Command::new(claude_cli_name());
         command.args(["--resume", &conversation_id]);
         command.args(default_args);
         command.current_dir(&cwd);
         return run_claude_command(command);
     }
 
-    let mut command = Command::new("claude");
+    let mut command = Command::new(claude_cli_name());
     command.args(["--resume", &conversation_id]);
     if fork_session {
         command.arg("--fork-session");


### PR DESCRIPTION
## Summary

- `resume_with_claude()` had `"claude"` hardcoded in both `Command::new()` calls, ignoring the `CLAUDE_CLI_NAME` environment variable
- Users running custom-named binaries (e.g. `CLAUDE_CLI_NAME=claude-internal claude-history`) would see the default `claude` invoked on resume instead of their configured binary
- Added a `claude_cli_name()` helper that reads `CLAUDE_CLI_NAME` with a fallback to `"claude"`, used in both resume code paths

## Reproduce

```bash
CLAUDE_CONFIG_DIR=~/.claude-internal CLAUDE_CLI_NAME=claude-internal claude-history
# Select a conversation and press Enter to resume
# Before fix: invokes `claude --resume <id>` (wrong)
# After fix:  invokes `claude-internal --resume <id>` (correct)
```

## Test plan

- [ ] Verify `CLAUDE_CLI_NAME=custom-claude claude-history` resumes with `custom-claude`
- [ ] Verify default behavior (no env var set) still invokes `claude`
- [ ] Verify fork-resume path also uses the correct binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)