### PR TITLE
Add exclude_projects config to hide projects from the TUI list

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,10 +460,12 @@ combinations like `"ctrl+r"` or `"alt+f"`. Only single-character keys with
 
 #### TUI options
 
-- `exclude_projects` (array of strings): Exact, case-sensitive project names to
-  hide from TUI browse/search lists. Match against the project name shown in the
-  leftmost column. Excluded conversations remain on disk and can still be opened
-  by pasting their full UUID or by passing the JSONL file path directly.
+- `exclude_projects` (array of strings): Case-sensitive project names to hide
+  from TUI browse/search lists. Match against the project name shown in the
+  leftmost column; a parent entry like `"repo"` also hides displayed worktree
+  rows like `"repo/feature"`. Excluded conversations remain on disk and can
+  still be opened by pasting their full UUID or by passing the JSONL file path
+  directly.
 
 ### Overriding config
 

--- a/README.md
+++ b/README.md
@@ -419,12 +419,6 @@ pager = true
 # Supports ctrl+<key> and alt+<key> combinations
 # fork = "alt+f"
 
-[filter]
-# Hide named projects from the TUI conversation list.
-# Match is exact and case-sensitive against the project name shown
-# on the left of each TUI row.
-# exclude_projects = ["observer-sessions", "scratch"]
-
 EOF
 ```
 
@@ -460,22 +454,6 @@ combinations like `"ctrl+r"` or `"alt+f"`. Only single-character keys with
 - `fork` (string): Fork and resume conversation (default: `"ctrl+f"`)
 - `delete` (string): Delete conversation (default: `"ctrl+x"`)
 
-#### Filter options
-
-Set under a `[filter]` section in `config.toml`.
-
-- `exclude_projects` (array of strings): Project names to hide from the TUI
-  conversation list. Match is exact and case-sensitive against the project
-  name shown in the leftmost column of each row. Excluded sessions are still
-  reachable via UUID lookup (paste a UUID into the search box) and direct
-  file input (`claude-history /path/to/file.jsonl`); only the browse list
-  hides them.
-
-  ```toml
-  [filter]
-  exclude_projects = ["observer-sessions"]
-  ```
-
 ### Overriding config
 
 Each display option has opposing flags for explicit override:
@@ -503,8 +481,6 @@ only see transcripts that are likely to matter for your recent work.
 - Skips the "Warmup / I'm Claude Code…" exchanges that are sometimes injected
   without user interaction
 - Skips conversations that only contain the `/clear` terminal command
-- Hides any project listed under `exclude_projects` in your config (see
-  [Configuration](#configuration))
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,12 @@ pager = true
 # Supports ctrl+<key> and alt+<key> combinations
 # fork = "alt+f"
 
+[filter]
+# Hide named projects from the TUI conversation list.
+# Match is exact and case-sensitive against the project name shown
+# on the left of each TUI row.
+# exclude_projects = ["observer-sessions", "scratch"]
+
 EOF
 ```
 
@@ -454,6 +460,22 @@ combinations like `"ctrl+r"` or `"alt+f"`. Only single-character keys with
 - `fork` (string): Fork and resume conversation (default: `"ctrl+f"`)
 - `delete` (string): Delete conversation (default: `"ctrl+x"`)
 
+#### Filter options
+
+Set under a `[filter]` section in `config.toml`.
+
+- `exclude_projects` (array of strings): Project names to hide from the TUI
+  conversation list. Match is exact and case-sensitive against the project
+  name shown in the leftmost column of each row. Excluded sessions are still
+  reachable via UUID lookup (paste a UUID into the search box) and direct
+  file input (`claude-history /path/to/file.jsonl`); only the browse list
+  hides them.
+
+  ```toml
+  [filter]
+  exclude_projects = ["observer-sessions"]
+  ```
+
 ### Overriding config
 
 Each display option has opposing flags for explicit override:
@@ -481,6 +503,8 @@ only see transcripts that are likely to matter for your recent work.
 - Skips the "Warmup / I'm Claude Code…" exchanges that are sometimes injected
   without user interaction
 - Skips conversations that only contain the `/clear` terminal command
+- Hides any project listed under `exclude_projects` in your config (see
+  [Configuration](#configuration))
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,10 @@ pager = true
 # Supports ctrl+<key> and alt+<key> combinations
 # fork = "alt+f"
 
+[tui]
+# Hide exact project names from TUI browse/search lists
+# exclude_projects = ["project-name", "repo/worktree"]
+
 EOF
 ```
 
@@ -453,6 +457,13 @@ combinations like `"ctrl+r"` or `"alt+f"`. Only single-character keys with
 - `resume` (string): Resume conversation (default: `"ctrl+r"`)
 - `fork` (string): Fork and resume conversation (default: `"ctrl+f"`)
 - `delete` (string): Delete conversation (default: `"ctrl+x"`)
+
+#### TUI options
+
+- `exclude_projects` (array of strings): Exact, case-sensitive project names to
+  hide from TUI browse/search lists. Match against the project name shown in the
+  leftmost column. Excluded conversations remain on disk and can still be opened
+  by pasting their full UUID or by passing the JSONL file path directly.
 
 ### Overriding config
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,47 @@ pub struct ConfigFile {
     pub display: Option<DisplayConfig>,
     pub resume: Option<ResumeConfig>,
     pub keys: Option<KeysConfig>,
+    pub tui: Option<TuiConfig>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct TuiConfig {
+    #[serde(default)]
+    pub exclude_projects: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_without_tui_defaults_to_no_excluded_projects() {
+        let config: ConfigFile = toml::from_str("").unwrap();
+        assert!(config.tui.unwrap_or_default().exclude_projects.is_empty());
+    }
+
+    #[test]
+    fn empty_tui_table_defaults_to_no_excluded_projects() {
+        let config: ConfigFile = toml::from_str("[tui]\n").unwrap();
+        assert!(config.tui.unwrap_or_default().exclude_projects.is_empty());
+    }
+
+    #[test]
+    fn tui_exclude_projects_preserves_exact_strings() {
+        let config: ConfigFile = toml::from_str(
+            r#"
+[tui]
+exclude_projects = ["Hidden", "hidden", " spaced "]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.tui.unwrap().exclude_projects,
+            vec!["Hidden", "hidden", " spaced "]
+        );
+    }
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,15 +17,6 @@ pub struct ConfigFile {
     pub display: Option<DisplayConfig>,
     pub resume: Option<ResumeConfig>,
     pub keys: Option<KeysConfig>,
-    pub filter: Option<FilterConfig>,
-}
-
-#[derive(Deserialize, Debug, Default)]
-#[serde(deny_unknown_fields)]
-pub struct FilterConfig {
-    /// Project names (as shown in the TUI list) to hide from the conversation list.
-    /// Match is exact and case-sensitive against `Conversation::project_name`.
-    pub exclude_projects: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -218,50 +209,4 @@ pub fn load_config() -> Result<ConfigFile> {
             e
         ))
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_exclude_projects_from_filter_section() {
-        let toml_text = r#"
-[filter]
-exclude_projects = ["observer-sessions", "scratch"]
-"#;
-        let cfg: ConfigFile = toml::from_str(toml_text).expect("toml parse failed");
-        let filter = cfg.filter.expect("filter section should be present");
-        assert_eq!(
-            filter.exclude_projects,
-            Some(vec!["observer-sessions".to_string(), "scratch".to_string()])
-        );
-    }
-
-    #[test]
-    fn filter_section_can_appear_after_other_sections() {
-        // TOML key/value pairs belong to whatever section header preceded them,
-        // so a top-level `exclude_projects` placed after `[keys]` would be
-        // parsed as `keys.exclude_projects`. Nesting under `[filter]` makes
-        // section ordering irrelevant.
-        let toml_text = r#"
-[keys]
-fork = "alt+f"
-
-[filter]
-exclude_projects = ["observer-sessions"]
-"#;
-        let cfg: ConfigFile = toml::from_str(toml_text).expect("toml parse failed");
-        let filter = cfg.filter.expect("filter section should be present");
-        assert_eq!(
-            filter.exclude_projects,
-            Some(vec!["observer-sessions".to_string()])
-        );
-    }
-
-    #[test]
-    fn filter_defaults_to_none() {
-        let cfg: ConfigFile = toml::from_str("").expect("toml parse failed");
-        assert!(cfg.filter.is_none());
-    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,15 @@ pub struct ConfigFile {
     pub display: Option<DisplayConfig>,
     pub resume: Option<ResumeConfig>,
     pub keys: Option<KeysConfig>,
+    pub filter: Option<FilterConfig>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FilterConfig {
+    /// Project names (as shown in the TUI list) to hide from the conversation list.
+    /// Match is exact and case-sensitive against `Conversation::project_name`.
+    pub exclude_projects: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -209,4 +218,50 @@ pub fn load_config() -> Result<ConfigFile> {
             e
         ))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_exclude_projects_from_filter_section() {
+        let toml_text = r#"
+[filter]
+exclude_projects = ["observer-sessions", "scratch"]
+"#;
+        let cfg: ConfigFile = toml::from_str(toml_text).expect("toml parse failed");
+        let filter = cfg.filter.expect("filter section should be present");
+        assert_eq!(
+            filter.exclude_projects,
+            Some(vec!["observer-sessions".to_string(), "scratch".to_string()])
+        );
+    }
+
+    #[test]
+    fn filter_section_can_appear_after_other_sections() {
+        // TOML key/value pairs belong to whatever section header preceded them,
+        // so a top-level `exclude_projects` placed after `[keys]` would be
+        // parsed as `keys.exclude_projects`. Nesting under `[filter]` makes
+        // section ordering irrelevant.
+        let toml_text = r#"
+[keys]
+fork = "alt+f"
+
+[filter]
+exclude_projects = ["observer-sessions"]
+"#;
+        let cfg: ConfigFile = toml::from_str(toml_text).expect("toml parse failed");
+        let filter = cfg.filter.expect("filter section should be present");
+        assert_eq!(
+            filter.exclude_projects,
+            Some(vec!["observer-sessions".to_string()])
+        );
+    }
+
+    #[test]
+    fn filter_defaults_to_none() {
+        let cfg: ConfigFile = toml::from_str("").expect("toml parse failed");
+        assert!(cfg.filter.is_none());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ fn run() -> Result<()> {
     let resume_config = config.resume.unwrap_or_default();
     let default_args = resume_config.default_args.as_deref().unwrap_or(&[]);
 
+    let exclude_projects = config.tui.unwrap_or_default().exclude_projects;
+
     // Disable colors globally when --no-color is passed
     if args.no_color {
         colored::control::set_override(false);
@@ -304,6 +306,7 @@ fn run() -> Result<()> {
         keys,
         workspace_filter,
         current_project_dir_name,
+        exclude_projects,
     )? {
         (tui::Action::Select(path), convs) => (convs, path),
         (tui::Action::Resume(path), convs) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,17 @@ fn run() -> Result<()> {
     // Resolve keybindings
     let keys = config::KeyBindings::from_config(config.keys);
 
+    // Materialize excluded project names into a hash set for O(1) lookup
+    let excluded_projects: std::sync::Arc<std::collections::HashSet<String>> = std::sync::Arc::new(
+        config
+            .filter
+            .as_ref()
+            .and_then(|f| f.exclude_projects.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+    );
+
     // Use positive names internally for clarity
     let show_tools = resolve_bool_setting(
         args.show_tools,
@@ -304,6 +315,7 @@ fn run() -> Result<()> {
         keys,
         workspace_filter,
         current_project_dir_name,
+        excluded_projects,
     )? {
         (tui::Action::Select(path), convs) => (convs, path),
         (tui::Action::Resume(path), convs) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,17 +84,6 @@ fn run() -> Result<()> {
     // Resolve keybindings
     let keys = config::KeyBindings::from_config(config.keys);
 
-    // Materialize excluded project names into a hash set for O(1) lookup
-    let excluded_projects: std::sync::Arc<std::collections::HashSet<String>> = std::sync::Arc::new(
-        config
-            .filter
-            .as_ref()
-            .and_then(|f| f.exclude_projects.clone())
-            .unwrap_or_default()
-            .into_iter()
-            .collect(),
-    );
-
     // Use positive names internally for clarity
     let show_tools = resolve_bool_setting(
         args.show_tools,
@@ -315,7 +304,6 @@ fn run() -> Result<()> {
         keys,
         workspace_filter,
         current_project_dir_name,
-        excluded_projects,
     )? {
         (tui::Action::Select(path), convs) => (convs, path),
         (tui::Action::Resume(path), convs) => {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2298,21 +2298,17 @@ where
                 .is_none_or(|name| !project_is_excluded(name, excluded_projects))
         })
         .filter(|&idx| {
-            if !workspace_filter {
+            let Some(project_dir_name) = current_project_dir_name.filter(|_| workspace_filter)
+            else {
                 return true;
-            }
-            current_project_dir_name.is_some_and(|project_dir_name| {
-                conversations[idx]
-                    .path
-                    .parent()
-                    .and_then(|p| p.file_name())
-                    .is_some_and(|name| {
-                        crate::history::path::is_same_project(
-                            &name.to_string_lossy(),
-                            project_dir_name,
-                        )
-                    })
-            })
+            };
+            conversations[idx]
+                .path
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|name| {
+                    crate::history::path::is_same_project(&name.to_string_lossy(), project_dir_name)
+                })
         })
         .collect()
 }
@@ -2621,6 +2617,27 @@ mod tests {
         .unwrap();
 
         app.receive_search_results();
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+    }
+
+    #[test]
+    fn workspace_filter_without_project_context_keeps_rows() {
+        let mut app = App::new_loading(
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            true,
+            None,
+            vec![],
+        );
+
+        app.append_conversations(vec![conversation(
+            Some("Visible"),
+            "-tmp-visible",
+            "22222222-2222-4222-8222-222222222222",
+            "needle",
+        )]);
+
         assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,25 +14,11 @@ use crossterm::event::{
 };
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
-use std::collections::HashSet;
 use std::io::{self, Stdout};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
-
-/// Returns true if the conversation's project_name is in the excluded set.
-/// Match is exact and case-sensitive. A conversation with no project_name is
-/// never excluded (defensive: keep showing data we can't classify).
-pub(crate) fn is_project_excluded(conv: &Conversation, excluded: &HashSet<String>) -> bool {
-    if excluded.is_empty() {
-        return false;
-    }
-    match conv.project_name.as_deref() {
-        Some(name) => excluded.contains(name),
-        None => false,
-    }
-}
 
 /// Result of running the TUI
 pub enum Action {
@@ -151,7 +137,6 @@ enum SearchCommand {
     UpdateData {
         conversations: Arc<Vec<Conversation>>,
         searchable: Arc<Vec<SearchableConversation>>,
-        excluded_projects: Arc<HashSet<String>>,
     },
     /// Run a search query
     Search {
@@ -179,18 +164,15 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
         .spawn(move || {
             let mut conversations: Arc<Vec<Conversation>> = Arc::new(Vec::new());
             let mut searchable: Arc<Vec<SearchableConversation>> = Arc::new(Vec::new());
-            let mut excluded_projects: Arc<HashSet<String>> = Arc::new(HashSet::new());
 
             while let Ok(cmd) = cmd_rx.recv() {
                 match cmd {
                     SearchCommand::UpdateData {
                         conversations: c,
                         searchable: s,
-                        excluded_projects: e,
                     } => {
                         conversations = c;
                         searchable = s;
-                        excluded_projects = e;
                     }
                     SearchCommand::Search {
                         mut query,
@@ -205,11 +187,9 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
                                 SearchCommand::UpdateData {
                                     conversations: c,
                                     searchable: s,
-                                    excluded_projects: e,
                                 } => {
                                     conversations = c;
                                     searchable = s;
-                                    excluded_projects = e;
                                 }
                                 SearchCommand::Search {
                                     query: q,
@@ -227,12 +207,6 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
 
                         let now = chrono::Local::now();
                         let mut filtered = search::search(&conversations, &searchable, &query, now);
-
-                        if !excluded_projects.is_empty() {
-                            filtered.retain(|&idx| {
-                                !is_project_excluded(&conversations[idx], &excluded_projects)
-                            });
-                        }
 
                         if workspace_filter && let Some(ref dir_name) = project_dir_name {
                             filtered.retain(|&idx| {
@@ -298,8 +272,6 @@ pub struct App {
     workspace_filter: bool,
     /// The encoded project directory name for the current workspace (for filtering)
     current_project_dir_name: Option<String>,
-    /// Project names to exclude from the TUI list. Loaded once from config at startup.
-    excluded_projects: Arc<HashSet<String>>,
     /// Channel to send commands to the background search worker
     search_tx: mpsc::Sender<SearchCommand>,
     /// Channel to receive results from the background search worker
@@ -328,7 +300,6 @@ impl App {
         let _ = search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(conversations.clone()),
             searchable: Arc::new(searchable.clone()),
-            excluded_projects: Arc::new(HashSet::new()),
         });
 
         Self {
@@ -349,7 +320,6 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
-            excluded_projects: Arc::new(HashSet::new()),
             search_tx,
             search_rx,
             search_generation: 0,
@@ -364,7 +334,6 @@ impl App {
         keys: KeyBindings,
         workspace_filter: bool,
         current_project_dir_name: Option<String>,
-        excluded_projects: Arc<HashSet<String>>,
     ) -> Self {
         let (search_tx, search_rx) = spawn_search_worker();
 
@@ -386,7 +355,6 @@ impl App {
             keys,
             workspace_filter,
             current_project_dir_name,
-            excluded_projects,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -454,7 +422,6 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
-            excluded_projects: Arc::new(HashSet::new()),
             search_tx,
             search_rx,
             search_generation: 0,
@@ -477,11 +444,6 @@ impl App {
         // (Items shown in arrival order initially, will be re-sorted in finish_loading)
         // Apply workspace filter during loading too
         for idx in start_idx..end_idx {
-            // Hide projects listed in config exclude_projects
-            if is_project_excluded(&self.conversations[idx], &self.excluded_projects) {
-                continue;
-            }
-            // Apply workspace filter during loading too
             if self.workspace_filter
                 && let Some(ref project_dir_name) = self.current_project_dir_name
                 && self.conversations[idx]
@@ -529,14 +491,13 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
-            excluded_projects: Arc::clone(&self.excluded_projects),
         });
 
         self.loading_state = LoadingState::Ready;
 
-        // Apply filter (handles query, workspace filter, and exclusions)
-        if self.query.is_empty() && !self.workspace_filter && self.excluded_projects.is_empty() {
-            // No query, no workspace filter, no exclusions - show all
+        // Apply filter (handles both query and workspace filter)
+        if self.query.is_empty() && !self.workspace_filter {
+            // No query and no workspace filter - show all
             self.filtered = (0..self.conversations.len()).collect();
             self.selected = if self.filtered.is_empty() {
                 None
@@ -544,7 +505,7 @@ impl App {
                 Some(0)
             };
         } else {
-            // Has query, workspace filter, or exclusions active - apply full filter
+            // Has query or workspace filter active - apply full filter
             self.update_filter();
         }
     }
@@ -577,14 +538,6 @@ impl App {
 
         let now = Local::now();
         let mut filtered = search::search(&self.conversations, &self.searchable, &self.query, now);
-
-        // Hide projects listed in config exclude_projects.
-        // `&self.excluded_projects` deref-coerces from `&Arc<HashSet<_>>` to `&HashSet<_>`.
-        if !self.excluded_projects.is_empty() {
-            filtered.retain(|&idx| {
-                !is_project_excluded(&self.conversations[idx], &self.excluded_projects)
-            });
-        }
 
         // Apply workspace filter if active
         // Matches conversations from the same project, including workmux worktrees
@@ -697,7 +650,6 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
-            excluded_projects: Arc::clone(&self.excluded_projects),
         });
 
         Some(idx)
@@ -1025,7 +977,6 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
-            excluded_projects: Arc::clone(&self.excluded_projects),
         });
         self.search_generation += 1;
     }
@@ -2502,7 +2453,6 @@ pub fn run_with_loader(
     keys: KeyBindings,
     workspace_filter: bool,
     current_project_dir_name: Option<String>,
-    excluded_projects: Arc<HashSet<String>>,
 ) -> Result<(Action, Vec<Conversation>)> {
     // Set up panic hook to restore terminal
     let original_hook = std::panic::take_hook();
@@ -2519,7 +2469,6 @@ pub fn run_with_loader(
         keys,
         workspace_filter,
         current_project_dir_name,
-        excluded_projects,
     );
 
     loop {
@@ -2706,76 +2655,5 @@ pub fn run_single_file(
                 return Ok(());
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::history::Conversation;
-    use chrono::Local;
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-
-    fn make_conv(project_name: Option<&str>) -> Conversation {
-        Conversation {
-            path: PathBuf::from("/tmp/x.jsonl"),
-            index: 0,
-            timestamp: Local::now(),
-            preview: String::new(),
-            preview_first: String::new(),
-            preview_last: String::new(),
-            full_text: String::new(),
-            search_text_lower: String::new(),
-            project_name: project_name.map(String::from),
-            project_path: None,
-            cwd: None,
-            message_count: 0,
-            parse_errors: Vec::new(),
-            summary: None,
-            custom_title: None,
-            model: None,
-            total_tokens: 0,
-            duration_minutes: None,
-        }
-    }
-
-    #[test]
-    fn excluded_project_name_matches() {
-        let mut set = HashSet::new();
-        set.insert("observer-sessions".to_string());
-        let conv = make_conv(Some("observer-sessions"));
-        assert!(is_project_excluded(&conv, &set));
-    }
-
-    #[test]
-    fn non_matching_project_name_not_excluded() {
-        let mut set = HashSet::new();
-        set.insert("observer-sessions".to_string());
-        let conv = make_conv(Some("services"));
-        assert!(!is_project_excluded(&conv, &set));
-    }
-
-    #[test]
-    fn empty_set_excludes_nothing() {
-        let set = HashSet::new();
-        let conv = make_conv(Some("observer-sessions"));
-        assert!(!is_project_excluded(&conv, &set));
-    }
-
-    #[test]
-    fn missing_project_name_not_excluded() {
-        let mut set = HashSet::new();
-        set.insert("observer-sessions".to_string());
-        let conv = make_conv(None);
-        assert!(!is_project_excluded(&conv, &set));
-    }
-
-    #[test]
-    fn match_is_case_sensitive() {
-        let mut set = HashSet::new();
-        set.insert("observer-sessions".to_string());
-        let conv = make_conv(Some("Observer-Sessions"));
-        assert!(!is_project_excluded(&conv, &set));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,11 +14,25 @@ use crossterm::event::{
 };
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
+use std::collections::HashSet;
 use std::io::{self, Stdout};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
 use std::time::Duration;
+
+/// Returns true if the conversation's project_name is in the excluded set.
+/// Match is exact and case-sensitive. A conversation with no project_name is
+/// never excluded (defensive: keep showing data we can't classify).
+pub(crate) fn is_project_excluded(conv: &Conversation, excluded: &HashSet<String>) -> bool {
+    if excluded.is_empty() {
+        return false;
+    }
+    match conv.project_name.as_deref() {
+        Some(name) => excluded.contains(name),
+        None => false,
+    }
+}
 
 /// Result of running the TUI
 pub enum Action {
@@ -137,6 +151,7 @@ enum SearchCommand {
     UpdateData {
         conversations: Arc<Vec<Conversation>>,
         searchable: Arc<Vec<SearchableConversation>>,
+        excluded_projects: Arc<HashSet<String>>,
     },
     /// Run a search query
     Search {
@@ -164,15 +179,18 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
         .spawn(move || {
             let mut conversations: Arc<Vec<Conversation>> = Arc::new(Vec::new());
             let mut searchable: Arc<Vec<SearchableConversation>> = Arc::new(Vec::new());
+            let mut excluded_projects: Arc<HashSet<String>> = Arc::new(HashSet::new());
 
             while let Ok(cmd) = cmd_rx.recv() {
                 match cmd {
                     SearchCommand::UpdateData {
                         conversations: c,
                         searchable: s,
+                        excluded_projects: e,
                     } => {
                         conversations = c;
                         searchable = s;
+                        excluded_projects = e;
                     }
                     SearchCommand::Search {
                         mut query,
@@ -187,9 +205,11 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
                                 SearchCommand::UpdateData {
                                     conversations: c,
                                     searchable: s,
+                                    excluded_projects: e,
                                 } => {
                                     conversations = c;
                                     searchable = s;
+                                    excluded_projects = e;
                                 }
                                 SearchCommand::Search {
                                     query: q,
@@ -207,6 +227,12 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
 
                         let now = chrono::Local::now();
                         let mut filtered = search::search(&conversations, &searchable, &query, now);
+
+                        if !excluded_projects.is_empty() {
+                            filtered.retain(|&idx| {
+                                !is_project_excluded(&conversations[idx], &excluded_projects)
+                            });
+                        }
 
                         if workspace_filter && let Some(ref dir_name) = project_dir_name {
                             filtered.retain(|&idx| {
@@ -272,6 +298,8 @@ pub struct App {
     workspace_filter: bool,
     /// The encoded project directory name for the current workspace (for filtering)
     current_project_dir_name: Option<String>,
+    /// Project names to exclude from the TUI list. Loaded once from config at startup.
+    excluded_projects: Arc<HashSet<String>>,
     /// Channel to send commands to the background search worker
     search_tx: mpsc::Sender<SearchCommand>,
     /// Channel to receive results from the background search worker
@@ -300,6 +328,7 @@ impl App {
         let _ = search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(conversations.clone()),
             searchable: Arc::new(searchable.clone()),
+            excluded_projects: Arc::new(HashSet::new()),
         });
 
         Self {
@@ -320,6 +349,7 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            excluded_projects: Arc::new(HashSet::new()),
             search_tx,
             search_rx,
             search_generation: 0,
@@ -334,6 +364,7 @@ impl App {
         keys: KeyBindings,
         workspace_filter: bool,
         current_project_dir_name: Option<String>,
+        excluded_projects: Arc<HashSet<String>>,
     ) -> Self {
         let (search_tx, search_rx) = spawn_search_worker();
 
@@ -355,6 +386,7 @@ impl App {
             keys,
             workspace_filter,
             current_project_dir_name,
+            excluded_projects,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -422,6 +454,7 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            excluded_projects: Arc::new(HashSet::new()),
             search_tx,
             search_rx,
             search_generation: 0,
@@ -444,6 +477,11 @@ impl App {
         // (Items shown in arrival order initially, will be re-sorted in finish_loading)
         // Apply workspace filter during loading too
         for idx in start_idx..end_idx {
+            // Hide projects listed in config exclude_projects
+            if is_project_excluded(&self.conversations[idx], &self.excluded_projects) {
+                continue;
+            }
+            // Apply workspace filter during loading too
             if self.workspace_filter
                 && let Some(ref project_dir_name) = self.current_project_dir_name
                 && self.conversations[idx]
@@ -491,13 +529,14 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
+            excluded_projects: Arc::clone(&self.excluded_projects),
         });
 
         self.loading_state = LoadingState::Ready;
 
-        // Apply filter (handles both query and workspace filter)
-        if self.query.is_empty() && !self.workspace_filter {
-            // No query and no workspace filter - show all
+        // Apply filter (handles query, workspace filter, and exclusions)
+        if self.query.is_empty() && !self.workspace_filter && self.excluded_projects.is_empty() {
+            // No query, no workspace filter, no exclusions - show all
             self.filtered = (0..self.conversations.len()).collect();
             self.selected = if self.filtered.is_empty() {
                 None
@@ -505,7 +544,7 @@ impl App {
                 Some(0)
             };
         } else {
-            // Has query or workspace filter active - apply full filter
+            // Has query, workspace filter, or exclusions active - apply full filter
             self.update_filter();
         }
     }
@@ -538,6 +577,14 @@ impl App {
 
         let now = Local::now();
         let mut filtered = search::search(&self.conversations, &self.searchable, &self.query, now);
+
+        // Hide projects listed in config exclude_projects.
+        // `&self.excluded_projects` deref-coerces from `&Arc<HashSet<_>>` to `&HashSet<_>`.
+        if !self.excluded_projects.is_empty() {
+            filtered.retain(|&idx| {
+                !is_project_excluded(&self.conversations[idx], &self.excluded_projects)
+            });
+        }
 
         // Apply workspace filter if active
         // Matches conversations from the same project, including workmux worktrees
@@ -650,6 +697,7 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
+            excluded_projects: Arc::clone(&self.excluded_projects),
         });
 
         Some(idx)
@@ -977,6 +1025,7 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::UpdateData {
             conversations: Arc::new(self.conversations.clone()),
             searchable: Arc::new(self.searchable.clone()),
+            excluded_projects: Arc::clone(&self.excluded_projects),
         });
         self.search_generation += 1;
     }
@@ -2453,6 +2502,7 @@ pub fn run_with_loader(
     keys: KeyBindings,
     workspace_filter: bool,
     current_project_dir_name: Option<String>,
+    excluded_projects: Arc<HashSet<String>>,
 ) -> Result<(Action, Vec<Conversation>)> {
     // Set up panic hook to restore terminal
     let original_hook = std::panic::take_hook();
@@ -2469,6 +2519,7 @@ pub fn run_with_loader(
         keys,
         workspace_filter,
         current_project_dir_name,
+        excluded_projects,
     );
 
     loop {
@@ -2655,5 +2706,76 @@ pub fn run_single_file(
                 return Ok(());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::Conversation;
+    use chrono::Local;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    fn make_conv(project_name: Option<&str>) -> Conversation {
+        Conversation {
+            path: PathBuf::from("/tmp/x.jsonl"),
+            index: 0,
+            timestamp: Local::now(),
+            preview: String::new(),
+            preview_first: String::new(),
+            preview_last: String::new(),
+            full_text: String::new(),
+            search_text_lower: String::new(),
+            project_name: project_name.map(String::from),
+            project_path: None,
+            cwd: None,
+            message_count: 0,
+            parse_errors: Vec::new(),
+            summary: None,
+            custom_title: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
+        }
+    }
+
+    #[test]
+    fn excluded_project_name_matches() {
+        let mut set = HashSet::new();
+        set.insert("observer-sessions".to_string());
+        let conv = make_conv(Some("observer-sessions"));
+        assert!(is_project_excluded(&conv, &set));
+    }
+
+    #[test]
+    fn non_matching_project_name_not_excluded() {
+        let mut set = HashSet::new();
+        set.insert("observer-sessions".to_string());
+        let conv = make_conv(Some("services"));
+        assert!(!is_project_excluded(&conv, &set));
+    }
+
+    #[test]
+    fn empty_set_excludes_nothing() {
+        let set = HashSet::new();
+        let conv = make_conv(Some("observer-sessions"));
+        assert!(!is_project_excluded(&conv, &set));
+    }
+
+    #[test]
+    fn missing_project_name_not_excluded() {
+        let mut set = HashSet::new();
+        set.insert("observer-sessions".to_string());
+        let conv = make_conv(None);
+        assert!(!is_project_excluded(&conv, &set));
+    }
+
+    #[test]
+    fn match_is_case_sensitive() {
+        let mut set = HashSet::new();
+        set.insert("observer-sessions".to_string());
+        let conv = make_conv(Some("Observer-Sessions"));
+        assert!(!is_project_excluded(&conv, &set));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -14,6 +14,7 @@ use crossterm::event::{
 };
 use crossterm::terminal::{self, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::prelude::*;
+use std::collections::HashSet;
 use std::io::{self, Stdout};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -139,12 +140,7 @@ enum SearchCommand {
         searchable: Arc<Vec<SearchableConversation>>,
     },
     /// Run a search query
-    Search {
-        query: String,
-        generation: u64,
-        workspace_filter: bool,
-        project_dir_name: Option<String>,
-    },
+    Search { query: String, generation: u64 },
 }
 
 /// Result returned from the background search worker
@@ -177,8 +173,6 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
                     SearchCommand::Search {
                         mut query,
                         mut generation,
-                        mut workspace_filter,
-                        mut project_dir_name,
                     } => {
                         // Drain pending commands: apply all data updates,
                         // keep only the latest search request
@@ -194,34 +188,15 @@ fn spawn_search_worker() -> (mpsc::Sender<SearchCommand>, mpsc::Receiver<SearchR
                                 SearchCommand::Search {
                                     query: q,
                                     generation: g,
-                                    workspace_filter: wf,
-                                    project_dir_name: pdn,
                                 } => {
                                     query = q;
                                     generation = g;
-                                    workspace_filter = wf;
-                                    project_dir_name = pdn;
                                 }
                             }
                         }
 
                         let now = chrono::Local::now();
-                        let mut filtered = search::search(&conversations, &searchable, &query, now);
-
-                        if workspace_filter && let Some(ref dir_name) = project_dir_name {
-                            filtered.retain(|&idx| {
-                                conversations[idx]
-                                    .path
-                                    .parent()
-                                    .and_then(|p| p.file_name())
-                                    .is_some_and(|name| {
-                                        crate::history::path::is_same_project(
-                                            &name.to_string_lossy(),
-                                            dir_name,
-                                        )
-                                    })
-                            });
-                        }
+                        let filtered = search::search(&conversations, &searchable, &query, now);
 
                         let _ = res_tx.send(SearchResponse {
                             filtered,
@@ -272,6 +247,8 @@ pub struct App {
     workspace_filter: bool,
     /// The encoded project directory name for the current workspace (for filtering)
     current_project_dir_name: Option<String>,
+    /// Exact project names hidden from list-mode display
+    excluded_projects: HashSet<String>,
     /// Channel to send commands to the background search worker
     search_tx: mpsc::Sender<SearchCommand>,
     /// Channel to receive results from the background search worker
@@ -290,9 +267,17 @@ impl App {
         tool_display: ToolDisplayMode,
         show_thinking: bool,
         keys: KeyBindings,
+        exclude_projects: Vec<String>,
     ) -> Self {
         let searchable = search::precompute_search_text(&conversations);
-        let filtered: Vec<usize> = (0..conversations.len()).collect();
+        let excluded_projects = exclude_projects.into_iter().collect();
+        let filtered = filter_conversation_indices(
+            0..conversations.len(),
+            &conversations,
+            &excluded_projects,
+            false,
+            None,
+        );
         let selected = if filtered.is_empty() { None } else { Some(0) };
         let (search_tx, search_rx) = spawn_search_worker();
 
@@ -320,6 +305,7 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            excluded_projects,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -334,8 +320,10 @@ impl App {
         keys: KeyBindings,
         workspace_filter: bool,
         current_project_dir_name: Option<String>,
+        exclude_projects: Vec<String>,
     ) -> Self {
         let (search_tx, search_rx) = spawn_search_worker();
+        let excluded_projects = exclude_projects.into_iter().collect();
 
         Self {
             conversations: Vec::new(),
@@ -355,6 +343,7 @@ impl App {
             keys,
             workspace_filter,
             current_project_dir_name,
+            excluded_projects,
             search_tx,
             search_rx,
             search_generation: 0,
@@ -422,6 +411,7 @@ impl App {
             keys,
             workspace_filter: false,
             current_project_dir_name: None,
+            excluded_projects: HashSet::new(),
             search_tx,
             search_rx,
             search_generation: 0,
@@ -440,27 +430,8 @@ impl App {
         self.conversations.extend(new_convs);
         let end_idx = self.conversations.len();
 
-        // Update filtered so items appear in the list during loading
-        // (Items shown in arrival order initially, will be re-sorted in finish_loading)
-        // Apply workspace filter during loading too
-        for idx in start_idx..end_idx {
-            if self.workspace_filter
-                && let Some(ref project_dir_name) = self.current_project_dir_name
-                && self.conversations[idx]
-                    .path
-                    .parent()
-                    .and_then(|p| p.file_name())
-                    .is_none_or(|name| {
-                        !crate::history::path::is_same_project(
-                            &name.to_string_lossy(),
-                            project_dir_name,
-                        )
-                    })
-            {
-                continue;
-            }
-            self.filtered.push(idx);
-        }
+        let new_filtered = self.filter_indices(start_idx..end_idx);
+        self.filtered.extend(new_filtered);
 
         // Select first item if nothing selected yet
         if self.selected.is_none() && !self.filtered.is_empty() {
@@ -495,19 +466,11 @@ impl App {
 
         self.loading_state = LoadingState::Ready;
 
-        // Apply filter (handles both query and workspace filter)
-        if self.query.is_empty() && !self.workspace_filter {
-            // No query and no workspace filter - show all
-            self.filtered = (0..self.conversations.len()).collect();
-            self.selected = if self.filtered.is_empty() {
-                None
-            } else {
-                Some(0)
-            };
-        } else {
-            // Has query or workspace filter active - apply full filter
-            self.update_filter();
-        }
+        self.search_generation += 1;
+        self.search_in_flight = false;
+
+        // Apply filter (handles query, exclusions, and workspace filter)
+        self.update_filter();
     }
 
     /// Consume the app and return its conversations
@@ -521,6 +484,28 @@ impl App {
 
     pub fn is_loading(&self) -> bool {
         matches!(self.loading_state, LoadingState::Loading { .. })
+    }
+
+    fn filter_indices<I>(&self, indices: I) -> Vec<usize>
+    where
+        I: IntoIterator<Item = usize>,
+    {
+        filter_conversation_indices(
+            indices,
+            &self.conversations,
+            &self.excluded_projects,
+            self.workspace_filter,
+            self.current_project_dir_name.as_deref(),
+        )
+    }
+
+    fn apply_filtered(&mut self, filtered: Vec<usize>) {
+        self.filtered = filtered;
+        self.selected = if self.filtered.is_empty() {
+            None
+        } else {
+            Some(0)
+        };
     }
 
     /// Update filtered results based on current query
@@ -537,33 +522,9 @@ impl App {
         }
 
         let now = Local::now();
-        let mut filtered = search::search(&self.conversations, &self.searchable, &self.query, now);
-
-        // Apply workspace filter if active
-        // Matches conversations from the same project, including workmux worktrees
-        if self.workspace_filter
-            && let Some(ref project_dir_name) = self.current_project_dir_name
-        {
-            filtered.retain(|&idx| {
-                self.conversations[idx]
-                    .path
-                    .parent()
-                    .and_then(|p| p.file_name())
-                    .is_some_and(|name| {
-                        crate::history::path::is_same_project(
-                            &name.to_string_lossy(),
-                            project_dir_name,
-                        )
-                    })
-            });
-        }
-
-        self.filtered = filtered;
-        self.selected = if self.filtered.is_empty() {
-            None
-        } else {
-            Some(0)
-        };
+        let filtered = search::search(&self.conversations, &self.searchable, &self.query, now);
+        let filtered = self.filter_indices(filtered);
+        self.apply_filtered(filtered);
     }
 
     /// Dispatch a search to the background worker.
@@ -573,6 +534,8 @@ impl App {
 
         // UUID search: synchronous (rare, needs to modify conversations)
         if search::is_uuid(&query) {
+            self.search_generation += 1;
+            self.search_in_flight = false;
             if let Some(idx) = self.find_or_load_uuid(&query) {
                 self.filtered = vec![idx];
                 self.selected = Some(0);
@@ -585,8 +548,6 @@ impl App {
         let _ = self.search_tx.send(SearchCommand::Search {
             query,
             generation: self.search_generation,
-            workspace_filter: self.workspace_filter,
-            project_dir_name: self.current_project_dir_name.clone(),
         });
     }
 
@@ -597,12 +558,8 @@ impl App {
         while let Ok(response) = self.search_rx.try_recv() {
             // Only apply the result if it matches the latest generation
             if response.generation == self.search_generation {
-                self.filtered = response.filtered;
-                self.selected = if self.filtered.is_empty() {
-                    None
-                } else {
-                    Some(0)
-                };
+                let filtered = self.filter_indices(response.filtered);
+                self.apply_filtered(filtered);
                 self.search_in_flight = false;
                 applied = true;
             }
@@ -791,6 +748,8 @@ impl App {
         // Only toggle if we have a workspace context
         if self.current_project_dir_name.is_some() {
             self.workspace_filter = !self.workspace_filter;
+            self.search_generation += 1;
+            self.search_in_flight = false;
             self.update_filter();
         }
     }
@@ -2313,6 +2272,44 @@ impl App {
     }
 }
 
+fn filter_conversation_indices<I>(
+    indices: I,
+    conversations: &[Conversation],
+    excluded_projects: &HashSet<String>,
+    workspace_filter: bool,
+    current_project_dir_name: Option<&str>,
+) -> Vec<usize>
+where
+    I: IntoIterator<Item = usize>,
+{
+    indices
+        .into_iter()
+        .filter(|&idx| {
+            conversations[idx]
+                .project_name
+                .as_deref()
+                .is_none_or(|name| !excluded_projects.contains(name))
+        })
+        .filter(|&idx| {
+            if !workspace_filter {
+                return true;
+            }
+            current_project_dir_name.is_some_and(|project_dir_name| {
+                conversations[idx]
+                    .path
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .is_some_and(|name| {
+                        crate::history::path::is_same_project(
+                            &name.to_string_lossy(),
+                            project_dir_name,
+                        )
+                    })
+            })
+        })
+        .collect()
+}
+
 /// Stable reference point for preserving scroll position across re-renders.
 /// `entry_index` survives re-renders (it's the JSONL line index), and
 /// `relative_row` is the message's screen row (`start_line - scroll_offset`)
@@ -2365,6 +2362,313 @@ fn find_message_idx_or_prev(ranges: &[MessageRange], entry_index: usize) -> Opti
         Ok(idx) => Some(idx),
         Err(0) => Some(0),
         Err(idx) => Some(idx - 1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::Conversation;
+    use chrono::{Local, TimeZone};
+    use std::path::PathBuf;
+
+    fn conversation(
+        project: Option<&str>,
+        project_dir: &str,
+        uuid: &str,
+        text: &str,
+    ) -> Conversation {
+        Conversation {
+            path: PathBuf::from(format!("/tmp/claude-projects/{project_dir}/{uuid}.jsonl")),
+            index: 0,
+            timestamp: Local.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap(),
+            preview: text.to_string(),
+            preview_first: text.to_string(),
+            preview_last: text.to_string(),
+            full_text: text.to_string(),
+            search_text_lower: search::normalize_for_search(text),
+            project_name: project.map(str::to_string),
+            project_path: None,
+            cwd: None,
+            message_count: 1,
+            parse_errors: Vec::new(),
+            summary: None,
+            custom_title: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
+        }
+    }
+
+    fn app(conversations: Vec<Conversation>, excluded: Vec<&str>) -> App {
+        App::new(
+            conversations,
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            excluded.into_iter().map(str::to_string).collect(),
+        )
+    }
+
+    fn filtered_projects(app: &App) -> Vec<Option<&str>> {
+        app.filtered()
+            .iter()
+            .map(|&idx| app.conversations()[idx].project_name.as_deref())
+            .collect()
+    }
+
+    #[test]
+    fn exclude_projects_filters_browse_list_exactly() {
+        let app = app(
+            vec![
+                conversation(
+                    Some("Hidden"),
+                    "-tmp-hidden",
+                    "11111111-1111-4111-8111-111111111111",
+                    "needle",
+                ),
+                conversation(
+                    Some("Visible"),
+                    "-tmp-visible",
+                    "22222222-2222-4222-8222-222222222222",
+                    "needle",
+                ),
+                conversation(
+                    Some("hidden"),
+                    "-tmp-lower",
+                    "33333333-3333-4333-8333-333333333333",
+                    "needle",
+                ),
+            ],
+            vec!["Hidden"],
+        );
+
+        assert_eq!(
+            filtered_projects(&app),
+            vec![Some("Visible"), Some("hidden")]
+        );
+    }
+
+    #[test]
+    fn exclude_projects_filters_search_results() {
+        let mut app = app(
+            vec![
+                conversation(
+                    Some("Hidden"),
+                    "-tmp-hidden",
+                    "11111111-1111-4111-8111-111111111111",
+                    "shared needle",
+                ),
+                conversation(
+                    Some("Visible"),
+                    "-tmp-visible",
+                    "22222222-2222-4222-8222-222222222222",
+                    "shared needle",
+                ),
+            ],
+            vec!["Hidden"],
+        );
+
+        app.query = "needle".to_string();
+        app.update_filter();
+
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+    }
+
+    #[test]
+    fn exclude_projects_apply_before_workspace_filter() {
+        let mut app = app(
+            vec![
+                conversation(
+                    Some("Hidden"),
+                    "-tmp-project--worktrees-a",
+                    "11111111-1111-4111-8111-111111111111",
+                    "needle",
+                ),
+                conversation(
+                    Some("Visible"),
+                    "-tmp-project",
+                    "22222222-2222-4222-8222-222222222222",
+                    "needle",
+                ),
+            ],
+            vec!["Hidden"],
+        );
+        app.workspace_filter = true;
+        app.current_project_dir_name = Some("-tmp-project".to_string());
+        app.update_filter();
+
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+    }
+
+    #[test]
+    fn uuid_lookup_bypasses_excluded_projects() {
+        let uuid = "11111111-1111-4111-8111-111111111111";
+        let mut app = app(
+            vec![conversation(Some("Hidden"), "-tmp-hidden", uuid, "needle")],
+            vec!["Hidden"],
+        );
+        assert!(app.filtered().is_empty());
+
+        app.query = uuid.to_string();
+        app.update_filter();
+        assert_eq!(filtered_projects(&app), vec![Some("Hidden")]);
+
+        app.query.clear();
+        app.update_filter();
+        assert!(app.filtered().is_empty());
+        assert_eq!(app.conversations().len(), 1);
+        assert_eq!(app.searchable.len(), 1);
+    }
+
+    #[test]
+    fn uuid_dispatch_invalidates_stale_search_response() {
+        let uuid = "11111111-1111-4111-8111-111111111111";
+        let mut app = app(
+            vec![
+                conversation(Some("Hidden"), "-tmp-hidden", uuid, "needle"),
+                conversation(
+                    Some("Visible"),
+                    "-tmp-visible",
+                    "22222222-2222-4222-8222-222222222222",
+                    "needle",
+                ),
+            ],
+            vec!["Hidden"],
+        );
+
+        let (tx, rx) = mpsc::channel();
+        app.search_rx = rx;
+        app.search_generation = 1;
+        app.search_in_flight = true;
+
+        app.query = uuid.to_string();
+        app.dispatch_search();
+        assert_eq!(filtered_projects(&app), vec![Some("Hidden")]);
+
+        tx.send(SearchResponse {
+            filtered: vec![1],
+            generation: 1,
+        })
+        .unwrap();
+
+        app.receive_search_results();
+        assert_eq!(filtered_projects(&app), vec![Some("Hidden")]);
+    }
+
+    #[test]
+    fn finish_loading_invalidates_stale_loading_search_response() {
+        let mut app = App::new_loading(
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            false,
+            None,
+            vec![],
+        );
+
+        let (tx, rx) = mpsc::channel();
+        app.search_rx = rx;
+        app.search_generation = 1;
+        app.search_in_flight = true;
+
+        app.append_conversations(vec![conversation(
+            Some("Visible"),
+            "-tmp-visible",
+            "22222222-2222-4222-8222-222222222222",
+            "needle",
+        )]);
+        app.finish_loading();
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+
+        tx.send(SearchResponse {
+            filtered: vec![],
+            generation: 1,
+        })
+        .unwrap();
+
+        app.receive_search_results();
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+    }
+
+    #[test]
+    fn exclude_projects_filters_incremental_loading() {
+        let mut app = App::new_loading(
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            false,
+            None,
+            vec!["Hidden".to_string()],
+        );
+
+        app.append_conversations(vec![
+            conversation(
+                Some("Hidden"),
+                "-tmp-hidden",
+                "11111111-1111-4111-8111-111111111111",
+                "needle",
+            ),
+            conversation(
+                Some("Visible"),
+                "-tmp-visible",
+                "22222222-2222-4222-8222-222222222222",
+                "needle",
+            ),
+        ]);
+
+        assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+    }
+
+    #[test]
+    fn empty_exclusions_preserve_browse_results() {
+        let app = app(
+            vec![
+                conversation(
+                    Some("Hidden"),
+                    "-tmp-hidden",
+                    "11111111-1111-4111-8111-111111111111",
+                    "needle",
+                ),
+                conversation(
+                    None,
+                    "-tmp-none",
+                    "22222222-2222-4222-8222-222222222222",
+                    "needle",
+                ),
+            ],
+            vec![],
+        );
+
+        assert_eq!(filtered_projects(&app), vec![Some("Hidden"), None]);
+    }
+
+    #[test]
+    fn project_without_name_is_never_excluded() {
+        let app = app(
+            vec![conversation(
+                None,
+                "-tmp-none",
+                "11111111-1111-4111-8111-111111111111",
+                "needle",
+            )],
+            vec![""],
+        );
+
+        assert_eq!(filtered_projects(&app), vec![None]);
+    }
+
+    #[test]
+    fn single_file_mode_has_no_project_exclusions() {
+        let app = App::new_single_file(
+            PathBuf::from("/tmp/hidden.jsonl"),
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+        );
+
+        assert!(app.excluded_projects.is_empty());
+        assert!(app.is_single_file_mode());
     }
 }
 
@@ -2453,6 +2757,7 @@ pub fn run_with_loader(
     keys: KeyBindings,
     workspace_filter: bool,
     current_project_dir_name: Option<String>,
+    exclude_projects: Vec<String>,
 ) -> Result<(Action, Vec<Conversation>)> {
     // Set up panic hook to restore terminal
     let original_hook = std::panic::take_hook();
@@ -2469,6 +2774,7 @@ pub fn run_with_loader(
         keys,
         workspace_filter,
         current_project_dir_name,
+        exclude_projects,
     );
 
     loop {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2272,6 +2272,13 @@ impl App {
     }
 }
 
+fn project_is_excluded(project_name: &str, excluded_projects: &HashSet<String>) -> bool {
+    excluded_projects.contains(project_name)
+        || project_name
+            .split_once('/')
+            .is_some_and(|(parent, _)| excluded_projects.contains(parent))
+}
+
 fn filter_conversation_indices<I>(
     indices: I,
     conversations: &[Conversation],
@@ -2288,7 +2295,7 @@ where
             conversations[idx]
                 .project_name
                 .as_deref()
-                .is_none_or(|name| !excluded_projects.contains(name))
+                .is_none_or(|name| !project_is_excluded(name, excluded_projects))
         })
         .filter(|&idx| {
             if !workspace_filter {
@@ -2446,6 +2453,32 @@ mod tests {
         assert_eq!(
             filtered_projects(&app),
             vec![Some("Visible"), Some("hidden")]
+        );
+    }
+
+    #[test]
+    fn exclude_projects_filters_worktrees_by_parent_project() {
+        let app = app(
+            vec![
+                conversation(
+                    Some("claude-history/exclude-projects"),
+                    "-tmp-claude-history--worktrees-exclude-projects",
+                    "11111111-1111-4111-8111-111111111111",
+                    "needle",
+                ),
+                conversation(
+                    Some("other/exclude-projects"),
+                    "-tmp-other--worktrees-exclude-projects",
+                    "22222222-2222-4222-8222-222222222222",
+                    "needle",
+                ),
+            ],
+            vec!["claude-history"],
+        );
+
+        assert_eq!(
+            filtered_projects(&app),
+            vec![Some("other/exclude-projects")]
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an `exclude_projects` config option (under a new `[filter]` section) that hides selected projects from the TUI conversation list.

**Motivation:** I use [claude-mem](https://github.com/thedotmack/claude-mem), which spawns background "observer" sessions to capture conversation memory. These sessions are recorded under a dedicated `observer-sessions` project and aren't sessions I ever want to open or resume (they're tooling-internal), but they show up interleaved with my real conversations and crowd them out of the list. With the option set, those rows disappear
from the TUI while remaining intact on disk for claude-mem to read. Anyone running similar background-session tooling has the same problem; the option is general but this is the concrete use case that prompted it.

```toml
# ~/.config/claude-history/config.toml
[filter]
exclude_projects = ["observer-sessions"]
```

Match is exact and case-sensitive against the project name shown in the leftmost column of each TUI row (i.e. `format_short_name_from_path(cwd)`: the short folder name; for workmux worktrees, the `<project>/<worktree>` form).

## Where the filter applies

| Path | Filtered? |
|---|---|
| TUI browse list | Yes |
| TUI search results | Yes |
| `Tab` workspace toggle | Yes (filter applied before workspace check) |
| UUID paste in the search box | **No**: the explicit lookup wins |
| Direct file input (`claude-history file.jsonl`) | **No**: bypasses the list entirely |
| `--render`, `--delete`, `--debug-search`, `--show-id`, `--show-path` | **No**: non-TUI commands are unaffected |

The filter is a TUI list display concern, not a load-time skip. Conversations from excluded projects are still loaded and cached normally, so toggling the config never invalidates caches, and explicit references to a session (by UUID or file path) always work.

## Implementation notes

- New `FilterConfig` struct holding `exclude_projects: Option<Vec<String>>`, exposed on `ConfigFile` as `pub filter: Option<FilterConfig>`. Nesting under a `[filter]` section (rather than as a top-level key) keeps the option order-independent in TOML and matches how every other option in this config lives under a section header.
- Materialized once at startup into `Arc<HashSet<String>>` and threaded into the TUI through `run_with_loader` and `App` constructors.
- A free `is_project_excluded(&Conversation, &HashSet<String>)` helper is applied at all four existing list-filter sites:
  - `append_conversations` (streaming load)
  - `finish_loading` (fast-path)
  - `update_filter` (synchronous recompute)
  - the background search worker
- The exclude set is shipped to the search worker as a third field on `SearchCommand::UpdateData` so the worker stays in sync with config state.
- Loader and on-disk cache are untouched.

## Test plan

- [x] Unit tests for the helper (`is_project_excluded`): exact match, missing
  `project_name`, empty set, case sensitivity.
- [x] Unit tests for config parsing: `[filter]` section deserializes; works even when placed after other sections; defaults to `None` when absent.
- [x] `cargo build` clean, `cargo test` 245/245 passing.
- [x] Manual smoke test: with `[filter] exclude_projects = ["observer-sessions"]` set, confirmed those rows disappear from both the browse list and search results, and that pasting a UUID belonging to an excluded session still loads it.

## Commits

1. `config: add exclude_projects field to ConfigFile`: config field + parsing tests
2. `tui: filter excluded projects from the conversation list`: helper + plumbing + filter at all 4 sites + helper unit tests
3. `docs: document exclude_projects config option`: README updates

## Open question: CLI flag?

I noticed almost every other display option has a corresponding CLI flag (`--no-tools` / `--show-tools`, `--first` / `--last`, `--hide-thinking` / `--show-thinking`, `--plain`, `--no-pager`). I deliberately kept this PR config-only because the use case I had in mind is "set once, hide always", but it's a small extension to add a flag for parity with the rest of the options.

Happy to add it in this PR if you'd prefer. Likely shape:

- `--exclude <NAME>` (repeatable): adds names on top of the config list.
  Example: `claude-history --exclude observer-sessions --exclude scratch`.
- `--no-exclude`: clears the config list for this invocation (escape hatch when you want to see everything once).

Let me know your preference and I'll add it as an additional commit on this branch.
