### PR TITLE
fix: case-insensitive workspace filter on Windows

### DIFF
--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -100,8 +100,27 @@ pub fn encoded_project_root(encoded: &str) -> &str {
 /// Two names are considered part of the same project if they share the same
 /// encoded project root (i.e., stripping any workmux `--worktrees-<branch>`
 /// suffix yields the same string).
+///
+/// On Windows the comparison is case-insensitive. NTFS is case-insensitive
+/// and case-preserving, so the same logical directory can be reached via
+/// differently-cased paths (e.g. `cd myproject` vs `cd MyProject`) and reported
+/// back as differently-cased cwd strings. Because the encoded form preserves
+/// the original casing, a case-sensitive compare causes the workspace filter
+/// (`-L` / `Tab`) to drop every conversation when the current shell's cwd
+/// casing differs from the casing recorded when the sessions were created.
+/// The encoded form contains only ASCII alphanumeric characters and `-`, so
+/// `eq_ignore_ascii_case` is sufficient.
 pub fn is_same_project(a: &str, b: &str) -> bool {
-    encoded_project_root(a) == encoded_project_root(b)
+    let root_a = encoded_project_root(a);
+    let root_b = encoded_project_root(b);
+    #[cfg(windows)]
+    {
+        root_a.eq_ignore_ascii_case(root_b)
+    }
+    #[cfg(not(windows))]
+    {
+        root_a == root_b
+    }
 }
 
 /// Decode a project directory name back to a path (simple heuristic fallback).
@@ -443,5 +462,35 @@ mod tests {
             "/Users/raine/code/myproject__worktrees/feature",
         ));
         assert!(is_same_project(&main, &worktree));
+    }
+
+    // === Platform-specific case sensitivity tests ===
+    //
+    // Windows filesystems are case-insensitive, so the same on-disk directory
+    // can be reached via differently-cased paths and the workspace filter must
+    // treat them as the same project. POSIX filesystems are typically
+    // case-sensitive, so differently-cased encoded names refer to genuinely
+    // distinct directories and must remain not-equal.
+
+    #[cfg(windows)]
+    #[test]
+    fn is_same_project_case_insensitive_on_windows() {
+        let lowercase = "-Users-Foo-myproject";
+        let mixed = "-Users-Foo-MyProject";
+        assert!(is_same_project(lowercase, mixed));
+        assert!(is_same_project(mixed, lowercase));
+
+        // Worktree on the lowercase variant matches main on the uppercase variant
+        let worktree_lower = "-Users-Foo-myproject--worktrees-feature";
+        let main_upper = "-Users-Foo-MyProject";
+        assert!(is_same_project(worktree_lower, main_upper));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn is_same_project_case_sensitive_on_unix() {
+        let lowercase = "-home-user-myproject";
+        let mixed = "-home-user-MyProject";
+        assert!(!is_same_project(lowercase, mixed));
     }
 }


### PR DESCRIPTION
Fixes #44.

## Summary

On Windows, `-L` / `Tab` (workspace filter) returns no results when the
current shell's `cwd` casing differs from the casing recorded when the
project's sessions were created.

## Repro

1. On Windows, in any shell where `cd myproject` resolves to e.g.
   `C:\Users\Foo\myproject\` — Windows is case-insensitive but
   case-preserving, so the same dir can be reached via any casing.
2. The on-disk sessions live at `~/.claude/projects/C--Users-Foo-MyProject/`
   (whatever case Claude Code first created the dir with — often capitalized,
   matching the original folder casing).
3. Run `claude-history -L`. Result: empty list, despite `claude-history` (no
   flag) listing the project's sessions normally.

In my case I had 100+ sessions in `C--Users-Foo-MyProject` and `-L` from a
lowercase `myproject` cwd returned zero.

## Root cause

- `convert_path_to_project_dir_name` (`src/history/path.rs`) encodes the cwd
  by replacing non-alphanumerics with `-` but **preserves case**, so
  `C:\Users\Foo\myproject` becomes `C--Users-Foo-myproject` (lowercase `m`).
- `is_same_project` (same file) compares encoded names with `==`, which is
  case-sensitive.
- On NTFS the on-disk dir has exactly one canonical casing (the one used at
  creation), so any cwd that arrives with different casing fails the compare.

## Fix

Make `is_same_project` case-insensitive on Windows only. POSIX filesystems
are typically case-sensitive — `MyProject` and `myproject` there are
genuinely distinct directories — so the existing case-sensitive comparison
is preserved for `cfg(not(windows))`.

The encoded form contains only ASCII alphanumerics and `-`, so
`eq_ignore_ascii_case` is sufficient (no need for `unicase` / locale-aware
folding).

## Test plan

- [x] Added `is_same_project_case_insensitive_on_windows` (gated
  `#[cfg(windows)]`) covering main↔main and worktree↔main cross-case matches.
- [x] Added `is_same_project_case_sensitive_on_unix` (gated
  `#[cfg(not(windows))]`) asserting the existing case-sensitive behavior is
  preserved on Linux/macOS.
- [x] All 23 `history::path::tests::*` tests pass (`cargo test --all path::`)
  on Windows.
- [x] Full `cargo test --all` is clean apart from a pre-existing
  `update::tests::test_platform_suffix_current` failure (no Windows release
  artifact). Reproduces on `main` without this PR — out of scope here.
- [x] Manual smoke test: from a lowercase-cwd shell, the dev binary now
  returns this project's sessions for `claude-history --debug-search "the" -L`
  (previously empty).

## Out of scope

The same case-sensitivity issue affects `PathBuf` equality in fork logic
(`src/main.rs:447` compares `cwd_projects_dir != conv_projects_dir` to decide
whether to copy session files cross-project on `--fork-session`). On Windows,
that comparison can spuriously fire when only casing differs, triggering an
unnecessary copy. Fixing it requires platform-conditional `PathBuf`
comparison, so I left it alone here. Happy to file a follow-up if useful.