### PR TITLE
Pin Linux release builds to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             target: aarch64-apple-darwin
             platform: darwin-arm64
             use_cross: false
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             platform: linux-amd64
             use_cross: false


### PR DESCRIPTION
Fixes #57

Pins the Linux `linux-amd64` release build to `ubuntu-22.04` so prebuilt binaries stay compatible with GLIBC 2.35 (Ubuntu 22.04) instead of picking up GLIBC 2.38+ from `ubuntu-latest`.

Made with [Cursor](https://cursor.com)