### PR TITLE
feat(tui): archive sessions to ~/.claude/archive/<project>/

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,12 +162,21 @@ pub struct Args {
     )]
     pub delete: Option<String>,
 
+    /// Archive a session by its ID (moves to ~/.claude/archive/<project>/)
+    #[arg(
+        long,
+        value_name = "SESSION_ID",
+        help = "Archive a session by its UUID and exit",
+        conflicts_with_all = ["global", "show_dir", "resume", "show_path", "show_id", "plain", "render", "input_file", "delete"]
+    )]
+    pub archive: Option<String>,
+
     /// Debug search scoring for a query
     #[arg(
         long = "debug-search",
         value_name = "QUERY",
         help = "Debug search result scoring for a query",
-        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "input_file", "semantic_search"]
+        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive", "input_file", "semantic_search"]
     )]
     pub debug_search: Option<String>,
 
@@ -177,7 +186,7 @@ pub struct Args {
         value_name = "QUERY",
         value_parser = non_empty_string,
         hide = true,
-        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "input_file", "debug_search", "semantic_search", "generate_semantic_cache", "clear_semantic_cache"]
+        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive", "input_file", "debug_search", "semantic_search", "generate_semantic_cache", "clear_semantic_cache"]
     )]
     pub debug_semantic_search: Option<String>,
 
@@ -188,7 +197,7 @@ pub struct Args {
         help = "Run a local semantic search over conversations",
         value_parser = non_empty_string,
         hide = true,
-        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "input_file", "debug_search", "clear_semantic_cache"]
+        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive", "input_file", "debug_search", "clear_semantic_cache"]
     )]
     pub semantic_search: Option<String>,
 
@@ -206,7 +215,7 @@ pub struct Args {
     #[arg(
         long = "generate-semantic-cache",
         hide = true,
-        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "input_file", "debug_search", "semantic_search", "clear_semantic_cache"]
+        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive", "input_file", "debug_search", "semantic_search", "clear_semantic_cache"]
     )]
     pub generate_semantic_cache: bool,
 
@@ -214,7 +223,7 @@ pub struct Args {
     #[arg(
         long = "clear-semantic-cache",
         hide = true,
-        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "input_file", "debug_search", "semantic_search", "generate_semantic_cache", "debug_semantic_search"]
+        conflicts_with_all = ["show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive", "input_file", "debug_search", "semantic_search", "generate_semantic_cache", "debug_semantic_search"]
     )]
     pub clear_semantic_cache: bool,
 
@@ -222,7 +231,7 @@ pub struct Args {
     #[arg(
         value_name = "FILE",
         help = "JSONL conversation file to view directly",
-        conflicts_with_all = ["global", "local", "show_dir", "resume", "show_path", "show_id", "plain", "render", "delete"]
+        conflicts_with_all = ["global", "local", "show_dir", "resume", "show_path", "show_id", "plain", "render", "delete", "archive"]
     )]
     pub input_file: Option<PathBuf>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,7 @@ pub struct KeysConfig {
     pub fork: Option<KeyBinding>,
     pub rename: Option<KeyBinding>,
     pub delete: Option<KeyBinding>,
+    pub archive: Option<KeyBinding>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -226,6 +227,7 @@ pub struct KeyBindings {
     pub fork: KeyBinding,
     pub rename: KeyBinding,
     pub delete: KeyBinding,
+    pub archive: KeyBinding,
 }
 
 impl Default for KeyBindings {
@@ -247,6 +249,10 @@ impl Default for KeyBindings {
                 code: KeyCode::Char('x'),
                 modifiers: KeyModifiers::CONTROL,
             },
+            archive: KeyBinding {
+                code: KeyCode::Char('a'),
+                modifiers: KeyModifiers::CONTROL,
+            },
         }
     }
 }
@@ -261,6 +267,7 @@ impl KeyBindings {
                 fork: cfg.fork.unwrap_or(defaults.fork),
                 rename: cfg.rename.unwrap_or(defaults.rename),
                 delete: cfg.delete.unwrap_or(defaults.delete),
+                archive: cfg.archive.unwrap_or(defaults.archive),
             },
         }
     }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -231,6 +231,105 @@ pub fn delete_session_by_uuid(uuid: &str) -> Result<usize> {
     Ok(count)
 }
 
+/// Archive root: <claude-dir>/archive (sibling of projects/).
+fn get_claude_archive_root() -> Result<PathBuf> {
+    let projects = super::get_claude_projects_root()?;
+    let claude_dir = projects.parent().ok_or_else(|| {
+        AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not determine Claude config directory",
+        ))
+    })?;
+    Ok(claude_dir.join("archive"))
+}
+
+/// Archive a session by UUID across all projects.
+/// Moves both the .jsonl file and the session subdirectory (if any) from
+/// `<claude>/projects/<project>/` to `<claude>/archive/<project>/`.
+/// Falls back to copy+remove when the source and destination are on different
+/// filesystems. Returns the number of sessions moved.
+pub fn archive_session_by_uuid(uuid: &str) -> Result<usize> {
+    if uuid.is_empty() || !uuid.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(AppError::SessionNotFound(uuid.to_owned()));
+    }
+
+    let matches = find_all_jsonl_by_uuid(uuid)?;
+    if matches.is_empty() {
+        return Err(AppError::SessionNotFound(uuid.to_owned()));
+    }
+
+    let archive_root = get_claude_archive_root()?;
+    let count = matches.len();
+
+    for jsonl_path in &matches {
+        let project_dir = jsonl_path.parent().ok_or_else(|| {
+            AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Session file has no parent directory",
+            ))
+        })?;
+        let project_name = project_dir.file_name().ok_or_else(|| {
+            AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not read project directory name",
+            ))
+        })?;
+
+        let dest_project_dir = archive_root.join(project_name);
+        std::fs::create_dir_all(&dest_project_dir)?;
+
+        let filename = jsonl_path.file_name().ok_or_else(|| {
+            AppError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Session file has no name",
+            ))
+        })?;
+        let dest_jsonl = dest_project_dir.join(filename);
+        move_path(jsonl_path, &dest_jsonl)?;
+
+        let session_dir = project_dir.join(uuid);
+        if session_dir.is_dir() {
+            let dest_session_dir = dest_project_dir.join(uuid);
+            move_path(&session_dir, &dest_session_dir)?;
+        }
+    }
+
+    Ok(count)
+}
+
+/// Move a file or directory, preferring rename, falling back to copy+remove
+/// when the source and destination are on different filesystems.
+fn move_path(src: &Path, dst: &Path) -> Result<()> {
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            if src.is_dir() {
+                copy_dir_recursive(src, dst)?;
+                std::fs::remove_dir_all(src)?;
+            } else {
+                std::fs::copy(src, dst)?;
+                std::fs::remove_file(src)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
 /// List all projects that contain conversation files
 pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
     let entries = read_dir(root)?;

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -24,7 +24,7 @@ use std::time::SystemTime;
 
 // Re-export public API
 pub use loader::{
-    delete_session_by_uuid, find_jsonl_by_uuid, load_all_conversations,
+    archive_session_by_uuid, delete_session_by_uuid, find_jsonl_by_uuid, load_all_conversations,
     load_all_conversations_streaming,
 };
 pub use parser::process_conversation_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,24 @@ fn run() -> Result<()> {
         }
     }
 
+    // Handle --archive flag: archive a session by UUID and exit
+    if let Some(ref session_id) = args.archive {
+        match history::archive_session_by_uuid(session_id) {
+            Ok(count) => {
+                if count == 1 {
+                    eprintln!("Archived session {}", session_id);
+                } else {
+                    eprintln!(
+                        "Archived session {} ({} copies across projects)",
+                        session_id, count
+                    );
+                }
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
     // Handle --debug-search flag: debug search result scoring
     if let Some(ref query) = args.debug_search {
         let mut conversations = history::load_all_conversations(show_last, args.debug)?;
@@ -333,6 +351,7 @@ fn run() -> Result<()> {
         }
         (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
         (tui::Action::Delete(_), _) => unreachable!("Delete is handled internally"),
+        (tui::Action::Archive(_), _) => unreachable!("Archive is handled internally"),
     };
 
     if args.show_path {

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -10,10 +10,15 @@ const EXPORT_OPTIONS: [&str; 4] = [
 
 impl App {
     pub(super) fn handle_confirm_key(&mut self, code: KeyCode) -> Option<Action> {
+        let current = self.dialog_mode.clone();
         match code {
             KeyCode::Char('y') | KeyCode::Char('Y') => {
                 self.dialog_mode = DialogMode::None;
-                self.get_selected_path().map(Action::Delete)
+                match current {
+                    DialogMode::ConfirmDelete => self.get_selected_path().map(Action::Delete),
+                    DialogMode::ConfirmArchive => self.get_selected_path().map(Action::Archive),
+                    _ => None,
+                }
             }
             KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                 self.dialog_mode = DialogMode::None;

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -122,7 +122,9 @@ impl App {
         viewport_height: usize,
     ) -> Option<Action> {
         match self.dialog_mode {
-            DialogMode::ConfirmDelete => return self.handle_confirm_key(code),
+            DialogMode::ConfirmDelete | DialogMode::ConfirmArchive => {
+                return self.handle_confirm_key(code);
+            }
             DialogMode::ExportMenu { .. } | DialogMode::YankMenu { .. } => {
                 return self.handle_menu_key(code);
             }
@@ -165,6 +167,12 @@ impl App {
         if self.keys.delete.matches(code, modifiers) {
             if !self.single_file_mode {
                 self.dialog_mode = DialogMode::ConfirmDelete;
+            }
+            return None;
+        }
+        if self.keys.archive.matches(code, modifiers) {
+            if !self.single_file_mode {
+                self.dialog_mode = DialogMode::ConfirmArchive;
             }
             return None;
         }
@@ -549,6 +557,12 @@ impl App {
         if self.keys.delete.matches(code, modifiers) {
             if self.get_selected_path().is_some() {
                 self.dialog_mode = DialogMode::ConfirmDelete;
+            }
+            return None;
+        }
+        if self.keys.archive.matches(code, modifiers) {
+            if self.get_selected_path().is_some() {
+                self.dialog_mode = DialogMode::ConfirmArchive;
             }
             return None;
         }

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 pub enum Action {
     Select(PathBuf),
     Delete(PathBuf),
+    Archive(PathBuf),
     Resume(PathBuf),
     ForkResume(PathBuf),
     Quit,
@@ -23,6 +24,8 @@ pub enum DialogMode {
     None,
     /// Confirming deletion of the selected conversation
     ConfirmDelete,
+    /// Confirming archive (move to ~/.claude/archive/<project>/) of the selected conversation
+    ConfirmArchive,
     /// Export menu (save to file)
     ExportMenu { selected: usize },
     /// Yank menu (copy to clipboard)

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -223,6 +223,21 @@ pub fn run_with_loader(
                             }
                         }
                     }
+                    Action::Archive(ref path) => {
+                        let uuid = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                        match crate::history::archive_session_by_uuid(uuid) {
+                            Ok(_) => {
+                                app.remove_selected_from_list();
+                                app.exit_view_mode();
+                            }
+                            Err(e) => {
+                                let _ = debug_log::log_debug(&format!(
+                                    "Failed to archive session {}: {}",
+                                    uuid, e
+                                ));
+                            }
+                        }
+                    }
                     _ => return Ok((action, app.into_conversations())),
                 }
             }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -148,7 +148,9 @@ fn render_list_mode(frame: &mut Frame, app: &App) {
 
     // Render bottom bar: confirm dialog > status message > hotkeys
     if *app.dialog_mode() == DialogMode::ConfirmDelete {
-        render_confirm_dialog(frame, chunks[2]);
+        render_confirm_dialog(frame, chunks[2], ConfirmKind::Delete);
+    } else if *app.dialog_mode() == DialogMode::ConfirmArchive {
+        render_confirm_dialog(frame, chunks[2], ConfirmKind::Archive);
     } else if let Some((msg, instant)) = app.status_message()
         && instant.elapsed() < STATUS_TTL
     {
@@ -223,6 +225,8 @@ fn render_list_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(" rename  ", action_label),
         Span::styled(keys.delete.short_label(), action_key),
         Span::styled(" delete  ", action_label),
+        Span::styled(keys.archive.short_label(), action_key),
+        Span::styled(" archive  ", action_label),
     ];
 
     // Scope toggle (only when project context exists)
@@ -489,7 +493,8 @@ fn render_view_mode(frame: &mut Frame, app: &App, state: &ViewState) {
 
     // Render dialog overlay if active
     match app.dialog_mode() {
-        DialogMode::ConfirmDelete => render_confirm_dialog(frame, layout.status),
+        DialogMode::ConfirmDelete => render_confirm_dialog(frame, layout.status, ConfirmKind::Delete),
+        DialogMode::ConfirmArchive => render_confirm_dialog(frame, layout.status, ConfirmKind::Archive),
         DialogMode::ExportMenu { selected } => render_export_menu(frame, *selected, false),
         DialogMode::YankMenu { selected } => render_export_menu(frame, *selected, true),
         DialogMode::Help { scroll } => {
@@ -868,6 +873,8 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
             Span::styled(" fork  ", label_style),
             Span::styled(app.keys().delete.short_label(), key_style),
             Span::styled(" del  ", label_style),
+            Span::styled(app.keys().archive.short_label(), key_style),
+            Span::styled(" archive  ", label_style),
             Span::styled("q", key_style),
             Span::styled("uit", label_style),
         ]);
@@ -1160,13 +1167,19 @@ fn centered_modal_area(area: Rect, preferred_width: u16, preferred_height: u16) 
     }
 }
 
-fn render_confirm_dialog(frame: &mut Frame, area: Rect) {
+enum ConfirmKind {
+    Delete,
+    Archive,
+}
+
+fn render_confirm_dialog(frame: &mut Frame, area: Rect, kind: ConfirmKind) {
+    let text = match kind {
+        ConfirmKind::Delete => "Delete this conversation? ",
+        ConfirmKind::Archive => "Archive this conversation to ~/.claude/archive/? ",
+    };
     let prompt = Line::from(vec![
         Span::raw(" "),
-        Span::styled(
-            "Delete this conversation? ",
-            Style::default().fg(Color::Yellow),
-        ),
+        Span::styled(text, Style::default().fg(Color::Yellow)),
         Span::styled("(y/n)", Style::default().fg(rgb(th().text_secondary))),
     ]);
     let paragraph = Paragraph::new(prompt);
@@ -1320,6 +1333,7 @@ fn render_help_overlay(
             (keys.resume.help_label(), "Resume"),
             (keys.fork.help_label(), "Fork resume"),
             (keys.delete.help_label(), "Delete"),
+            (keys.archive.help_label(), "Archive"),
             ("q / Esc".into(), exit_text),
         ]
     } else {
@@ -1340,6 +1354,7 @@ fn render_help_overlay(
             (keys.fork.help_label(), "Fork resume"),
             (keys.rename.help_label(), "Rename"),
             (keys.delete.help_label(), "Delete"),
+            (keys.archive.help_label(), "Archive"),
             ("Esc".into(), "Quit"),
         ];
         if semantic_available {
@@ -3179,7 +3194,7 @@ mod tests {
             }))
             .unwrap();
         app.receive_search_results();
-        let backend = TestBackend::new(80, 2);
+        let backend = TestBackend::new(100, 2);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal


### PR DESCRIPTION
## Summary

Adds an archive action that moves a conversation's `.jsonl` (and its session subdirectory, if any) from `<claude>/projects/<project>/` to `<claude>/archive/<project>/`, preserving the encoded project directory layout. Useful when you want a conversation out of the active list but not gone forever.

- New keybinding (default `Ctrl+A`, configurable via `keys.archive` in `config.toml`) available in both list and view modes, with a `y/n` confirmation prompt that mirrors the delete flow.
- New `--archive <SESSION_ID>` CLI flag, symmetric with `--delete`.
- Cross-device safe: falls back to copy+remove when source and destination are on different filesystems.

## UX

- List/view mode: `Ctrl+A` → "Archive this conversation to ~/.claude/archive/? (y/n)" → confirmed sessions disappear from the list and the view exits, same as delete.
- Help overlay and status bars list the new archive shortcut next to delete.

## Files

- `src/history/loader.rs` — `archive_session_by_uuid()` + small `move_path` / `copy_dir_recursive` helpers.
- `src/history/mod.rs` — re-export.
- `src/config.rs` — `KeyBindings`/`KeysConfig` gain `archive` (default `Ctrl+A`).
- `src/tui/app/types.rs` — `Action::Archive(PathBuf)`, `DialogMode::ConfirmArchive`.
- `src/tui/app/dialog_state.rs` — confirm dispatches based on current dialog mode.
- `src/tui/app/input_controller.rs` — bind archive key in list + view modes; route both confirm dialogs.
- `src/tui/runtime.rs` — handle `Action::Archive`, same loop pattern as `Action::Delete`.
- `src/tui/ui.rs` — confirm-dialog text branches on kind; status bars + help overlay list archive.
- `src/main.rs` — `--archive` CLI handler (mirrors `--delete`); `Action::Archive` marked unreachable in the post-TUI match (handled inside `runtime`).
- `src/cli.rs` — new `--archive` arg + `conflicts_with_all` updated everywhere `delete` appeared.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release` — 536/537 pass; one pre-existing failure (`empty_prewarm_search_builds_cache_without_idle_short_circuit`) is environmental (tries to fetch `onnx/model.onnx`) and unrelated to this change.
- [x] `semantic_status_bar_keeps_hotkeys_when_result_metadata_exists` updated: 80-col `TestBackend` now widened to 100 so the longer status bar (extra `Ctrl+A archive` entry) still fits before the semantic indicator.
- [x] Manual: `~/.local/bin/claude-history` → `Ctrl+A` on a conversation moves the file + session dir into `~/.claude/archive/<encoded-project>/`; `--archive <UUID>` works headlessly.

## Notes

- Archive root is derived as `<projects-root>/../archive`, so it respects `CLAUDE_CONFIG_DIR` the same way `projects/` does.
- No changes to existing keybindings or flag semantics.