### PR TITLE
add time filtering to conversation search

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,39 @@ Results are ranked by relevance using field-aware scoring: matches in the
 title, project name, and summary are weighted higher than body text. Within
 equally relevant results, recent conversations rank first.
 
+### Time filtering
+
+`--since` narrows to recent conversations, `--before` to older ones, and the two
+combine into a range. `--after` is an alias for `--since`, so the two cannot be
+used together. Both the conversation list and `agent search` accept them:
+
+```sh
+claude-history --since 2d
+claude-history agent search "cache invalidation" --since 1w
+claude-history agent search "cache invalidation" --after 2026-07-01 --before 2026-07-20
+```
+
+A value is either a duration back from now or an absolute local time:
+
+| Form | Meaning |
+| --- | --- |
+| `45s` `30m` `3h` `2d` `1w` | seconds, minutes, hours, days, weeks |
+| `6mo` `1y` | calendar months and years |
+| `1d6h` `1mo2w` | components combine |
+| `2026-07-20` | midnight local time |
+| `2026-07-20T14:30` | a time of day, space instead of `T` also accepted |
+
+Long spellings (`30minutes`, `2days`, `6months`) work too, and units are
+case-insensitive. Note that `m` is minutes and `mo` is months, months and years
+follow the calendar rather than 30- or 365-day approximations, and bounds are
+inclusive to the end of the unit written — so `--before 2026-07-20` includes all
+of the 20th.
+
+Filtering happens before ranking, so all four search modes honour it.
+Conversation times come from the transcript file's modification time — the same
+value behind the `3 days ago` column and the recency ranking bonus — so a
+resumed conversation counts as recent.
+
 ### Semantic search
 
 Semantic search ranks conversations by meaning instead of exact word matches. It
@@ -285,6 +318,9 @@ Options:
       --debug-search <QUERY>  Debug search result scoring for a query
       --debug [<LEVEL>]  Print debug information (optionally filter by level: debug, info, warn, error)
   -L, --local            Show only conversations from the current workspace directory
+      --since <WHEN>     Only conversations this recent (duration or date)
+      --after <WHEN>     Alias for --since
+      --before <WHEN>    Only conversations older than this duration or date
       --pager            Display output through a pager (less)
       --no-pager         Disable pager output
       --render <FILE>    Render a JSONL file in ledger format and exit

--- a/skills/claude-history/SKILL.md
+++ b/skills/claude-history/SKILL.md
@@ -37,7 +37,21 @@ claude-history agent search "DEPLOYMENT_TOKEN" --mode exact
 ```
 
 Search is global by default. Use `--local` for the current workspace or `--all`
-to explicitly override a configured local scope. Grouped search ranks
+to explicitly override a configured local scope. `--since` and `--before` narrow
+the corpus by time before ranking, and combine with `--local`:
+
+```sh
+claude-history agent search "retry backoff" --since 2d
+claude-history agent search "retry backoff" --after 2026-07-01 --before 2026-07-20 --local
+```
+
+Values are a duration back from now (`45s`, `30m`, `3h`, `2d`, `1w`, `6mo`, `1y`,
+or combined as `1d6h`) or an absolute local time (`2026-07-20`,
+`2026-07-20T14:30`). Note that `m` is minutes and `mo` is months. Bounds are
+inclusive and an upper bound covers the whole unit written, so
+`--before 2026-07-20` includes all of the 20th. `--after` is an alias for
+`--since`; passing both is an error, as is a range whose lower bound is later
+than its upper bound. Grouped search ranks
 conversations. `--flat` ranks message hits across conversations. Use
 `--hits-per-conv` when one conversation needs more evidence and `--all-hits`
 only when duplicate suppression hides relevant tool-heavy evidence.

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -155,9 +155,13 @@ impl AgentService {
         let config = config::load_config()?;
         let search_config = config.search.unwrap_or_default();
         let agent_config = config.agent.unwrap_or_default();
+        // Resolved before loading so an inverted range fails without paying for
+        // a full corpus parse.
+        let time = args.time.resolve()?;
         let mut conversations = history::load_all_conversations(false, None)?;
         conversations.retain(|conversation| {
             !project_is_excluded(&conversation.path, &agent_config.exclude_projects)
+                && time.matches(conversation.timestamp)
         });
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         let scope = configured_scope(args, &agent_config);
@@ -197,6 +201,15 @@ impl AgentService {
         let (mut keys, mut base_warnings) =
             discover_agent_keys(current_project_dir_name.as_deref())?;
         keys.retain(|key| !project_is_excluded(&key.path, &agent_config.exclude_projects));
+        if time.is_active() {
+            // Key discovery walks the projects directory independently, so
+            // without this every conversation outside the window would be
+            // reported as a skipped transcript rather than simply filtered out.
+            // Tested against each file's own timestamp, not against membership
+            // in `conversations`, so that transcripts inside the window which
+            // failed to parse still report their diagnostics.
+            keys.retain(|key| transcript_timestamp(&key.path).is_none_or(|at| time.matches(at)));
+        }
         base_warnings.extend(warnings_for_skipped_transcripts(
             self,
             &conversations,
@@ -624,6 +637,16 @@ fn ensure_complete_compact_output(output: String) -> Result<String> {
     }
 }
 
+/// The timestamp a transcript is filtered on, matching how conversation
+/// timestamps are derived. `None` when the file cannot be inspected, so callers
+/// keep it rather than silently dropping it.
+fn transcript_timestamp(path: &std::path::Path) -> Option<chrono::DateTime<chrono::Local>> {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .map(chrono::DateTime::<chrono::Local>::from)
+}
+
 fn structured_agent_error(error: AppError) -> AppError {
     match error {
         AppError::Agent(_) => error,
@@ -639,6 +662,9 @@ fn structured_agent_error(error: AppError) -> AppError {
         }
         AppError::Io(error) => AgentError::io(None, error.to_string()).into(),
         AppError::ConfigError(detail) => AgentError::invalid_ref("command", detail).into(),
+        AppError::TimeFilter(error) => {
+            AgentError::out_of_range(Some("command"), error.to_string()).into()
+        }
         error => AgentError::io(None, error.to_string()).into(),
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::agent::protocol::MessageLineRange;
 use crate::search::mode::SearchMode;
+use crate::time_filter::{TimeFilter, TimeFilterError, TimePoint};
 use clap::{ArgGroup, Args as ClapArgs, Parser, Subcommand};
 use std::fmt;
 use std::path::PathBuf;
@@ -158,6 +159,8 @@ pub struct AgentSearchArgs {
     pub all: bool,
     #[command(flatten)]
     pub search_mode: AgentSearchModeArgs,
+    #[command(flatten)]
+    pub time: TimeRangeArgs,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -234,6 +237,36 @@ pub struct AgentOutlineArgs {
     pub conversation: String,
     #[command(flatten)]
     pub output: AgentOutputFlags,
+}
+
+// Bounds that narrow the conversation corpus by timestamp before ranking.
+//
+// Flattened into both the top-level args and `agent search`, because
+// `args_conflicts_with_subcommands` means a top-level flag cannot be combined
+// with a subcommand. Kept as `//` rather than `///`: clap promotes a flattened
+// struct's doc comment to the containing command's long help.
+#[derive(Debug, Default, ClapArgs)]
+pub struct TimeRangeArgs {
+    /// Only conversations this recent, as a duration or date (2d, 1d6h, 6mo, 2026-07-20)
+    #[arg(long, value_name = "WHEN", group = "time_lower_bound")]
+    pub since: Option<TimePoint>,
+    /// Alias for --since
+    #[arg(long, value_name = "WHEN", group = "time_lower_bound")]
+    pub after: Option<TimePoint>,
+    /// Only conversations older than this duration or date
+    #[arg(long, value_name = "WHEN")]
+    pub before: Option<TimePoint>,
+}
+
+impl TimeRangeArgs {
+    /// Resolve the flags into a filter, relative to the current instant.
+    pub fn resolve(&self) -> std::result::Result<TimeFilter, TimeFilterError> {
+        TimeFilter::resolve(
+            self.since.as_ref(),
+            self.after.as_ref(),
+            self.before.as_ref(),
+        )
+    }
 }
 
 impl AgentSearchArgs {
@@ -363,6 +396,9 @@ pub struct Args {
         help = "Show only conversations from the current workspace directory"
     )]
     pub local: bool,
+
+    #[command(flatten)]
+    pub time: TimeRangeArgs,
 
     /// Display output through a pager (less)
     #[arg(long, group = "pager_display")]
@@ -499,6 +535,112 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn agent_search_captures_time_range_flags() {
+        let args = Args::try_parse_from([
+            "claude-history",
+            "agent",
+            "search",
+            "cache warming",
+            "--since",
+            "2d",
+            "--before",
+            "2026-07-20",
+        ])
+        .unwrap();
+
+        match args.command.unwrap() {
+            Commands::Agent {
+                command: AgentCommand::Search(search),
+            } => {
+                assert!(search.time.since.is_some());
+                assert!(search.time.after.is_none());
+                assert!(search.time.before.is_some());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_time_range_flags_are_accepted() {
+        let args = Args::try_parse_from(["claude-history", "--since", "1w"]).unwrap();
+        assert!(args.time.since.is_some());
+        assert!(args.time.resolve().unwrap().is_active());
+    }
+
+    #[test]
+    fn absent_time_range_flags_resolve_to_an_inactive_filter() {
+        let args = Args::try_parse_from(["claude-history"]).unwrap();
+        assert_eq!(args.time.resolve().unwrap(), TimeFilter::default());
+    }
+
+    #[test]
+    fn since_and_after_are_mutually_exclusive() {
+        assert!(
+            Args::try_parse_from(["claude-history", "--since", "2d", "--after", "3d"]).is_err()
+        );
+        assert!(
+            Args::try_parse_from([
+                "claude-history",
+                "agent",
+                "search",
+                "needle",
+                "--since",
+                "2d",
+                "--after",
+                "3d",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn since_and_before_can_be_combined() {
+        // Absolute on both ends so the assertion does not depend on today's
+        // date the way a relative lower bound would.
+        let args = Args::try_parse_from([
+            "claude-history",
+            "--since",
+            "2026-01-01",
+            "--before",
+            "2026-07-20",
+        ])
+        .unwrap();
+
+        let filter = args.time.resolve().unwrap();
+        assert!(filter.after.is_some());
+        assert!(filter.before.is_some());
+    }
+
+    #[test]
+    fn invalid_time_value_is_rejected_at_parse_time() {
+        let error = Args::try_parse_from(["claude-history", "--since", "30x"])
+            .expect_err("30x is not a valid span");
+
+        // Proves the bare FromStr impl's Display reaches the user rather than a
+        // generic clap "invalid value" message.
+        assert!(
+            error.to_string().contains("unknown unit 'x'"),
+            "unhelpful error: {error}"
+        );
+    }
+
+    #[test]
+    fn inverted_time_range_is_rejected_at_resolve_time() {
+        // clap accepts each value on its own; only resolving the pair catches
+        // the contradiction.
+        let args = Args::try_parse_from([
+            "claude-history",
+            "--after",
+            "2026-07-20",
+            "--before",
+            "2026-01-01",
+        ])
+        .unwrap();
+
+        assert!(args.time.resolve().is_err());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,9 @@ pub enum AppError {
     #[error("{0}")]
     AgentProtocol(String),
 
+    #[error("Invalid time range: {0}")]
+    TimeFilter(#[from] crate::time_filter::TimeFilterError),
+
     #[error("Semantic search cancelled")]
     SemanticSearchCancelled,
 }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -14,6 +14,7 @@ use crate::claude::{LogEntry, extract_search_text_from_user, parse_agent_progres
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
+use crate::time_filter::TimeFilter;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::{File, read_dir};
@@ -114,11 +115,12 @@ pub fn load_all_conversations(
 pub fn load_all_conversations_streaming(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time: TimeFilter,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level);
+        load_all_streaming_inner(tx, show_last, debug_level, time);
     });
 
     rx
@@ -128,6 +130,7 @@ fn load_all_streaming_inner(
     tx: Sender<LoaderMessage>,
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    time: TimeFilter,
 ) {
     // First, validate that the projects root exists (fatal if not)
     let root = match super::get_claude_projects_root() {
@@ -175,6 +178,17 @@ fn load_all_streaming_inner(
                     let project_path = conv.cwd.clone().unwrap_or_else(|| fallback_path.clone());
                     conv.project_name = Some(format_short_name_from_path(&project_path));
                     conv.project_path = Some(project_path);
+                }
+
+                // Filtered here rather than inside load_conversations, whose
+                // per-project cache is rebuilt from the vec it returns —
+                // dropping conversations earlier would evict their cache
+                // entries and force a re-parse on every later run.
+                if time.is_active() {
+                    convs.retain(|conv| time.matches(conv.timestamp));
+                    if convs.is_empty() {
+                        return;
+                    }
                 }
 
                 // Send batch, ignore error if receiver dropped

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod semantic;
 mod semantic_cli;
 mod syntax;
 mod text_match;
+mod time_filter;
 mod tool_format;
 mod tui;
 mod update;
@@ -235,9 +236,14 @@ fn run() -> Result<()> {
         }
     }
 
+    // Resolved before the search paths below so every one of them honours the
+    // window rather than silently ignoring it.
+    let time_filter = args.time.resolve()?;
+
     // Handle --debug-search flag: debug search result scoring
     if let Some(ref query) = args.debug_search {
         let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
         let searchable = search::precompute_search_text(&conversations);
@@ -317,11 +323,19 @@ fn run() -> Result<()> {
 
     if let Some(ref query) = args.debug_semantic_search {
         let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::debug_search(query, &conversations, args.local);
     }
 
     if args.generate_semantic_cache {
+        // Cache generation covers the whole corpus by definition; a partial
+        // cache would be silently wrong on later unfiltered searches.
+        if time_filter.is_active() {
+            return Err(AppError::ConfigError(
+                "--generate-semantic-cache cannot be combined with a time filter".to_string(),
+            ));
+        }
         let mut conversations = history::load_all_conversations(show_last, args.debug)?;
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::generate_cache(&conversations, args.local);
@@ -334,6 +348,7 @@ fn run() -> Result<()> {
     // Handle --semantic-search flag
     if let Some(ref query) = args.semantic_search {
         let mut conversations = history::load_all_conversations(show_last, args.debug)?;
+        conversations.retain(|conversation| time_filter.matches(conversation.timestamp));
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         return semantic_cli::run(query, &conversations, args.semantic_top, args.local);
     }
@@ -394,7 +409,16 @@ fn run() -> Result<()> {
     let workspace_filter = use_local;
 
     // Always use streaming global loader for all conversations
-    let rx = history::load_all_conversations_streaming(show_last, args.debug);
+    let rx = history::load_all_conversations_streaming(show_last, args.debug, time_filter);
+
+    // An empty result is far more often the time filter than an empty history,
+    // so say which when a filter is in play.
+    let describe_empty = |error| match error {
+        AppError::NoHistoryFound(scope) if time_filter.is_active() => {
+            AppError::NoHistoryFound(format!("{scope} within the requested time range"))
+        }
+        other => other,
+    };
 
     let (conversations, selected_path) = match tui::run_with_loader(
         rx,
@@ -407,7 +431,9 @@ fn run() -> Result<()> {
         tui::TuiSearchOptions {
             default_mode: tui_search_mode(search_mode),
         },
-    )? {
+    )
+    .map_err(describe_empty)?
+    {
         (tui::Action::Select(path), convs) => (convs, path),
         (tui::Action::Resume(path), convs) => {
             let conv = convs.iter().find(|c| c.path == path);

--- a/src/time_filter.rs
+++ b/src/time_filter.rs
@@ -1,0 +1,785 @@
+//! Time-based filtering for conversations.
+//!
+//! A [`TimeFilter`] holds an optional lower and upper bound and tests a
+//! conversation's `timestamp` against them. Bounds come from [`TimePoint`],
+//! which accepts either a relative span (`2d`, `1w6h`, `6mo`) or an absolute
+//! local datetime (`2026-07-20`, `2026-07-20T14:30`).
+//!
+//! Two details worth knowing:
+//!
+//! * `m` means minutes, not months. Months are `mo`. Bare `m` for months (as
+//!   some tools use) makes `30m` ambiguous between half an hour and two and a
+//!   half years, so this module refuses to guess.
+//! * Months and years are calendar-accurate, not 30- or 365-day
+//!   approximations. `1mo` before 2026-03-31 is 2026-02-28, and clamping to a
+//!   short month is what [`chrono::Months`] already does.
+
+use chrono::{DateTime, Duration, Local, LocalResult, Months, NaiveDateTime, TimeZone};
+use std::fmt;
+use std::str::FromStr;
+
+/// Error type for time filter parsing and resolution failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeFilterError {
+    /// The input was empty or only whitespace.
+    Empty,
+    /// A span component had a unit with no leading count (e.g. `"d"`, `"1dh"`).
+    MissingNumber(String),
+    /// A span ended with a count and no unit (e.g. `"2"`, `"1d2"`).
+    MissingUnit(String),
+    /// A count did not fit in the supported range.
+    NumberOverflow(String),
+    /// The unit is not one this module recognises.
+    UnknownUnit { unit: String, input: String },
+    /// The input looked absolute but matched none of the accepted formats.
+    UnknownDateFormat(String),
+    /// The local time does not exist or is ambiguous and could not be resolved.
+    UnresolvableLocalTime(String),
+    /// The resolved span or datetime fell outside the representable range.
+    OutOfRange(String),
+    /// The lower bound resolved later than the upper bound.
+    InvertedRange {
+        after: DateTime<Local>,
+        before: DateTime<Local>,
+    },
+}
+
+impl fmt::Display for TimeFilterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "expected a duration or date, got an empty value"),
+            Self::MissingNumber(input) => write!(
+                f,
+                "'{input}': every unit needs a count before it (e.g. '2d', not 'd')"
+            ),
+            Self::MissingUnit(input) => write!(
+                f,
+                "'{input}': every count needs a unit after it ({})",
+                UNIT_SUMMARY
+            ),
+            Self::NumberOverflow(input) => {
+                write!(f, "'{input}': count is too large")
+            }
+            Self::UnknownUnit { unit, input } => {
+                write!(f, "'{input}': unknown unit '{unit}' ({})", UNIT_SUMMARY)
+            }
+            Self::UnknownDateFormat(input) => write!(
+                f,
+                "'{input}': expected YYYY-MM-DD, YYYY-MM-DDTHH:MM, or YYYY-MM-DDTHH:MM:SS"
+            ),
+            Self::UnresolvableLocalTime(input) => write!(
+                f,
+                "'{input}': that local time does not exist in this timezone (daylight saving gap)"
+            ),
+            Self::OutOfRange(input) => {
+                write!(
+                    f,
+                    "'{input}': resolves to a time outside the supported range"
+                )
+            }
+            Self::InvertedRange { after, before } => write!(
+                f,
+                "lower bound {} is later than upper bound {}",
+                after.format("%Y-%m-%d %H:%M"),
+                before.format("%Y-%m-%d %H:%M")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TimeFilterError {}
+
+const UNIT_SUMMARY: &str = "s, m (minutes), h, d, w, mo (months), y";
+
+/// Which end of a range a [`TimePoint`] is being resolved for.
+///
+/// Upper bounds extend to the end of the precision the user typed, so
+/// `--before 2026-07-20` includes everything on the 20th rather than cutting
+/// off at midnight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Bound {
+    Lower,
+    Upper,
+}
+
+/// How precisely an absolute datetime was written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Precision {
+    Date,
+    Minute,
+    Second,
+}
+
+impl Precision {
+    /// The span this precision covers, used to extend upper bounds.
+    fn remainder(self) -> Duration {
+        match self {
+            Self::Date => Duration::days(1),
+            Self::Minute => Duration::minutes(1),
+            Self::Second => Duration::seconds(1),
+        }
+    }
+}
+
+/// A span measured backwards from a reference instant.
+///
+/// Calendar months are kept separate from the fixed-length remainder because
+/// they cannot be expressed as a [`Duration`] without picking an anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct RelativeSpan {
+    months: u32,
+    duration: Duration,
+}
+
+impl RelativeSpan {
+    /// Subtract this span from `now`.
+    fn before(&self, now: DateTime<Local>) -> Option<DateTime<Local>> {
+        let shifted = if self.months == 0 {
+            now
+        } else {
+            now.checked_sub_months(Months::new(self.months))?
+        };
+        shifted.checked_sub_signed(self.duration)
+    }
+}
+
+/// One end of a time range, parsed from a CLI value.
+///
+/// Opaque by design: callers only ever parse one and hand it to
+/// [`TimeFilter::resolve`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TimePoint(Point);
+
+/// Either a span backwards from now, or an absolutely pinned wall-clock time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Point {
+    Relative(RelativeSpan),
+    /// A local datetime, with the precision it was written at.
+    Absolute {
+        naive: NaiveDateTime,
+        precision: Precision,
+    },
+}
+
+impl TimePoint {
+    /// Resolve to a concrete instant, relative to `now` for spans.
+    fn resolve_at(
+        &self,
+        now: DateTime<Local>,
+        bound: Bound,
+    ) -> Result<DateTime<Local>, TimeFilterError> {
+        match &self.0 {
+            Point::Relative(span) => span
+                .before(now)
+                .ok_or_else(|| TimeFilterError::OutOfRange(format!("{span:?}"))),
+            Point::Absolute { naive, precision } => {
+                // An upper bound written to day precision should include the
+                // whole day, so extend to the last instant it covers.
+                let naive = match bound {
+                    Bound::Lower => *naive,
+                    Bound::Upper => naive
+                        .checked_add_signed(precision.remainder())
+                        .and_then(|end| end.checked_sub_signed(Duration::nanoseconds(1)))
+                        .ok_or_else(|| TimeFilterError::OutOfRange(naive.to_string()))?,
+                };
+                resolve_local(naive)
+            }
+        }
+    }
+}
+
+impl FromStr for TimePoint {
+    type Err = TimeFilterError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(TimeFilterError::Empty);
+        }
+        if looks_absolute(trimmed) {
+            let (naive, precision) = parse_absolute(trimmed)?;
+            Ok(Self(Point::Absolute { naive, precision }))
+        } else {
+            Ok(Self(Point::Relative(parse_span(trimmed)?)))
+        }
+    }
+}
+
+/// Whether the input opens like a date: four digits then a separator.
+///
+/// Checked before span parsing so date-shaped input gets a date-format error.
+/// Any non-alphanumeric separator counts, not just `-`, so a near-miss like
+/// `2026/07/20` is told the expected date format instead of being read as a
+/// span and complaining about a missing unit. A digit run followed by a letter
+/// (`2026d`) is still a span.
+fn looks_absolute(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 5
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && !bytes[4].is_ascii_alphanumeric()
+}
+
+/// Parse an absolute local datetime, reporting the precision it was written at.
+///
+/// `T` and a space are interchangeable separators so shell-quoted values and
+/// ISO-8601 both work.
+fn parse_absolute(s: &str) -> Result<(NaiveDateTime, Precision), TimeFilterError> {
+    const FORMATS: &[(&str, Precision)] = &[
+        ("%Y-%m-%dT%H:%M:%S", Precision::Second),
+        ("%Y-%m-%d %H:%M:%S", Precision::Second),
+        ("%Y-%m-%dT%H:%M", Precision::Minute),
+        ("%Y-%m-%d %H:%M", Precision::Minute),
+    ];
+
+    for (format, precision) in FORMATS {
+        if let Ok(naive) = NaiveDateTime::parse_from_str(s, format) {
+            return Ok((naive, *precision));
+        }
+    }
+
+    let date = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .map_err(|_| TimeFilterError::UnknownDateFormat(s.to_string()))?;
+    let naive = date
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| TimeFilterError::OutOfRange(s.to_string()))?;
+    Ok((naive, Precision::Date))
+}
+
+/// Attach the local timezone to a wall-clock time.
+///
+/// Daylight saving makes this fallible in two ways. When the clocks go back a
+/// local time happens twice; we take the earlier instant so a lower bound stays
+/// inclusive. When they go forward it never happens at all, and there is no
+/// sensible answer, so that is an error.
+fn resolve_local(naive: NaiveDateTime) -> Result<DateTime<Local>, TimeFilterError> {
+    match Local.from_local_datetime(&naive) {
+        LocalResult::Single(resolved) => Ok(resolved),
+        LocalResult::Ambiguous(earlier, _) => Ok(earlier),
+        LocalResult::None => Err(TimeFilterError::UnresolvableLocalTime(naive.to_string())),
+    }
+}
+
+/// Parse a relative span such as `3h`, `1w`, or `1d6h`.
+///
+/// Components are count/unit pairs and may repeat; their values add up.
+fn parse_span(s: &str) -> Result<RelativeSpan, TimeFilterError> {
+    let lowered = s.to_ascii_lowercase();
+    let bytes = lowered.as_bytes();
+    let mut span = RelativeSpan::default();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let digits_start = cursor;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if cursor == digits_start {
+            return Err(TimeFilterError::MissingNumber(s.to_string()));
+        }
+        let count: i64 = lowered[digits_start..cursor]
+            .parse()
+            .map_err(|_| TimeFilterError::NumberOverflow(s.to_string()))?;
+
+        let unit_start = cursor;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_alphabetic() {
+            cursor += 1;
+        }
+        if cursor == unit_start {
+            return Err(TimeFilterError::MissingUnit(s.to_string()));
+        }
+        let unit = &lowered[unit_start..cursor];
+
+        add_component(&mut span, count, unit, s)?;
+    }
+
+    Ok(span)
+}
+
+/// Fold one count/unit pair into `span`, rejecting unknown units and overflow.
+fn add_component(
+    span: &mut RelativeSpan,
+    count: i64,
+    unit: &str,
+    input: &str,
+) -> Result<(), TimeFilterError> {
+    let overflow = || TimeFilterError::NumberOverflow(input.to_string());
+
+    // `None` means "not a calendar unit"; the inner `Result` carries overflow
+    // from the year-to-month conversion.
+    let months = match unit {
+        "mo" | "mon" | "mos" | "month" | "months" => Some(Ok(count)),
+        "y" | "yr" | "yrs" | "year" | "years" => Some(count.checked_mul(12).ok_or_else(overflow)),
+        _ => None,
+    };
+
+    if let Some(months) = months {
+        let months = u32::try_from(months?).map_err(|_| overflow())?;
+        span.months = span.months.checked_add(months).ok_or_else(overflow)?;
+        return Ok(());
+    }
+
+    let duration = match unit {
+        "s" | "sec" | "secs" | "second" | "seconds" => Duration::try_seconds(count),
+        "m" | "min" | "mins" | "minute" | "minutes" => Duration::try_minutes(count),
+        "h" | "hr" | "hrs" | "hour" | "hours" => Duration::try_hours(count),
+        "d" | "day" | "days" => Duration::try_days(count),
+        "w" | "wk" | "wks" | "week" | "weeks" => Duration::try_weeks(count),
+        _ => {
+            return Err(TimeFilterError::UnknownUnit {
+                unit: unit.to_string(),
+                input: input.to_string(),
+            });
+        }
+    };
+
+    span.duration = span
+        .duration
+        .checked_add(&duration.ok_or_else(overflow)?)
+        .ok_or_else(overflow)?;
+    Ok(())
+}
+
+/// A resolved half-open-at-neither-end range used to filter conversations.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TimeFilter {
+    /// Include conversations at or after this instant.
+    pub after: Option<DateTime<Local>>,
+    /// Include conversations at or before this instant.
+    pub before: Option<DateTime<Local>>,
+}
+
+impl TimeFilter {
+    /// Resolve CLI arguments into a filter, relative to `now`.
+    ///
+    /// `since` and `after` are aliases for the lower bound, and the CLI declares
+    /// them mutually exclusive.
+    pub fn resolve_at(
+        now: DateTime<Local>,
+        since: Option<&TimePoint>,
+        after: Option<&TimePoint>,
+        before: Option<&TimePoint>,
+    ) -> Result<Self, TimeFilterError> {
+        let lower = after.or(since);
+        let filter = Self {
+            after: lower
+                .map(|point| point.resolve_at(now, Bound::Lower))
+                .transpose()?,
+            before: before
+                .map(|point| point.resolve_at(now, Bound::Upper))
+                .transpose()?,
+        };
+
+        if let (Some(after), Some(before)) = (filter.after, filter.before)
+            && after > before
+        {
+            return Err(TimeFilterError::InvertedRange { after, before });
+        }
+        Ok(filter)
+    }
+
+    /// Resolve CLI arguments into a filter, relative to the current instant.
+    pub fn resolve(
+        since: Option<&TimePoint>,
+        after: Option<&TimePoint>,
+        before: Option<&TimePoint>,
+    ) -> Result<Self, TimeFilterError> {
+        Self::resolve_at(Local::now(), since, after, before)
+    }
+
+    /// Whether `timestamp` falls inside both bounds. Bounds are inclusive.
+    pub fn matches(&self, timestamp: DateTime<Local>) -> bool {
+        if self.after.is_some_and(|after| timestamp < after) {
+            return false;
+        }
+        if self.before.is_some_and(|before| timestamp > before) {
+            return false;
+        }
+        true
+    }
+
+    /// Whether this filter constrains anything.
+    ///
+    /// Callers use this to skip filtering work entirely on the common
+    /// unfiltered path.
+    pub fn is_active(&self) -> bool {
+        self.after.is_some() || self.before.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, Timelike};
+
+    fn span(s: &str) -> RelativeSpan {
+        match s.parse::<TimePoint>().unwrap() {
+            TimePoint(Point::Relative(span)) => span,
+            other => panic!("expected a relative span, got {other:?}"),
+        }
+    }
+
+    fn absolute(s: &str, bound: Bound) -> DateTime<Local> {
+        s.parse::<TimePoint>()
+            .unwrap()
+            .resolve_at(Local::now(), bound)
+            .unwrap()
+    }
+
+    fn at(year: i32, month: u32, day: u32, hour: u32, minute: u32) -> DateTime<Local> {
+        Local
+            .with_ymd_and_hms(year, month, day, hour, minute, 0)
+            .unwrap()
+    }
+
+    // ==================== span parsing ====================
+
+    #[test]
+    fn parses_fixed_length_units() {
+        assert_eq!(span("45s").duration, Duration::seconds(45));
+        assert_eq!(span("30m").duration, Duration::minutes(30));
+        assert_eq!(span("3h").duration, Duration::hours(3));
+        assert_eq!(span("2d").duration, Duration::days(2));
+        assert_eq!(span("1w").duration, Duration::weeks(1));
+    }
+
+    #[test]
+    fn parses_long_unit_spellings() {
+        assert_eq!(span("30minutes").duration, Duration::minutes(30));
+        assert_eq!(span("2days").duration, Duration::days(2));
+        assert_eq!(span("3weeks").duration, Duration::weeks(3));
+        assert_eq!(span("6months").months, 6);
+        assert_eq!(span("2years").months, 24);
+    }
+
+    #[test]
+    fn unit_parsing_is_case_insensitive() {
+        assert_eq!(span("2D").duration, Duration::days(2));
+        assert_eq!(span("6MO").months, 6);
+    }
+
+    #[test]
+    fn m_means_minutes_and_mo_means_months() {
+        assert_eq!(span("1m").duration, Duration::minutes(1));
+        assert_eq!(span("1m").months, 0);
+        assert_eq!(span("1mo").months, 1);
+        assert_eq!(span("1mo").duration, Duration::zero());
+    }
+
+    #[test]
+    fn years_become_calendar_months() {
+        assert_eq!(span("1y").months, 12);
+        assert_eq!(span("1y").duration, Duration::zero());
+    }
+
+    #[test]
+    fn parses_compound_spans() {
+        let compound = span("1d6h");
+        assert_eq!(compound.duration, Duration::days(1) + Duration::hours(6));
+
+        let mixed = span("1mo2w3h");
+        assert_eq!(mixed.months, 1);
+        assert_eq!(mixed.duration, Duration::weeks(2) + Duration::hours(3));
+    }
+
+    #[test]
+    fn repeated_components_accumulate() {
+        assert_eq!(span("1h1h").duration, Duration::hours(2));
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(span("  2d  ").duration, Duration::days(2));
+    }
+
+    // ==================== span parsing failures ====================
+
+    #[test]
+    fn rejects_empty_input() {
+        assert_eq!("".parse::<TimePoint>(), Err(TimeFilterError::Empty));
+        assert_eq!("   ".parse::<TimePoint>(), Err(TimeFilterError::Empty));
+    }
+
+    #[test]
+    fn rejects_missing_number() {
+        assert_eq!(
+            "d".parse::<TimePoint>(),
+            Err(TimeFilterError::MissingNumber("d".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_missing_unit() {
+        assert_eq!(
+            "2".parse::<TimePoint>(),
+            Err(TimeFilterError::MissingUnit("2".to_string()))
+        );
+        assert_eq!(
+            "1d2".parse::<TimePoint>(),
+            Err(TimeFilterError::MissingUnit("1d2".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_unit() {
+        assert_eq!(
+            "2x".parse::<TimePoint>(),
+            Err(TimeFilterError::UnknownUnit {
+                unit: "x".to_string(),
+                input: "2x".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_negative_and_fractional_counts() {
+        // A leading '-' is not a digit, so this fails as a missing count
+        // rather than silently shifting the bound the wrong way.
+        assert!(matches!(
+            "-2d".parse::<TimePoint>(),
+            Err(TimeFilterError::MissingNumber(_))
+        ));
+        assert!(matches!(
+            "1.5d".parse::<TimePoint>(),
+            Err(TimeFilterError::MissingUnit(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_counts_that_do_not_fit_the_parser() {
+        assert!(matches!(
+            "99999999999999999999d".parse::<TimePoint>(),
+            Err(TimeFilterError::NumberOverflow(_))
+        ));
+        assert!(matches!(
+            "99999999999y".parse::<TimePoint>(),
+            Err(TimeFilterError::NumberOverflow(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_spans_that_parse_but_cannot_be_subtracted() {
+        // A day count can be large enough to be a valid chrono Duration yet
+        // still run off the start of the representable calendar, so the
+        // failure surfaces at resolution rather than at parse time.
+        let point: TimePoint = "9999999999d".parse().unwrap();
+        assert!(matches!(
+            point.resolve_at(at(2026, 7, 26, 12, 0), Bound::Lower),
+            Err(TimeFilterError::OutOfRange(_))
+        ));
+    }
+
+    // ==================== absolute parsing ====================
+
+    #[test]
+    fn parses_date_only_at_midnight() {
+        let parsed = absolute("2026-07-20", Bound::Lower);
+        assert_eq!((parsed.year(), parsed.month(), parsed.day()), (2026, 7, 20));
+        assert_eq!((parsed.hour(), parsed.minute(), parsed.second()), (0, 0, 0));
+    }
+
+    #[test]
+    fn parses_time_of_day_with_either_separator() {
+        let t_form = absolute("2026-07-20T14:30", Bound::Lower);
+        let space_form = absolute("2026-07-20 14:30", Bound::Lower);
+        assert_eq!(t_form, space_form);
+        assert_eq!((t_form.hour(), t_form.minute()), (14, 30));
+    }
+
+    #[test]
+    fn parses_seconds_precision() {
+        let parsed = absolute("2026-07-20T14:30:45", Bound::Lower);
+        assert_eq!(
+            (parsed.hour(), parsed.minute(), parsed.second()),
+            (14, 30, 45)
+        );
+    }
+
+    #[test]
+    fn upper_bound_extends_to_end_of_stated_precision() {
+        let end_of_day = absolute("2026-07-20", Bound::Upper);
+        assert_eq!(end_of_day.day(), 20);
+        assert_eq!(
+            (end_of_day.hour(), end_of_day.minute(), end_of_day.second()),
+            (23, 59, 59)
+        );
+
+        let end_of_minute = absolute("2026-07-20T14:30", Bound::Upper);
+        assert_eq!(
+            (
+                end_of_minute.hour(),
+                end_of_minute.minute(),
+                end_of_minute.second()
+            ),
+            (14, 30, 59)
+        );
+    }
+
+    #[test]
+    fn rejects_unrecognised_date_formats() {
+        for input in ["2026/07/20", "2026-13-01", "2026-07-20T99:99"] {
+            assert!(
+                matches!(
+                    input.parse::<TimePoint>(),
+                    Err(TimeFilterError::UnknownDateFormat(_))
+                ),
+                "expected {input} to be rejected as a date format"
+            );
+        }
+    }
+
+    #[test]
+    fn year_prefixed_input_is_never_read_as_a_span() {
+        // Without the leading-year check this would complain about the unit
+        // "-07-20", which tells the user nothing useful.
+        assert!(matches!(
+            "2026-07-20".parse::<TimePoint>(),
+            Ok(TimePoint(Point::Absolute { .. }))
+        ));
+        assert!(matches!(
+            "2026-99-99".parse::<TimePoint>(),
+            Err(TimeFilterError::UnknownDateFormat(_))
+        ));
+    }
+
+    #[test]
+    fn four_digit_span_is_still_a_span() {
+        assert_eq!(span("2026d").duration, Duration::days(2026));
+    }
+
+    // ==================== resolution ====================
+
+    #[test]
+    fn relative_spans_resolve_backwards_from_now() {
+        let now = at(2026, 7, 26, 12, 0);
+        let point: TimePoint = "2d".parse().unwrap();
+        assert_eq!(
+            point.resolve_at(now, Bound::Lower).unwrap(),
+            at(2026, 7, 24, 12, 0)
+        );
+    }
+
+    #[test]
+    fn months_are_calendar_accurate_not_thirty_days() {
+        let now = at(2026, 3, 31, 12, 0);
+        let point: TimePoint = "1mo".parse().unwrap();
+        let resolved = point.resolve_at(now, Bound::Lower).unwrap();
+
+        // February has no 31st, so chrono clamps to the 28th. A 30-day
+        // approximation would have landed on March 1st instead.
+        assert_eq!(
+            (resolved.year(), resolved.month(), resolved.day()),
+            (2026, 2, 28)
+        );
+    }
+
+    #[test]
+    fn years_cross_leap_days_correctly() {
+        let now = at(2025, 3, 1, 9, 0);
+        let point: TimePoint = "1y".parse().unwrap();
+        let resolved = point.resolve_at(now, Bound::Lower).unwrap();
+        assert_eq!(
+            (resolved.year(), resolved.month(), resolved.day()),
+            (2024, 3, 1)
+        );
+    }
+
+    #[test]
+    fn compound_span_applies_months_then_duration() {
+        let now = at(2026, 7, 26, 12, 0);
+        let point: TimePoint = "1mo1d".parse().unwrap();
+        assert_eq!(
+            point.resolve_at(now, Bound::Lower).unwrap(),
+            at(2026, 6, 25, 12, 0)
+        );
+    }
+
+    // ==================== filter construction ====================
+
+    #[test]
+    fn default_filter_matches_everything() {
+        let filter = TimeFilter::default();
+        assert!(!filter.is_active());
+        assert!(filter.matches(at(1999, 1, 1, 0, 0)));
+        assert!(filter.matches(at(2099, 1, 1, 0, 0)));
+    }
+
+    #[test]
+    fn since_sets_the_lower_bound_only() {
+        let now = at(2026, 7, 26, 12, 0);
+        let since: TimePoint = "2d".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, Some(&since), None, None).unwrap();
+
+        assert_eq!(filter.after, Some(at(2026, 7, 24, 12, 0)));
+        assert_eq!(filter.before, None);
+        assert!(filter.is_active());
+    }
+
+    #[test]
+    fn after_accepts_a_relative_span_too() {
+        let now = at(2026, 7, 26, 12, 0);
+        let after: TimePoint = "3h".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, None, Some(&after), None).unwrap();
+
+        assert_eq!(filter.after, Some(at(2026, 7, 26, 9, 0)));
+    }
+
+    #[test]
+    fn rejects_inverted_ranges() {
+        let now = at(2026, 7, 26, 12, 0);
+        let after: TimePoint = "2026-07-20".parse().unwrap();
+        let before: TimePoint = "2026-07-10".parse().unwrap();
+
+        assert!(matches!(
+            TimeFilter::resolve_at(now, None, Some(&after), Some(&before)),
+            Err(TimeFilterError::InvertedRange { .. })
+        ));
+    }
+
+    #[test]
+    fn a_single_day_range_is_not_inverted() {
+        // Both bounds parse to the same date, but the upper one extends to the
+        // end of the day, so the range is valid and covers exactly that day.
+        let now = at(2026, 7, 26, 12, 0);
+        let day: TimePoint = "2026-07-20".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, None, Some(&day), Some(&day)).unwrap();
+
+        assert!(filter.matches(at(2026, 7, 20, 0, 0)));
+        assert!(filter.matches(at(2026, 7, 20, 23, 59)));
+        assert!(!filter.matches(at(2026, 7, 21, 0, 0)));
+    }
+
+    // ==================== matching ====================
+
+    #[test]
+    fn bounds_are_inclusive() {
+        let now = at(2026, 7, 26, 12, 0);
+        let after: TimePoint = "2026-07-20T08:00".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, None, Some(&after), None).unwrap();
+
+        assert!(filter.matches(at(2026, 7, 20, 8, 0)));
+        assert!(!filter.matches(at(2026, 7, 20, 7, 59)));
+    }
+
+    #[test]
+    fn range_excludes_both_sides() {
+        let now = at(2026, 7, 26, 12, 0);
+        let after: TimePoint = "2026-07-10".parse().unwrap();
+        let before: TimePoint = "2026-07-20".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, None, Some(&after), Some(&before)).unwrap();
+
+        assert!(!filter.matches(at(2026, 7, 9, 23, 59)));
+        assert!(filter.matches(at(2026, 7, 15, 12, 0)));
+        assert!(!filter.matches(at(2026, 7, 21, 0, 0)));
+    }
+
+    #[test]
+    fn future_timestamps_match_an_open_upper_bound() {
+        // Clock skew between machines can leave transcripts stamped ahead of
+        // now; --since should still surface them.
+        let now = at(2026, 7, 26, 12, 0);
+        let since: TimePoint = "1d".parse().unwrap();
+        let filter = TimeFilter::resolve_at(now, Some(&since), None, None).unwrap();
+
+        assert!(filter.matches(at(2026, 7, 27, 12, 0)));
+    }
+}

--- a/src/time_filter.rs
+++ b/src/time_filter.rs
@@ -33,7 +33,7 @@ pub enum TimeFilterError {
     UnknownUnit { unit: String, input: String },
     /// The input looked absolute but matched none of the accepted formats.
     UnknownDateFormat(String),
-    /// The local time does not exist or is ambiguous and could not be resolved.
+    /// The local time does not exist because of a timezone transition.
     UnresolvableLocalTime(String),
     /// The resolved span or datetime fell outside the representable range.
     OutOfRange(String),
@@ -133,14 +133,27 @@ struct RelativeSpan {
 
 impl RelativeSpan {
     /// Subtract this span from `now`.
-    fn before(&self, now: DateTime<Local>) -> Option<DateTime<Local>> {
+    fn before(
+        &self,
+        now: DateTime<Local>,
+        bound: Bound,
+    ) -> Result<DateTime<Local>, TimeFilterError> {
         let shifted = if self.months == 0 {
             now
         } else {
-            now.checked_sub_months(Months::new(self.months))?
+            let naive = subtract_calendar_months(now.naive_local(), self.months)
+                .ok_or_else(|| TimeFilterError::OutOfRange(format!("{self:?}")))?;
+            resolve_local(naive, bound)?
         };
-        shifted.checked_sub_signed(self.duration)
+        shifted
+            .checked_sub_signed(self.duration)
+            .ok_or_else(|| TimeFilterError::OutOfRange(format!("{self:?}")))
     }
+}
+
+/// Subtract calendar months without resolving the resulting wall-clock time.
+fn subtract_calendar_months(naive: NaiveDateTime, months: u32) -> Option<NaiveDateTime> {
+    naive.checked_sub_months(Months::new(months))
 }
 
 /// One end of a time range, parsed from a CLI value.
@@ -169,9 +182,7 @@ impl TimePoint {
         bound: Bound,
     ) -> Result<DateTime<Local>, TimeFilterError> {
         match &self.0 {
-            Point::Relative(span) => span
-                .before(now)
-                .ok_or_else(|| TimeFilterError::OutOfRange(format!("{span:?}"))),
+            Point::Relative(span) => span.before(now, bound),
             Point::Absolute { naive, precision } => {
                 // An upper bound written to day precision should include the
                 // whole day, so extend to the last instant it covers.
@@ -182,7 +193,7 @@ impl TimePoint {
                         .and_then(|end| end.checked_sub_signed(Duration::nanoseconds(1)))
                         .ok_or_else(|| TimeFilterError::OutOfRange(naive.to_string()))?,
                 };
-                resolve_local(naive)
+                resolve_local(naive, bound)
             }
         }
     }
@@ -248,14 +259,27 @@ fn parse_absolute(s: &str) -> Result<(NaiveDateTime, Precision), TimeFilterError
 /// Attach the local timezone to a wall-clock time.
 ///
 /// Daylight saving makes this fallible in two ways. When the clocks go back a
-/// local time happens twice; we take the earlier instant so a lower bound stays
-/// inclusive. When they go forward it never happens at all, and there is no
-/// sensible answer, so that is an error.
-fn resolve_local(naive: NaiveDateTime) -> Result<DateTime<Local>, TimeFilterError> {
+/// local time happens twice; lower bounds take the earlier instant and upper
+/// bounds take the later one so inclusive ranges cover both occurrences. When
+/// the clocks go forward it never happens at all, and there is no sensible
+/// answer, so that is an error.
+fn resolve_local(naive: NaiveDateTime, bound: Bound) -> Result<DateTime<Local>, TimeFilterError> {
     match Local.from_local_datetime(&naive) {
         LocalResult::Single(resolved) => Ok(resolved),
-        LocalResult::Ambiguous(earlier, _) => Ok(earlier),
+        LocalResult::Ambiguous(first, second) => Ok(select_ambiguous(first, second, bound)),
         LocalResult::None => Err(TimeFilterError::UnresolvableLocalTime(naive.to_string())),
+    }
+}
+
+fn select_ambiguous<T: Copy + Ord>(first: T, second: T, bound: Bound) -> T {
+    let (earlier, later) = if first <= second {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    match bound {
+        Bound::Lower => earlier,
+        Bound::Upper => later,
     }
 }
 
@@ -691,6 +715,29 @@ mod tests {
             point.resolve_at(now, Bound::Lower).unwrap(),
             at(2026, 6, 25, 12, 0)
         );
+    }
+
+    #[test]
+    fn calendar_month_subtraction_preserves_wall_clock_time() {
+        let start = chrono::NaiveDate::from_ymd_opt(2026, 12, 1)
+            .unwrap()
+            .and_hms_opt(1, 30, 0)
+            .unwrap();
+        let expected = chrono::NaiveDate::from_ymd_opt(2026, 11, 1)
+            .unwrap()
+            .and_hms_opt(1, 30, 0)
+            .unwrap();
+
+        assert_eq!(subtract_calendar_months(start, 1), Some(expected));
+    }
+
+    #[test]
+    fn ambiguous_bounds_cover_both_possible_instants() {
+        let earlier = chrono::Utc.with_ymd_and_hms(2026, 11, 1, 5, 30, 0).unwrap();
+        let later = chrono::Utc.with_ymd_and_hms(2026, 11, 1, 6, 30, 0).unwrap();
+
+        assert_eq!(select_ambiguous(later, earlier, Bound::Lower), earlier);
+        assert_eq!(select_ambiguous(later, earlier, Bound::Upper), later);
     }
 
     // ==================== filter construction ====================

--- a/tests/agent_cli.rs
+++ b/tests/agent_cli.rs
@@ -20,15 +20,33 @@ fn project(config: &Path) -> PathBuf {
 }
 
 fn write_transcript(path: &Path, needle: &str) {
+    write_transcript_at(path, needle, "2026-07-20");
+}
+
+/// Backdate a transcript's modification time.
+///
+/// Conversation timestamps come from the file's mtime (see
+/// `history::parser`), not from the records inside it, so time filtering can
+/// only be exercised by changing the mtime. `stamp` is `YYYYMMDDhhmm`.
+fn set_modified(path: &Path, stamp: &str) {
+    let status = Command::new("touch")
+        .args(["-t", stamp])
+        .arg(path)
+        .status()
+        .expect("run touch");
+    assert!(status.success(), "touch -t {stamp} failed");
+}
+
+fn write_transcript_at(path: &Path, needle: &str, date: &str) {
     let user = serde_json::json!({
         "type": "user",
-        "timestamp": "2026-07-20T00:00:00Z",
+        "timestamp": format!("{date}T00:00:00Z"),
         "cwd": "/tmp/agent-phase3-tests",
         "message": {"role": "user", "content": needle}
     });
     let assistant = serde_json::json!({
         "type": "assistant",
-        "timestamp": "2026-07-20T00:00:01Z",
+        "timestamp": format!("{date}T00:00:01Z"),
         "message": {"role": "assistant", "content": [{"type": "text", "text": "answer"}]}
     });
     std::fs::write(path, format!("{user}\n{assistant}\n")).expect("write transcript");
@@ -237,4 +255,115 @@ fn agent_filesystem_failures_use_io_envelope() {
     let output = run(config.path(), &["agent", "search", "--lexical", "needle"]);
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).starts_with("protocol agent-error kind=io"));
+}
+
+#[test]
+fn search_time_range_narrows_the_corpus_without_reporting_skips() {
+    let config = tempfile::tempdir().expect("config");
+    let project = project(config.path());
+
+    let recent = project.join("11111111-1111-4111-9111-111111111111.jsonl");
+    let old = project.join("22222222-2222-4222-9222-222222222222.jsonl");
+    write_transcript_at(&recent, "time filter needle", "2026-07-20");
+    write_transcript_at(&old, "time filter needle", "2020-01-15");
+    set_modified(&recent, "202607200000");
+    set_modified(&old, "202001150000");
+
+    let unfiltered = run(
+        config.path(),
+        &["agent", "search", "--lexical", "time filter needle"],
+    );
+    assert!(
+        unfiltered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&unfiltered.stderr)
+    );
+    let unfiltered_stdout = String::from_utf8_lossy(&unfiltered.stdout);
+    assert!(unfiltered_stdout.contains("uuid=11111111"));
+    assert!(unfiltered_stdout.contains("uuid=22222222"));
+
+    let filtered = run(
+        config.path(),
+        &[
+            "agent",
+            "search",
+            "--lexical",
+            "time filter needle",
+            "--since",
+            "2026-01-01",
+        ],
+    );
+    assert!(
+        filtered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&filtered.stderr)
+    );
+    let filtered_stdout = String::from_utf8_lossy(&filtered.stdout);
+    assert!(filtered_stdout.contains("uuid=11111111"));
+    assert!(
+        !filtered_stdout.contains("uuid=22222222"),
+        "out-of-window conversation still returned: {filtered_stdout}"
+    );
+
+    // Key discovery walks the projects directory independently of the time
+    // filter, so an unfiltered key list would report every excluded
+    // conversation as a skipped transcript and claim partial coverage.
+    assert!(
+        !filtered_stdout.contains("kind=skipped"),
+        "filtered-out conversations were reported as skipped: {filtered_stdout}"
+    );
+
+    // The converse: narrowing the key list must not hide diagnostics for files
+    // that are inside the window but failed to parse, or a filtered search would
+    // claim full coverage it does not have.
+    let unparseable = project.join("33333333-3333-4333-9333-333333333333.jsonl");
+    std::fs::write(&unparseable, "{malformed\n").expect("write malformed transcript");
+    set_modified(&unparseable, "202607200000");
+
+    let with_malformed = run(
+        config.path(),
+        &[
+            "agent",
+            "search",
+            "--lexical",
+            "time filter needle",
+            "--since",
+            "2026-01-01",
+        ],
+    );
+    assert!(with_malformed.status.success());
+    let with_malformed_stdout = String::from_utf8_lossy(&with_malformed.stdout);
+    assert!(
+        with_malformed_stdout.contains("kind=malformed-transcript"),
+        "in-window malformed transcript was silently dropped: {with_malformed_stdout}"
+    );
+}
+
+#[test]
+fn search_rejects_an_inverted_time_range() {
+    let config = tempfile::tempdir().expect("config");
+    let transcript = project(config.path()).join("33333333-3333-4333-9333-333333333333.jsonl");
+    write_transcript(&transcript, "inverted range needle");
+
+    let output = run(
+        config.path(),
+        &[
+            "agent",
+            "search",
+            "--lexical",
+            "inverted range needle",
+            "--after",
+            "2026-07-20",
+            "--before",
+            "2026-01-01",
+        ],
+    );
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .starts_with("protocol agent-error kind=out-of-range"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
Adds `--since` / `--after` / `--before` to the conversation list and `agent search`.

```sh
claude-history --since 2d
claude-history agent search "cache invalidation" --since 1w
claude-history agent search "auth bug" --after 2026-07-01 --before 2026-07-20
```

A value is either a span back from now or an absolute local datetime:

| Form | Meaning |
| --- | --- |
| `45s` `30m` `3h` `2d` `1w` | seconds, minutes, hours, days, weeks |
| `6mo` `1y` | calendar months and years |
| `1d6h` `1mo2w` | components combine |
| `2026-07-20` | midnight local |
| `2026-07-20T14:30` | time of day, space instead of `T` also accepted |

Long spellings (`30minutes`, `2days`) are accepted and units are
case-insensitive. `m` is minutes, `mo` is months. Months and years use calendar
arithmetic rather than fixed 30- or 365-day spans, so `1mo` before March 31 is
February 28. Bounds are inclusive to the end of the unit written, so
`--before 2026-07-20` covers all of the 20th.

`--after` is an alias for `--since`; passing both is rejected, as is a range
whose lower bound resolves later than its upper bound. Invalid values are
rejected by clap at parse time.

No new dependencies. `chrono` was already present and `Cargo.lock` is unchanged.

## Behaviour

Filtering is applied before ranking, so lexical, exact, semantic and hybrid all
honour it.

Conversations are matched on `Conversation.timestamp`, which is the transcript
file's mtime — the same value used by the age column and the recency ranking
bonus. A resumed conversation therefore counts as recent. If you would rather
filter on a timestamp derived from the transcript records, that is a
straightforward change, but it would diverge from what the list displays.

Explicit refs are not time-gated, so `agent within`, `read` and `outline` are
unchanged. `--generate-semantic-cache` returns an error when a filter is
supplied, instead of writing a cache covering only part of the corpus.

Two implementation details:

- The streaming loader filters after `load_conversations` returns rather than
  inside it. That function rebuilds its per-project cache from the vec it
  returns, so filtering inside it would drop cache entries for out-of-window
  conversations and re-parse them on subsequent runs.
- `agent search` filters its key list by each file's own mtime rather than by
  membership in the filtered conversation vec. Keys come from a separate
  directory walk, so filtering by membership reports every out-of-window
  conversation as `kind=skipped`, and also hides diagnostics for in-window
  transcripts that fail to parse.

## Relation to #6

This implements the time-filtering part of #6 by @gwpl against current `main`.
That branch is ~400 commits behind and the `main.rs` code it modifies has since
been removed, so this is a new implementation rather than a rebase.

Not carried over from #6: path filtering, which overlaps the existing
`exclude_projects` config and required a `regex` dependency; the boolean query
parser, which overlaps `src/search/`; and the `[lib]` plus second-binary
restructure.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all-targets --locked`,
`cargo test --all --locked` and `cargo build --all --locked` pass. Clippy reports
the same 30 warnings as `main`. `nix build --no-link` passes.

Added 35 unit tests covering span and date parsing, calendar arithmetic, DST
resolution, overflow and boundary conditions; 9 CLI parsing tests; and 2
end-to-end tests, one asserting that a filtered search neither reports
out-of-window conversations as `kind=skipped` nor drops diagnostics for an
in-window malformed transcript.
