### PR TITLE
flake.nix, update script and documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,22 @@ This will:
 3. Open editor to review changelog
 4. Commit, publish to crates.io, tag, and push
 
+## Updating flake.nix
+
+After a release, update the Nix flake to match the new version:
+
+```bash
+./scripts/update-flake.sh
+```
+
+This will:
+
+1. Read the version from Cargo.toml and update flake.nix
+2. Recalculate the `cargoHash` for the new dependencies
+3. Update `flake.lock`
+4. Verify the build and binary
+5. Stage the changes for commit
+
 ## Backfilling changelog
 
 To generate changelog entries for all git tags missing from CHANGELOG.md:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "Fuzzy-search Claude Code conversation history from the terminal.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "claude-history";
+            version = "0.1.51";
+
+            src = ./.;
+
+            cargoHash = "";
+
+            # Some tests require filesystem access not available in Nix sandbox
+            doCheck = false;
+
+            meta = with pkgs.lib; {
+              description = "Fuzzy-search Claude Code conversation history from the terminal.";
+              homepage = "https://github.com/raine/claude-history";
+              license = licenses.mit;
+              mainProgram = "claude-history";
+            };
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/claude-history";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              cargo
+              rustc
+              rust-analyzer
+              rustfmt
+              clippy
+            ];
+
+            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+          };
+        }
+      );
+    };
+}

--- a/scripts/update-flake.sh
+++ b/scripts/update-flake.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLAKE_FILE="flake.nix"
+
+# Get version from Cargo.toml
+NEW_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+OLD_VERSION=$(grep 'version = "' "$FLAKE_FILE" | head -1 | sed 's/.*"\(.*\)".*/\1/')
+
+if [ "$NEW_VERSION" = "$OLD_VERSION" ]; then
+  echo "flake.nix already at version $NEW_VERSION"
+else
+  echo "Updating version: $OLD_VERSION -> $NEW_VERSION"
+  sed -i "s/version = \"$OLD_VERSION\"/version = \"$NEW_VERSION\"/" "$FLAKE_FILE"
+fi
+
+# Clear cargoHash to trigger recalculation
+sed -i 's|cargoHash = "sha256-.*"|cargoHash = ""|' "$FLAKE_FILE"
+
+# Stage so nix can see the changes
+git add "$FLAKE_FILE"
+
+# Get the correct hash from the build error
+echo "Calculating new cargoHash..."
+HASH=$(nix build --no-link 2>&1 | grep "got:" | awk '{print $2}')
+
+if [ -z "$HASH" ]; then
+  echo "ERROR: Could not determine cargoHash. Build may have succeeded with empty hash or failed unexpectedly."
+  exit 1
+fi
+
+echo "New cargoHash: $HASH"
+sed -i "s|cargoHash = \"\"|cargoHash = \"$HASH\"|" "$FLAKE_FILE"
+
+# Update flake.lock
+nix flake update
+
+# Stage updated files
+git add "$FLAKE_FILE" flake.lock
+
+# Verify
+echo "Verifying build..."
+nix build --no-link
+echo "Verifying binary..."
+nix run . -- --version
+
+echo ""
+echo "flake.nix updated to version $NEW_VERSION with new hashes."
+echo "Changes are staged. Review with 'git diff --cached' and commit when ready."


### PR DESCRIPTION
  - Add flake.nix and flake.lock for declarative Nix-based installation and development
  - Add scripts/update-flake.sh to automate flake maintenance after releases (syncs version from Cargo.toml, recalculates cargoHash, updates flake.lock)
  - Document the update workflow in RELEASE.md