### PR TITLE
fix: preserve multiline tool results in viewer output

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -218,14 +218,12 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
     }
 
     fn format_tool_result(&mut self, content: Option<&serde_json::Value>) {
-        // Render markdown for string content, otherwise format as JSON
-        let rendered = match content {
-            Some(serde_json::Value::String(s)) => render_markdown(s, self.content_width),
-            _ => format_tool_content(content),
-        };
-
-        // Print with ↳ Result label
-        self.print_markdown("↳ Result", |s| s.custom_color(tool_text()), &rendered);
+        if let Some(text) = extract_tool_result_text(content) {
+            self.print_lines("↳ Result", |s| s.custom_color(tool_text()), &text);
+        } else {
+            let rendered = format_tool_content(content);
+            self.print_markdown("↳ Result", |s| s.custom_color(tool_text()), &rendered);
+        }
     }
 
     fn format_thinking(&mut self, thought: &str) {
@@ -276,7 +274,8 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
             |s| s.custom_color(dim_teal()).dimmed(),
             "<Result>",
         );
-        let content_str = format_tool_content(content);
+        let content_str =
+            extract_tool_result_text(content).unwrap_or_else(|| format_tool_content(content));
         self.print_continuation(&content_str);
     }
 }
@@ -310,7 +309,8 @@ impl<'a, W: Write + ?Sized> OutputFormatter for PlainFormatter<'a, W> {
 
     fn format_tool_result(&mut self, content: Option<&serde_json::Value>) {
         let _ = writeln!(self.writer, "Tool: <Result>");
-        let content_str = format_tool_content(content);
+        let content_str =
+            extract_tool_result_text(content).unwrap_or_else(|| format_tool_content(content));
         let _ = writeln!(self.writer, "{}", content_str);
     }
 
@@ -357,7 +357,8 @@ impl<'a, W: Write + ?Sized> OutputFormatter for PlainFormatter<'a, W> {
 
     fn format_agent_tool_result(&mut self, _agent_id: &str, content: Option<&serde_json::Value>) {
         let _ = writeln!(self.writer, "    Tool: <Result>");
-        let content_str = format_tool_content(content);
+        let content_str =
+            extract_tool_result_text(content).unwrap_or_else(|| format_tool_content(content));
         for line in content_str.lines() {
             let _ = writeln!(self.writer, "    {}", line);
         }
@@ -377,6 +378,51 @@ fn format_tool_content(content: Option<&serde_json::Value>) -> String {
             }
         }
         None => "<no content>".to_string(),
+    }
+}
+
+/// Extract plain text from tool result content for display.
+///
+/// Strings and arrays of text blocks should render as plain text, while
+/// structured data falls back to pretty-printed JSON.
+fn extract_tool_result_text(content: Option<&serde_json::Value>) -> Option<String> {
+    match content {
+        Some(serde_json::Value::String(s)) => {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s.clone())
+            }
+        }
+        Some(serde_json::Value::Array(items)) => {
+            let parts: Vec<&str> = items
+                .iter()
+                .filter_map(|item| match item {
+                    serde_json::Value::Object(map) => {
+                        let ty = map.get("type").and_then(|value| value.as_str());
+                        if ty.is_none() || ty == Some("text") {
+                            map.get("text").and_then(|value| value.as_str())
+                        } else {
+                            None
+                        }
+                    }
+                    serde_json::Value::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+                .collect();
+
+            if parts.is_empty() {
+                None
+            } else {
+                let joined = parts.join("\n\n");
+                if joined.trim().is_empty() {
+                    None
+                } else {
+                    Some(joined)
+                }
+            }
+        }
+        _ => None,
     }
 }
 
@@ -963,6 +1009,101 @@ pub fn render_to_terminal(file_path: &Path, options: &DisplayOptions) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn wrap_text_preserves_existing_newlines() {
+        let wrapped = wrap_text("line one\nline two\nline three", 80);
+        assert_eq!(wrapped, vec!["line one", "line two", "line three"]);
+    }
+
+    #[test]
+    fn ledger_tool_result_renders_text_blocks_as_plain_lines() {
+        let mut output = Vec::new();
+        let mut formatter = LedgerFormatter::new(&mut output, 80);
+        let content = json!([
+            {"type": "text", "text": "line one\nline two"},
+            {"type": "text", "text": "line three"}
+        ]);
+
+        formatter.format_tool_result(Some(&content));
+
+        let rendered = String::from_utf8(output).expect("formatter should emit utf-8");
+        assert!(rendered.contains("line one"), "missing first line: {rendered}");
+        assert!(rendered.contains("line two"), "missing second line: {rendered}");
+        assert!(rendered.contains("line three"), "missing third line: {rendered}");
+        assert!(
+            !rendered.contains("\"type\""),
+            "tool result should render text content, not raw JSON: {rendered}"
+        );
+    }
+
+    #[test]
+    fn ledger_agent_tool_result_renders_text_blocks_as_plain_lines() {
+        let mut output = Vec::new();
+        let mut formatter = LedgerFormatter::new(&mut output, 80);
+        let content = json!([
+            {"type": "text", "text": "agent line one\nagent line two"},
+            {"type": "text", "text": "agent line three"}
+        ]);
+
+        formatter.format_agent_tool_result("agent123", Some(&content));
+
+        let rendered = String::from_utf8(output).expect("formatter should emit utf-8");
+        assert!(rendered.contains("agent line one"), "missing first line: {rendered}");
+        assert!(rendered.contains("agent line two"), "missing second line: {rendered}");
+        assert!(rendered.contains("agent line three"), "missing third line: {rendered}");
+        assert!(
+            !rendered.contains("\"type\""),
+            "agent tool result should render text content, not raw JSON: {rendered}"
+        );
+    }
+
+    #[test]
+    fn plain_tool_result_renders_text_blocks_as_plain_lines() {
+        let mut output = Vec::new();
+        let mut formatter = PlainFormatter {
+            writer: &mut output,
+        };
+        let content = json!([
+            {"type": "text", "text": "line one\nline two"},
+            {"type": "text", "text": "line three"}
+        ]);
+
+        formatter.format_tool_result(Some(&content));
+
+        let rendered = String::from_utf8(output).expect("formatter should emit utf-8");
+        assert!(rendered.contains("line one"), "missing first line: {rendered}");
+        assert!(rendered.contains("line two"), "missing second line: {rendered}");
+        assert!(rendered.contains("line three"), "missing third line: {rendered}");
+        assert!(
+            !rendered.contains("\"type\""),
+            "plain tool result should render text content, not raw JSON: {rendered}"
+        );
+    }
+
+    #[test]
+    fn plain_agent_tool_result_renders_text_blocks_as_plain_lines() {
+        let mut output = Vec::new();
+        let mut formatter = PlainFormatter {
+            writer: &mut output,
+        };
+        let content = json!([
+            {"type": "text", "text": "agent line one\nagent line two"},
+            {"type": "text", "text": "agent line three"}
+        ]);
+
+        formatter.format_agent_tool_result("agent123", Some(&content));
+
+        let rendered = String::from_utf8(output).expect("formatter should emit utf-8");
+        assert!(rendered.contains("agent line one"), "missing first line: {rendered}");
+        assert!(rendered.contains("agent line two"), "missing second line: {rendered}");
+        assert!(rendered.contains("agent line three"), "missing third line: {rendered}");
+        assert!(
+            !rendered.contains("\"type\""),
+            "plain agent tool result should render text content, not raw JSON: {rendered}"
+        );
+    }
 
     #[test]
     fn process_command_message_skips_local_command_caveat() {

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -110,7 +110,6 @@ pub fn render_conversation(
     let mut lines = Vec::new();
     let mut messages = Vec::new();
     let mut entry_index: usize = 0;
-
     for line_result in reader.lines() {
         let line = line_result?;
         if line.trim().is_empty() {
@@ -1414,7 +1413,39 @@ fn render_tool_body(lines: &mut Vec<RenderedLine>, text: &str, dimmed: bool, sho
     }
 }
 
-/// Render tool result with arrow indicator and markdown
+/// Wrap plain text to fit the available width while preserving existing line breaks.
+fn wrap_plain_text_lines(text: &str, max_width: usize) -> Vec<String> {
+    if max_width == 0 {
+        return text.lines().map(|line| line.to_string()).collect();
+    }
+
+    let mut wrapped = Vec::new();
+    for line in text.lines() {
+        if line.is_empty() {
+            wrapped.push(String::new());
+            continue;
+        }
+
+        let pieces: Vec<String> = textwrap::wrap(line, max_width)
+            .into_iter()
+            .map(|piece| piece.into_owned())
+            .collect();
+
+        if pieces.is_empty() {
+            wrapped.push(String::new());
+        } else {
+            wrapped.extend(pieces);
+        }
+    }
+
+    if wrapped.is_empty() {
+        wrapped.push(String::new());
+    }
+
+    wrapped
+}
+
+/// Render tool result with arrow indicator using plain-text wrapping.
 fn render_tool_result(
     lines: &mut Vec<RenderedLine>,
     text: &str,
@@ -1422,17 +1453,15 @@ fn render_tool_result(
     timestamp: Option<&str>,
     tool_display: ToolDisplayMode,
 ) {
-    // Render markdown
-    let styled_lines = render_markdown_to_lines(text, content_width);
-
-    let total = styled_lines.len();
+    let wrapped_lines = wrap_plain_text_lines(text, content_width);
+    let total = wrapped_lines.len();
     let limit = if tool_display == ToolDisplayMode::Truncated && total > TRUNCATED_RESULT_LINES {
         TRUNCATED_RESULT_LINES
     } else {
         total
     };
 
-    for (i, styled_line) in styled_lines.iter().take(limit).enumerate() {
+    for (i, line_text) in wrapped_lines.iter().take(limit).enumerate() {
         let mut spans = Vec::new();
 
         // Timestamp prefix (only on first line if provided)
@@ -1475,10 +1504,7 @@ fn render_tool_result(
             },
         ));
 
-        // Content spans from markdown rendering
-        for (text, style) in &styled_line.spans {
-            spans.push((text.clone(), style.clone()));
-        }
+        spans.push((line_text.clone(), LineStyle::default()));
 
         lines.push(RenderedLine { spans });
     }
@@ -1875,6 +1901,18 @@ fn process_command_message(text: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::app::LineStyle;
+
+    fn lines_to_text(lines: &[RenderedLine]) -> Vec<String> {
+        lines.iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|(text, _style): &(String, LineStyle)| text.as_str())
+                    .collect::<String>()
+            })
+            .collect()
+    }
 
     /// Helper to render markdown and extract just the content text (without styling)
     fn render_to_text(input: &str, width: usize) -> String {
@@ -1889,6 +1927,26 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn test_render_tool_result_preserves_plain_multiline_text() {
+        let mut lines = Vec::new();
+        let text = "2034 }\n2035     let max_scroll = state.total_lines.saturating_sub(viewport_height);\n2036     state.scroll_offset = old_scroll.min(max_scroll);";
+
+        render_tool_result(&mut lines, text, 120, None, ToolDisplayMode::Full);
+
+        let rendered = lines_to_text(&lines);
+        assert_eq!(rendered.len(), 3, "Expected 3 lines, got:\n{rendered:#?}");
+        assert!(rendered[0].contains("2034 }"), "missing first line: {rendered:#?}");
+        assert!(
+            rendered[1].contains("2035     let max_scroll"),
+            "missing second line: {rendered:#?}"
+        );
+        assert!(
+            rendered[2].contains("2036     state.scroll_offset"),
+            "missing third line: {rendered:#?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #37

## Summary
- preserve plain multiline tool-result line breaks in the TUI viewer instead of reflowing them through markdown rendering
- render text-like tool results consistently in display paths, including text block arrays that previously fell back to JSON
- add regression coverage for multiline tool results in both viewer and display rendering

## Test Plan
- cargo test