### PR TITLE
fix: don't crash on `document` content blocks (untagged enum UserContent error)

### DIFF
--- a/src/agent/transcript.rs
+++ b/src/agent/transcript.rs
@@ -377,7 +377,7 @@ fn blocks_to_parts(
                     ),
                 })
             }
-            ContentBlock::Image { .. } => None,
+            ContentBlock::Image { .. } | ContentBlock::Other => None,
         })
         .collect()
 }
@@ -387,7 +387,7 @@ pub(crate) fn content_blocks_count_as_agent_message(blocks: &[ContentBlock]) -> 
         ContentBlock::Text { text } => !text.trim().is_empty(),
         ContentBlock::ToolUse { .. } | ContentBlock::ToolResult { .. } => true,
         ContentBlock::Thinking { thinking, .. } => !thinking.trim().is_empty(),
-        ContentBlock::Image { .. } => false,
+        ContentBlock::Image { .. } | ContentBlock::Other => false,
     })
 }
 
@@ -426,7 +426,7 @@ fn agent_search_text_from_block(role: AgentMessageRole, block: &ContentBlock) ->
         ContentBlock::Thinking { thinking, .. } => {
             non_empty_text(&truncate_chars(thinking, MAX_AGENT_SEGMENT_CHARS))
         }
-        ContentBlock::Image { .. } => None,
+        ContentBlock::Image { .. } | ContentBlock::Other => None,
     }
 }
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -155,6 +155,9 @@ pub enum ContentBlock {
     Image {
         source: serde_json::Value,
     },
+    /// Unknown content block type.
+    #[serde(other)]
+    Other,
 }
 
 /// Extract only Text blocks (for previews and user-facing display)
@@ -362,5 +365,34 @@ mod tests {
         let content = json!([{"text": "no type field"}]);
         let result = bounded_tool_result_text(&content);
         assert_eq!(result, Some("no type field".into()));
+    }
+
+    #[test]
+    fn deserializes_user_message_with_document_block() {
+        // Unknown block types parse as `Other` without hiding text blocks.
+        let message: UserMessage = serde_json::from_value(json!({
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": "JVBERi0xLjcK..."
+                    }
+                },
+                { "type": "text", "text": "summarize this" }
+            ]
+        }))
+        .expect("document block should deserialize as Other");
+
+        match &message.content {
+            UserContent::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 2);
+                assert!(matches!(blocks[0], ContentBlock::Other));
+            }
+            other => panic!("expected blocks, got {other:?}"),
+        }
+        assert_eq!(extract_text_from_user(&message), "summarize this");
     }
 }


### PR DESCRIPTION
## Problem

`agent search`, `agent outline`, etc. abort with exit 1 on any conversation that ever contained a file attachment:

```
Error: JSON parsing error: data did not match any variant of untagged enum UserContent
```

Attaching a file to a message produces a `document` content block. `ContentBlock` is internally tagged on `type` and had variants for `text`, `tool_use`, `tool_result`, `thinking`, and `image` — but **no `document` variant and no catch-all**. So the block fails to deserialize, and because `UserContent` is `#[serde(untagged)]`, serde reports the failure at the *outer* level as the confusing "did not match any variant of untagged enum UserContent". The whole entry — and thus the whole conversation — is dropped from results.

### Reproduce
Run `claude-history agent search ...` (or `outline`) over history that includes a conversation where a PDF/file was attached to a prompt.

## Fix

Add a `#[serde(other)] Other` catch-all variant to `ContentBlock`. Unknown block types now deserialize gracefully instead of failing the entry. This:

- fixes `document` blocks today, and
- is forward-compatible with any future block type Claude Code introduces.

Unknown blocks contribute no searchable text and don't count as agent messages — identical treatment to `image`. The three exhaustive `match` sites in `agent/transcript.rs` are updated accordingly (`Image { .. } | Other`).

## Test

Adds `deserializes_user_message_with_document_block`, which deserializes a user message containing a `document` block alongside a `text` block, asserts the document parses as `Other`, and asserts the surrounding text is still extractable.

`cargo test` — 645 passed, 0 failed. `cargo fmt --check` clean. No new clippy warnings.