### PR TITLE
Feat read orphaned sessions

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -1,5 +1,15 @@
 use serde::Deserialize;
 
+/// An entry from ~/.claude/history.jsonl (the global prompt log)
+#[derive(Debug, Deserialize)]
+pub struct HistoryEntry {
+    pub display: String,
+    pub timestamp: u64,
+    pub project: String,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,6 +133,10 @@ pub struct Args {
     )]
     pub local: bool,
 
+    /// Include orphan sessions from history.jsonl (sessions whose data has been cleaned up)
+    #[arg(long, help = "Include orphan sessions from history.jsonl")]
+    pub include_orphans: bool,
+
     /// Display output through a pager (less)
     #[arg(long, group = "pager_display")]
     pub pager: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct DisplayConfig {
     pub show_thinking: Option<bool>,
     pub plain: Option<bool>,
     pub pager: Option<bool>,
+    pub include_orphans: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -9,12 +9,16 @@ use super::path::{
     decode_project_dir_name, decode_project_dir_name_to_path, format_short_name_from_path,
 };
 use super::{Conversation, LoaderMessage, Project};
+use crate::claude::HistoryEntry;
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
+use crate::tui::search::normalize_for_search;
+use chrono::{DateTime, Local, TimeZone};
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::read_dir;
+use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
@@ -484,6 +488,100 @@ pub fn load_conversations(
         debug_level,
         &format!("Total conversations loaded: {}", conversations.len()),
     );
+
+    Ok(conversations)
+}
+
+/// Load orphan conversations from history.jsonl.
+///
+/// Reads the global prompt log, groups entries by sessionId,
+/// excludes sessions that already exist in the provided set of known IDs,
+/// and returns thin Conversation objects for the orphans.
+pub fn load_orphan_conversations(known_session_ids: &HashSet<String>) -> Result<Vec<Conversation>> {
+    let history_path = super::get_history_jsonl_path()?;
+    if !history_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let file = std::fs::File::open(&history_path)?;
+    let reader = std::io::BufReader::new(file);
+
+    // Group entries by sessionId
+    let mut sessions: HashMap<String, Vec<HistoryEntry>> = HashMap::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            continue;
+        }
+        match serde_json::from_str::<HistoryEntry>(trimmed) {
+            Ok(entry) => {
+                if !known_session_ids.contains(&entry.session_id) {
+                    sessions
+                        .entry(entry.session_id.clone())
+                        .or_default()
+                        .push(entry);
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    let mut conversations: Vec<Conversation> = sessions
+        .into_values()
+        .map(|mut entries| {
+            // Sort by timestamp ascending
+            entries.sort_by_key(|e| e.timestamp);
+
+            let last_ts = entries.last().map(|e| e.timestamp).unwrap_or(0);
+            let timestamp: DateTime<Local> = Local
+                .timestamp_millis_opt(last_ts as i64)
+                .single()
+                .unwrap_or_else(Local::now);
+
+            let project_path_str = &entries[0].project;
+            let project_path = PathBuf::from(project_path_str);
+            let project_name = project_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| format_short_name_from_path(&project_path));
+
+            let prompts: Vec<&str> = entries.iter().map(|e| e.display.as_str()).collect();
+            let all_prompts = prompts.join("\n");
+            let search_text_lower = normalize_for_search(&format!(
+                "{} {}",
+                project_name, all_prompts
+            ));
+
+            Conversation {
+                path: PathBuf::new(), // empty = orphan sentinel
+                index: 0,
+                timestamp,
+                preview: all_prompts.clone(),
+                preview_first: all_prompts.clone(),
+                preview_last: all_prompts.clone(),
+                full_text: all_prompts,
+                search_text_lower,
+                project_name: Some(project_name),
+                project_path: Some(project_path),
+                cwd: None,
+                message_count: entries.len(),
+                parse_errors: vec![],
+                summary: None,
+                custom_title: None,
+                model: None,
+                total_tokens: 0,
+                duration_minutes: None,
+            }
+        })
+        .collect();
+
+    // Sort by timestamp (newest first)
+    conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
     Ok(conversations)
 }

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 // Re-export public API
 pub use loader::{
     delete_session_by_uuid, find_jsonl_by_uuid, load_all_conversations,
-    load_all_conversations_streaming,
+    load_all_conversations_streaming, load_orphan_conversations,
 };
 pub use parser::process_conversation_file;
 pub use path::{convert_path_to_project_dir_name, format_short_name_from_path, is_same_project};
@@ -74,6 +74,13 @@ pub struct Conversation {
     pub duration_minutes: Option<u64>,
 }
 
+impl Conversation {
+    /// Returns true if this is an orphan session (from history.jsonl, no conversation file exists)
+    pub fn is_orphan(&self) -> bool {
+        self.path.as_os_str().is_empty()
+    }
+}
+
 pub struct Project {
     pub name: String,         // directory name (encoded)
     pub display_name: String, // heuristic decoded path
@@ -92,11 +99,10 @@ pub enum LoaderMessage {
     Done,
 }
 
-/// Get the root Claude projects directory (~/.claude/projects)
-/// Respects CLAUDE_CONFIG_DIR env variable if set.
-pub fn get_claude_projects_root() -> Result<PathBuf> {
-    let claude_dir = if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
-        PathBuf::from(config_dir)
+/// Get the Claude config directory (~/.claude or $CLAUDE_CONFIG_DIR)
+fn get_claude_config_dir() -> Result<PathBuf> {
+    if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        Ok(PathBuf::from(config_dir))
     } else {
         let home_dir = home::home_dir().ok_or_else(|| {
             AppError::Io(std::io::Error::new(
@@ -104,10 +110,20 @@ pub fn get_claude_projects_root() -> Result<PathBuf> {
                 "Could not determine home directory",
             ))
         })?;
-        home_dir.join(".claude")
-    };
+        Ok(home_dir.join(".claude"))
+    }
+}
 
-    Ok(claude_dir.join("projects"))
+/// Get the root Claude projects directory (~/.claude/projects)
+/// Respects CLAUDE_CONFIG_DIR env variable if set.
+pub fn get_claude_projects_root() -> Result<PathBuf> {
+    Ok(get_claude_config_dir()?.join("projects"))
+}
+
+/// Get the path to history.jsonl (~/.claude/history.jsonl)
+/// Respects CLAUDE_CONFIG_DIR env variable if set.
+pub(crate) fn get_history_jsonl_path() -> Result<PathBuf> {
+    Ok(get_claude_config_dir()?.join("history.jsonl"))
 }
 
 /// Get the Claude projects directory for the current working directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,13 @@ fn run() -> Result<()> {
     // Always use streaming global loader for all conversations
     let rx = history::load_all_conversations_streaming(show_last, args.debug);
 
+    let include_orphans = resolve_bool_setting(
+        args.include_orphans,
+        false,
+        display_config.include_orphans,
+        false,
+    );
+
     let (conversations, selected_path) = match tui::run_with_loader(
         rx,
         tool_display,
@@ -298,6 +305,7 @@ fn run() -> Result<()> {
         keys,
         workspace_filter,
         current_project_dir_name,
+        include_orphans,
     )? {
         (tui::Action::Select(path), convs) => (convs, path),
         (tui::Action::Resume(path), convs) => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -269,6 +269,12 @@ pub struct App {
     workspace_filter: bool,
     /// The encoded project directory name for the current workspace (for filtering)
     current_project_dir_name: Option<String>,
+    /// Whether orphan sessions (from history.jsonl) are shown
+    include_orphans: bool,
+    /// Loaded orphan conversations, held separately for toggle
+    orphan_conversations: Vec<Conversation>,
+    /// Whether history.jsonl exists (to show/hide keybind indicator)
+    orphans_available: bool,
     /// Channel to send commands to the background search worker
     search_tx: mpsc::Sender<SearchCommand>,
     /// Channel to receive results from the background search worker
@@ -317,6 +323,9 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            include_orphans: false,
+            orphan_conversations: Vec::new(),
+            orphans_available: false,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -331,8 +340,14 @@ impl App {
         keys: KeyBindings,
         workspace_filter: bool,
         current_project_dir_name: Option<String>,
+        include_orphans: bool,
     ) -> Self {
         let (search_tx, search_rx) = spawn_search_worker();
+
+        // Check if history.jsonl exists (cheap stat, no parsing)
+        let orphans_available = crate::history::get_history_jsonl_path()
+            .map(|p| p.exists())
+            .unwrap_or(false);
 
         Self {
             conversations: Vec::new(),
@@ -352,6 +367,9 @@ impl App {
             keys,
             workspace_filter,
             current_project_dir_name,
+            include_orphans,
+            orphan_conversations: Vec::new(),
+            orphans_available,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -419,6 +437,9 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            include_orphans: false,
+            orphan_conversations: Vec::new(),
+            orphans_available: false,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -472,6 +493,30 @@ impl App {
 
     /// Mark loading as complete: sort, precompute search, and transition to Ready
     pub fn finish_loading(&mut self) {
+        // If --include-orphans was set, load orphans now that we have all session IDs
+        if self.include_orphans && self.orphans_available {
+            let known_ids: std::collections::HashSet<String> = self
+                .conversations
+                .iter()
+                .filter_map(|c| {
+                    c.path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_string())
+                })
+                .collect();
+
+            match crate::history::load_orphan_conversations(&known_ids) {
+                Ok(orphans) => {
+                    self.orphan_conversations = orphans.clone();
+                    self.conversations.extend(orphans);
+                }
+                Err(_) => {
+                    self.include_orphans = false;
+                }
+            }
+        }
+
         // Sort all conversations by timestamp (newest first)
         self.conversations
             .sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -792,6 +837,104 @@ impl App {
         self.current_project_dir_name.is_some()
     }
 
+    pub fn include_orphans(&self) -> bool {
+        self.include_orphans
+    }
+
+    pub fn orphans_available(&self) -> bool {
+        self.orphans_available
+    }
+
+    /// Get the currently selected conversation (if any)
+    fn get_selected_conversation(&self) -> Option<&Conversation> {
+        self.selected
+            .and_then(|sel| self.filtered.get(sel))
+            .map(|&idx| &self.conversations[idx])
+    }
+
+    /// Toggle orphan sessions visibility
+    fn toggle_include_orphans(&mut self) {
+        if !self.orphans_available {
+            return;
+        }
+
+        self.include_orphans = !self.include_orphans;
+
+        if self.include_orphans && self.orphan_conversations.is_empty() {
+            // Lazy-load orphans on first enable
+            let known_ids: std::collections::HashSet<String> = self
+                .conversations
+                .iter()
+                .filter_map(|c| {
+                    c.path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_string())
+                })
+                .collect();
+
+            match crate::history::load_orphan_conversations(&known_ids) {
+                Ok(orphans) => {
+                    self.orphan_conversations = orphans;
+                    if self.orphan_conversations.is_empty() {
+                        self.orphans_available = false;
+                        self.include_orphans = false;
+                        self.status_message = Some((
+                            "No orphan sessions found".to_string(),
+                            std::time::Instant::now(),
+                        ));
+                        return;
+                    }
+                }
+                Err(_) => {
+                    self.include_orphans = false;
+                    self.status_message = Some((
+                        "Failed to load history.jsonl".to_string(),
+                        std::time::Instant::now(),
+                    ));
+                    return;
+                }
+            }
+        }
+
+        if self.include_orphans {
+            // Merge orphans into conversations
+            self.conversations
+                .extend(self.orphan_conversations.clone());
+
+            // Re-sort and reindex
+            self.conversations
+                .sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            for (idx, conv) in self.conversations.iter_mut().enumerate() {
+                conv.index = idx;
+            }
+
+            // Rebuild search index
+            self.searchable = search::precompute_search_text(&self.conversations);
+            let _ = self.search_tx.send(SearchCommand::UpdateData {
+                conversations: Arc::new(self.conversations.clone()),
+                searchable: Arc::new(self.searchable.clone()),
+            });
+        } else {
+            // Remove orphans from conversations
+            self.conversations.retain(|c| !c.is_orphan());
+
+            // Reindex
+            for (idx, conv) in self.conversations.iter_mut().enumerate() {
+                conv.index = idx;
+            }
+
+            // Rebuild search index
+            self.searchable = search::precompute_search_text(&self.conversations);
+            let _ = self.search_tx.send(SearchCommand::UpdateData {
+                conversations: Arc::new(self.conversations.clone()),
+                searchable: Arc::new(self.searchable.clone()),
+            });
+        }
+
+        self.update_filter();
+    }
+
     /// Toggle between global and workspace-only view
     fn toggle_workspace_filter(&mut self) {
         // Only toggle if we have a workspace context
@@ -1087,6 +1230,23 @@ impl App {
             None => return,
         };
 
+        // Orphan sessions: export from in-memory text
+        if path.as_os_str().is_empty() {
+            let text = self.get_orphan_export_text();
+            let result = if to_clipboard {
+                match crate::tui::export::copy_to_system_clipboard(&text) {
+                    Ok(()) => crate::tui::export::ExportResult {
+                        message: "Copied to clipboard".to_string(),
+                    },
+                    Err(e) => crate::tui::export::ExportResult { message: e },
+                }
+            } else {
+                crate::tui::export::export_text_to_file(&text, format)
+            };
+            self.status_message = Some((result.message, std::time::Instant::now()));
+            return;
+        }
+
         let result = if to_clipboard {
             crate::tui::export::export_to_clipboard(&path, format, options)
         } else {
@@ -1094,6 +1254,26 @@ impl App {
         };
 
         self.status_message = Some((result.message, std::time::Instant::now()));
+    }
+
+    /// Get export text for orphan session from the selected conversation's full_text
+    fn get_orphan_export_text(&self) -> String {
+        let conv_idx = self
+            .selected
+            .and_then(|sel| self.filtered.get(sel))
+            .copied();
+        if let Some(idx) = conv_idx {
+            let conv = &self.conversations[idx];
+            // Format each prompt with "You: " prefix
+            conv.full_text
+                .split('\n')
+                .filter(|s| !s.is_empty())
+                .map(|prompt| format!("You: {}", prompt))
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        } else {
+            String::new()
+        }
     }
 
     /// Handle a key event, returns Some(Action) if the app should exit
@@ -1138,11 +1318,25 @@ impl App {
         // Check configurable keybindings before the match block
         if self.keys.delete.matches(code, modifiers) {
             if !self.single_file_mode {
-                self.dialog_mode = DialogMode::ConfirmDelete;
+                if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                    self.status_message = Some((
+                        "Cannot delete: no session file exists".to_string(),
+                        std::time::Instant::now(),
+                    ));
+                } else {
+                    self.dialog_mode = DialogMode::ConfirmDelete;
+                }
             }
             return None;
         }
         if self.keys.resume.matches(code, modifiers) {
+            if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                self.status_message = Some((
+                    "Cannot resume: session data no longer exists".to_string(),
+                    std::time::Instant::now(),
+                ));
+                return None;
+            }
             return if self.single_file_mode {
                 None
             } else {
@@ -1150,6 +1344,13 @@ impl App {
             };
         }
         if self.keys.fork.matches(code, modifiers) {
+            if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                self.status_message = Some((
+                    "Cannot fork: session data no longer exists".to_string(),
+                    std::time::Instant::now(),
+                ));
+                return None;
+            }
             return if self.single_file_mode {
                 None
             } else {
@@ -1316,10 +1517,12 @@ impl App {
             // Show path
             KeyCode::Char('p') => {
                 if let AppMode::View(ref state) = self.app_mode {
-                    self.status_message = Some((
-                        state.conversation_path.display().to_string(),
-                        std::time::Instant::now(),
-                    ));
+                    let msg = if state.conversation_path.as_os_str().is_empty() {
+                        "Orphan session: no file path".to_string()
+                    } else {
+                        state.conversation_path.display().to_string()
+                    };
+                    self.status_message = Some((msg, std::time::Instant::now()));
                 }
                 None
             }
@@ -1512,6 +1715,11 @@ impl App {
                 KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                     Some(Action::Quit)
                 }
+                // Ctrl+G: toggle orphan sessions
+                KeyCode::Char('g') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.toggle_include_orphans();
+                    None
+                }
                 // Ctrl+Left: move cursor one word left
                 KeyCode::Left if modifiers.contains(KeyModifiers::CONTROL) => {
                     self.cursor_word_left();
@@ -1646,16 +1854,40 @@ impl App {
 
         // Check configurable keybindings before the match block
         if self.keys.delete.matches(code, modifiers) {
-            if self.get_selected_path().is_some() {
+            if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                self.status_message = Some((
+                    "Cannot delete: no session file exists".to_string(),
+                    std::time::Instant::now(),
+                ));
+            } else if self.get_selected_path().is_some() {
                 self.dialog_mode = DialogMode::ConfirmDelete;
             }
             return None;
         }
         if self.keys.resume.matches(code, modifiers) {
+            if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                self.status_message = Some((
+                    "Cannot resume: session data no longer exists".to_string(),
+                    std::time::Instant::now(),
+                ));
+                return None;
+            }
             return self.get_selected_path().map(Action::Resume);
         }
         if self.keys.fork.matches(code, modifiers) {
+            if self.get_selected_conversation().is_some_and(|c| c.is_orphan()) {
+                self.status_message = Some((
+                    "Cannot fork: session data no longer exists".to_string(),
+                    std::time::Instant::now(),
+                ));
+                return None;
+            }
             return self.get_selected_path().map(Action::ForkResume);
+        }
+        // Ctrl+G: toggle orphan sessions
+        if code == KeyCode::Char('g') && modifiers.contains(KeyModifiers::CONTROL) {
+            self.toggle_include_orphans();
+            return None;
         }
 
         // Normal handling when ready
@@ -1847,8 +2079,38 @@ impl App {
         let Some(&conv_idx) = self.filtered.get(selected) else {
             return;
         };
-        let path = self.conversations[conv_idx].path.clone();
+        let conv = &self.conversations[conv_idx];
 
+        if conv.is_orphan() {
+            // Build view in-memory from prompt text for orphan sessions
+            let (lines, messages) = Self::render_orphan_prompts(conv, content_width);
+            let total_lines = lines.len();
+            let first_msg = if messages.is_empty() {
+                None
+            } else {
+                Some(0)
+            };
+            self.app_mode = AppMode::View(ViewState {
+                conversation_path: PathBuf::new(),
+                scroll_offset: 0,
+                rendered_lines: lines,
+                total_lines,
+                tool_display: self.tool_display,
+                show_thinking: self.show_thinking,
+                show_timing: self.show_timing,
+                content_width,
+                search_mode: ViewSearchMode::Off,
+                search_query: String::new(),
+                search_matches: Vec::new(),
+                current_match: 0,
+                message_ranges: messages,
+                focused_message: first_msg,
+                message_nav_active: false,
+            });
+            return;
+        }
+
+        let path = conv.path.clone();
         let options = RenderOptions {
             tool_display: self.tool_display,
             show_thinking: self.show_thinking,
@@ -1887,6 +2149,92 @@ impl App {
                     Some((format!("Failed to open: {}", e), std::time::Instant::now()));
             }
         }
+    }
+
+    /// Render orphan session prompts as in-memory RenderedLines
+    fn render_orphan_prompts(
+        conv: &Conversation,
+        content_width: usize,
+    ) -> (Vec<RenderedLine>, Vec<crate::tui::viewer::MessageRange>) {
+        use crate::tui::viewer::MessageRange;
+
+        let th = crate::tui::theme::detect_theme();
+        let name_width = 9; // matches viewer::NAME_WIDTH
+
+        let mut lines = Vec::new();
+        let mut messages = Vec::new();
+
+        // Header line: "Orphan session — prompts only (no conversation data)"
+        lines.push(RenderedLine {
+            spans: vec![
+                (
+                    " ".repeat(name_width),
+                    LineStyle::default(),
+                ),
+                (
+                    " Orphan session — prompts only (no conversation data)".to_string(),
+                    LineStyle {
+                        fg: Some((140, 140, 140)),
+                        dimmed: true,
+                        ..Default::default()
+                    },
+                ),
+            ],
+        });
+        lines.push(RenderedLine { spans: vec![] });
+
+        for prompt_text in conv.full_text.split('\n') {
+            if prompt_text.is_empty() {
+                continue;
+            }
+
+            let start_line = lines.len();
+
+            // Wrap text to content_width
+            let wrapped = textwrap::wrap(prompt_text, content_width);
+
+            for (i, line_text) in wrapped.iter().enumerate() {
+                let mut spans = Vec::new();
+
+                // Name label on first line, padding on continuation
+                let name_text = if i == 0 {
+                    format!("{:>width$}", "You", width = name_width)
+                } else {
+                    " ".repeat(name_width)
+                };
+
+                spans.push((
+                    name_text,
+                    LineStyle {
+                        fg: Some(th.text_primary),
+                        bold: true,
+                        ..Default::default()
+                    },
+                ));
+
+                spans.push((
+                    format!(" {}", line_text),
+                    LineStyle {
+                        fg: Some(th.text_primary),
+                        ..Default::default()
+                    },
+                ));
+
+                lines.push(RenderedLine { spans });
+            }
+
+            let end_line = lines.len();
+            messages.push(MessageRange {
+                entry_index: messages.len(),
+                start_line,
+                end_line,
+            });
+
+            // Blank line between prompts
+            lines.push(RenderedLine { spans: vec![] });
+        }
+
+        (lines, messages)
     }
 
     /// Exit view mode and return to list
@@ -2002,6 +2350,23 @@ impl App {
         use crate::tui::viewer::{RenderOptions, render_conversation};
 
         if let AppMode::View(ref mut state) = self.app_mode {
+            // Orphan sessions: re-render from in-memory data
+            if state.conversation_path.as_os_str().is_empty() {
+                let conv_idx = self
+                    .selected
+                    .and_then(|sel| self.filtered.get(sel))
+                    .copied();
+                if let Some(idx) = conv_idx {
+                    let conv = &self.conversations[idx];
+                    let (lines, messages) =
+                        Self::render_orphan_prompts(conv, state.content_width);
+                    state.total_lines = lines.len();
+                    state.rendered_lines = lines;
+                    state.message_ranges = messages;
+                }
+                return;
+            }
+
             let options = RenderOptions {
                 tool_display: state.tool_display,
                 show_thinking: state.show_thinking,
@@ -2177,6 +2542,48 @@ impl App {
             return;
         };
 
+        // Orphan sessions: copy prompt text directly from rendered lines
+        if path.as_os_str().is_empty() {
+            if let AppMode::View(ref state) = self.app_mode
+                && let Some(idx) = state.focused_message
+                && let Some(msg) = state.message_ranges.get(idx)
+            {
+                // Extract text from the rendered lines for this message
+                let text: String = state.rendered_lines[msg.start_line..msg.end_line]
+                    .iter()
+                    .map(|line| {
+                        line.spans
+                            .iter()
+                            .map(|(text, _)| text.as_str())
+                            .collect::<String>()
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+                    .trim()
+                    .to_string();
+
+                if text.is_empty() {
+                    self.status_message = Some((
+                        "No text content in this message".to_string(),
+                        std::time::Instant::now(),
+                    ));
+                } else {
+                    match crate::tui::export::copy_to_system_clipboard(&text) {
+                        Ok(()) => {
+                            self.status_message = Some((
+                                "Message copied to clipboard".to_string(),
+                                std::time::Instant::now(),
+                            ));
+                        }
+                        Err(e) => {
+                            self.status_message = Some((e, std::time::Instant::now()));
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
         let options = if let AppMode::View(ref state) = self.app_mode {
             crate::tui::export::ExportOptions {
                 show_tools: state.tool_display.is_visible(),
@@ -2301,6 +2708,7 @@ pub fn run_with_loader(
     keys: KeyBindings,
     workspace_filter: bool,
     current_project_dir_name: Option<String>,
+    include_orphans: bool,
 ) -> Result<(Action, Vec<Conversation>)> {
     // Set up panic hook to restore terminal
     let original_hook = std::panic::take_hook();
@@ -2317,6 +2725,7 @@ pub fn run_with_loader(
         keys,
         workspace_filter,
         current_project_dir_name,
+        include_orphans,
     );
 
     loop {

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -92,6 +92,22 @@ pub fn export_to_file(
     }
 }
 
+/// Export pre-generated text to a file (for orphan sessions that have no JSONL file)
+pub fn export_text_to_file(text: &str, format: ExportFormat) -> ExportResult {
+    let timestamp = Local::now().format("%Y-%m-%d-%H%M%S");
+    let ext = format.extension();
+    let filename = format!("conversation-{}.{}", timestamp, ext);
+
+    match fs::write(&filename, text) {
+        Ok(_) => ExportResult {
+            message: format!("Exported to {}", filename),
+        },
+        Err(e) => ExportResult {
+            message: format!("Failed to write: {}", e),
+        },
+    }
+}
+
 /// Copy text to the system clipboard.
 ///
 /// On Linux, selects clipboard tools based on the display server: `wl-copy`

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -215,6 +215,22 @@ fn render_list_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         ]);
     }
 
+    // Orphan sessions toggle (only when history.jsonl has orphans)
+    if app.orphans_available() {
+        let orphan_label = if app.include_orphans() { "On" } else { "Off" };
+        let orphan_val_style = if app.include_orphans() {
+            Style::default().fg(rgb(th().accent)).bold()
+        } else {
+            label_style
+        };
+        spans.extend([
+            Span::styled("^G", key_style),
+            Span::styled("\u{b7}", label_style),
+            Span::styled(orphan_label, orphan_val_style),
+            Span::raw("  "),
+        ]);
+    }
+
     spans.extend([
         Span::styled("?", key_style),
         Span::styled("help  ", label_style),
@@ -250,7 +266,9 @@ fn header_fits_single_line(conv: &crate::history::Conversation, terminal_width: 
         .map(|m| format_model_name(m).len() + 3) // + " · "
         .unwrap_or(0);
 
-    let msg_count_len = if conv.message_count == 1 {
+    let msg_count_len = if conv.is_orphan() {
+        if conv.message_count == 1 { "1 prompt".len() } else { format!("{} prompts", conv.message_count).len() }
+    } else if conv.message_count == 1 {
         "1 message".len()
     } else {
         format!("{} messages", conv.message_count).len()
@@ -367,7 +385,13 @@ fn render_view_header(frame: &mut Frame, app: &App, state: &ViewState, area: Rec
         let project = conv.project_name.as_deref().unwrap_or("Unknown");
         let custom_title = conv.custom_title.clone();
         let model = conv.model.as_ref().map(|m| format_model_name(m));
-        let msg_count = if conv.message_count == 1 {
+        let msg_count = if conv.is_orphan() {
+            if conv.message_count == 1 {
+                "1 prompt".to_string()
+            } else {
+                format!("{} prompts", conv.message_count)
+            }
+        } else if conv.message_count == 1 {
             "1 message".to_string()
         } else {
             format!("{} messages", conv.message_count)
@@ -630,25 +654,32 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
     let key_style = Style::default().fg(rgb(th().accent));
     let label_style = Style::default().fg(rgb(th().text_muted));
 
-    // Fixed-width status labels to prevent jumping when toggling
-    let tools_status = state.tool_display.status_label();
-    let thinking_status = if state.show_thinking { "on " } else { "off" };
-    let timing_status = if state.show_timing { "on " } else { "off" };
+    let is_orphan = state.conversation_path.as_os_str().is_empty();
 
     let mut spans = vec![
         Span::raw("  "),
         Span::styled(scroll_pos, Style::default().fg(rgb(th().text_secondary))),
         Span::raw("  "),
-        Span::styled("t", key_style),
-        Span::styled(format!("ools·{} ", tools_status), label_style),
-        Span::styled("T", key_style),
-        Span::styled(format!("hink·{} ", thinking_status), label_style),
-        Span::styled("i", key_style),
-        Span::styled(format!("nfo·{}", timing_status), label_style),
-        Span::raw("  "),
-        Span::styled("│", label_style),
-        Span::raw("  "),
     ];
+
+    // Tools/Think/Info toggles are not relevant for orphan sessions (prompts only)
+    if !is_orphan {
+        let tools_status = state.tool_display.status_label();
+        let thinking_status = if state.show_thinking { "on " } else { "off" };
+        let timing_status = if state.show_timing { "on " } else { "off" };
+
+        spans.extend([
+            Span::styled("t", key_style),
+            Span::styled(format!("ools·{} ", tools_status), label_style),
+            Span::styled("T", key_style),
+            Span::styled(format!("hink·{} ", thinking_status), label_style),
+            Span::styled("i", key_style),
+            Span::styled(format!("nfo·{}", timing_status), label_style),
+            Span::raw("  "),
+            Span::styled("│", label_style),
+            Span::raw("  "),
+        ]);
+    }
 
     if state.search_mode == ViewSearchMode::Active {
         spans.extend([
@@ -669,12 +700,19 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
             Span::styled("xport  ", label_style),
             Span::styled("y", key_style),
             Span::styled("ank  ", label_style),
-            Span::styled(app.keys().resume.short_label(), key_style),
-            Span::styled(" resume  ", label_style),
-            Span::styled(app.keys().fork.short_label(), key_style),
-            Span::styled(" fork  ", label_style),
-            Span::styled(app.keys().delete.short_label(), key_style),
-            Span::styled(" del  ", label_style),
+        ]);
+        // Resume/fork/delete not available for orphan sessions
+        if !is_orphan {
+            spans.extend([
+                Span::styled(app.keys().resume.short_label(), key_style),
+                Span::styled(" resume  ", label_style),
+                Span::styled(app.keys().fork.short_label(), key_style),
+                Span::styled(" fork  ", label_style),
+                Span::styled(app.keys().delete.short_label(), key_style),
+                Span::styled(" del  ", label_style),
+            ]);
+        }
+        spans.extend([
             Span::styled("q", key_style),
             Span::styled("uit", label_style),
         ]);
@@ -1065,6 +1103,7 @@ fn render_help_overlay(
             ("PgUp / PgDn".into(), "Jump by page"),
             ("Home / End".into(), "Jump to first/last"),
             ("Tab".into(), "Toggle scope (All/Project)"),
+            ("Ctrl+G".into(), "Toggle orphan sessions"),
             ("Enter".into(), "Open viewer"),
             ("Ctrl+O".into(), "Select and exit"),
             ("Ctrl+W".into(), "Delete word"),
@@ -1185,8 +1224,14 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
             // Format timestamp (hybrid: relative for recent, absolute for older)
             let (timestamp, recency) = format_timestamp(conv.timestamp, now);
 
-            // Format message count
-            let msg_count = if conv.message_count == 1 {
+            // Format message count — use "prompts" for orphan sessions
+            let msg_count = if conv.is_orphan() {
+                if conv.message_count == 1 {
+                    "1 prompt".to_string()
+                } else {
+                    format!("{} prompts", conv.message_count)
+                }
+            } else if conv.message_count == 1 {
                 "1 msg".to_string()
             } else {
                 format!("{} msgs", conv.message_count)


### PR DESCRIPTION
## Summary

  - Add opt-in support for "orphan" sessions — sessions that exist only in ~/.claude/history.jsonl with no corresponding .jsonl file in
  projects/
  - Toggle with Ctrl+G keybind or --include-orphans CLI flag (off by default)
  - Orphan sessions are fully searchable, openable (in-memory prompt rendering), and support yank/export
  - Resume, fork, and delete are disabled with clear status messages

## Details

  - Parses history.jsonl, groups by sessionId, filters out sessions that still have files on disk
  - Lazy-loads on first toggle to avoid startup cost
  - Enter opens an in-memory view showing all prompts with You labels (no temp files)
  - Yank and export read from rendered lines / formatted text, bypassing the normal file-based path
  - Config file support: display.include_orphans = true

## Test plan

  - Start with --include-orphans, verify orphan sessions appear in list
  - Toggle Ctrl+G on/off, verify sessions appear/disappear
  - Enter an orphan session, verify prompts render correctly
  - Yank a message in orphan view mode, verify clipboard content
  - Export orphan session to file and clipboard
  - Verify Ctrl+R/F/X show appropriate "cannot" messages
  - Search with orphans visible, verify prompt text matches
  - Workspace filter + orphans: verify project filtering applies






[orphan-sessions-openspec-proposal.zip](https://github.com/user-attachments/files/26686316/orphan-sessions-openspec-proposal.zip)
