### PR TITLE
Support multiple config dirs in CLAUDE_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,20 @@ If you use the `CLAUDE_CONFIG_DIR` environment variable to store Claude's
 configuration in a non-default location, `claude-history` will respect it
 automatically — no extra flags needed.
 
+`CLAUDE_CONFIG_DIR` may also contain multiple config directories separated by
+the platform's `PATH` separator (`:` on Unix, `;` on Windows). This is handy if
+you keep separate Claude accounts, e.g. one for work and one for personal use:
+
+```sh
+CLAUDE_CONFIG_DIR="$HOME/.claude-personal:$HOME/.claude-work" claude-history
+```
+
+Conversations from all config directories are shown in one list, and resuming a
+conversation launches `claude` with `CLAUDE_CONFIG_DIR` set to the single
+config directory the session belongs to, so the right account is used
+automatically. (Note that `claude` itself expects a single directory — pass the
+multi-directory form only to `claude-history`.)
+
 ## Filtering details
 
 The tool filters out some noisy artifacts before showing conversations, so you

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -392,82 +392,88 @@ impl AgentService {
 fn discover_agent_keys(
     project_filter: Option<&str>,
 ) -> Result<(Vec<agent::refs::AgentConversationKey>, Vec<AgentWarning>)> {
-    let root = history::get_claude_projects_root().map_err(structured_agent_error)?;
-    let projects = std::fs::read_dir(&root).map_err(|error| {
-        AgentError::io(
-            Some(&root.to_string_lossy()),
-            format!("failed to list projects: {error}"),
-        )
-    })?;
+    let roots = history::get_claude_projects_roots().map_err(structured_agent_error)?;
     let mut keys = Vec::new();
     let mut warnings = Vec::new();
-    for project in projects {
-        let project = match project {
-            Ok(project) => project,
-            Err(error) => {
-                warnings.push(AgentWarning {
-                    kind: AgentWarningKind::Io,
-                    reference: None,
-                    detail: format!("failed to read project entry: {error}"),
-                });
-                continue;
-            }
-        };
-        let project_path = project.path();
-        if !project_path.is_dir() {
+    for root in &roots {
+        if !root.exists() {
             continue;
         }
-        let Some(project_name) = project_path.file_name().and_then(|name| name.to_str()) else {
-            continue;
-        };
-        if project_filter.is_some_and(|filter| !history::is_same_project(project_name, filter)) {
-            continue;
-        }
-        let entries = match std::fs::read_dir(&project_path) {
-            Ok(entries) => entries,
-            Err(error) => {
-                warnings.push(AgentWarning {
-                    kind: AgentWarningKind::Io,
-                    reference: None,
-                    detail: format!(
-                        "failed to list project transcripts at {}: {error}",
-                        project_path.display()
-                    ),
-                });
+        let projects = std::fs::read_dir(root).map_err(|error| {
+            AgentError::io(
+                Some(&root.to_string_lossy()),
+                format!("failed to list projects: {error}"),
+            )
+        })?;
+        for project in projects {
+            let project = match project {
+                Ok(project) => project,
+                Err(error) => {
+                    warnings.push(AgentWarning {
+                        kind: AgentWarningKind::Io,
+                        reference: None,
+                        detail: format!("failed to read project entry: {error}"),
+                    });
+                    continue;
+                }
+            };
+            let project_path = project.path();
+            if !project_path.is_dir() {
                 continue;
             }
-        };
-        for entry in entries {
-            let entry = match entry {
-                Ok(entry) => entry,
+            let Some(project_name) = project_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if project_filter.is_some_and(|filter| !history::is_same_project(project_name, filter))
+            {
+                continue;
+            }
+            let entries = match std::fs::read_dir(&project_path) {
+                Ok(entries) => entries,
                 Err(error) => {
                     warnings.push(AgentWarning {
                         kind: AgentWarningKind::Io,
                         reference: None,
                         detail: format!(
-                            "failed to read transcript entry in {}: {error}",
+                            "failed to list project transcripts at {}: {error}",
                             project_path.display()
                         ),
                     });
                     continue;
                 }
             };
-            let path = entry.path();
-            let Some(filename) = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(str::to_string)
-            else {
-                continue;
-            };
-            if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl")
-                && !filename.starts_with("agent-")
-            {
-                keys.push(agent::refs::AgentConversationKey::new(
-                    project_name,
-                    filename,
-                    path,
-                ));
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(error) => {
+                        warnings.push(AgentWarning {
+                            kind: AgentWarningKind::Io,
+                            reference: None,
+                            detail: format!(
+                                "failed to read transcript entry in {}: {error}",
+                                project_path.display()
+                            ),
+                        });
+                        continue;
+                    }
+                };
+                let path = entry.path();
+                let Some(filename) = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl")
+                    && !filename.starts_with("agent-")
+                {
+                    keys.push(agent::refs::AgentConversationKey::new(
+                        project_name,
+                        filename,
+                        path,
+                    ));
+                }
             }
         }
     }

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -65,29 +65,34 @@ pub struct CachedParseError {
 }
 
 /// Get the cache directory for per-project cache files.
-/// Respects CLAUDE_CONFIG_DIR to namespace caches per config root.
-fn cache_dir() -> Option<PathBuf> {
-    let base = home::home_dir()?.join(".cache").join("claude-history");
-    if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
-        // Namespace by config dir to avoid cross-config cache collisions
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        std::hash::Hash::hash(&config_dir, &mut hasher);
-        let hash = std::hash::Hasher::finish(&hasher);
-        Some(base.join(format!("config-{:016x}", hash)).join("projects"))
-    } else {
-        Some(base.join("projects"))
+/// Namespaced by the project's config root (derived from the project path) to
+/// avoid cross-config cache collisions when CLAUDE_CONFIG_DIR points at one or
+/// more non-default locations.
+fn cache_dir(project_dir: &std::path::Path) -> Option<PathBuf> {
+    let home = home::home_dir()?;
+    let base = home.join(".cache").join("claude-history");
+    let default_projects_root = home.join(".claude").join("projects");
+    match project_dir.parent() {
+        Some(projects_root) if projects_root != default_projects_root => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(&projects_root, &mut hasher);
+            let hash = std::hash::Hasher::finish(&hasher);
+            Some(base.join(format!("config-{:016x}", hash)).join("projects"))
+        }
+        _ => Some(base.join("projects")),
     }
 }
 
-/// Get the cache file path for a specific project
-fn cache_path_for_project(project_dir_name: &str) -> Option<PathBuf> {
-    cache_dir().map(|d| d.join(format!("{}.bin", project_dir_name)))
+/// Get the cache file path for a specific project directory
+fn cache_path_for_project(project_dir: &std::path::Path) -> Option<PathBuf> {
+    let name = project_dir.file_name()?.to_str()?;
+    cache_dir(project_dir).map(|d| d.join(format!("{}.bin", name)))
 }
 
 /// Read a project's cache file, returning entries keyed by session filename.
 /// Returns None on any failure (missing, corrupt, version mismatch).
-pub fn read_project_cache(project_dir_name: &str) -> Option<HashMap<String, CacheEntry>> {
-    let path = cache_path_for_project(project_dir_name)?;
+pub fn read_project_cache(project_dir: &std::path::Path) -> Option<HashMap<String, CacheEntry>> {
+    let path = cache_path_for_project(project_dir)?;
     let data = std::fs::read(&path).ok()?;
     if data.len() < 12 {
         return None;
@@ -104,8 +109,8 @@ pub fn read_project_cache(project_dir_name: &str) -> Option<HashMap<String, Cach
 
 /// Write a project's cache file atomically (temp file + rename).
 /// Uses tempfile for safe concurrent writes. Silently ignores failures.
-pub fn write_project_cache(project_dir_name: &str, entries: HashMap<String, CacheEntry>) {
-    let Some(path) = cache_path_for_project(project_dir_name) else {
+pub fn write_project_cache(project_dir: &std::path::Path, entries: HashMap<String, CacheEntry>) {
+    let Some(path) = cache_path_for_project(project_dir) else {
         return;
     };
     let Some(parent) = path.parent() else {
@@ -350,6 +355,14 @@ mod tests {
         assert!(!entry_matches(&entry, 501, mtime));
     }
 
+    fn test_project_dir(name: &str) -> std::path::PathBuf {
+        home::home_dir()
+            .unwrap()
+            .join(".claude")
+            .join("projects")
+            .join(name)
+    }
+
     #[test]
     fn cache_file_roundtrip() {
         // Use a unique project name to avoid test interference
@@ -365,10 +378,10 @@ mod tests {
         entries.insert("empty.jsonl".to_string(), empty_entry(100, mtime));
 
         // Write cache
-        write_project_cache(&project_name, entries);
+        write_project_cache(&test_project_dir(&project_name), entries);
 
         // Read it back
-        let loaded = read_project_cache(&project_name);
+        let loaded = read_project_cache(&test_project_dir(&project_name));
         assert!(loaded.is_some(), "Cache file should be readable");
 
         let loaded = loaded.unwrap();
@@ -384,7 +397,7 @@ mod tests {
         assert!(empty.is_empty);
 
         // Clean up
-        if let Some(path) = cache_path_for_project(&project_name) {
+        if let Some(path) = cache_path_for_project(&test_project_dir(&project_name)) {
             let _ = std::fs::remove_file(path);
         }
     }
@@ -392,13 +405,13 @@ mod tests {
     #[test]
     fn corrupt_cache_returns_none() {
         let project_name = format!("test-corrupt-{}", std::process::id());
-        if let Some(path) = cache_path_for_project(&project_name) {
+        if let Some(path) = cache_path_for_project(&test_project_dir(&project_name)) {
             if let Some(parent) = path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
             // Write garbage
             let _ = std::fs::write(&path, b"not a valid cache file");
-            assert!(read_project_cache(&project_name).is_none());
+            assert!(read_project_cache(&test_project_dir(&project_name)).is_none());
             let _ = std::fs::remove_file(path);
         }
     }
@@ -406,7 +419,7 @@ mod tests {
     #[test]
     fn wrong_version_returns_none() {
         let project_name = format!("test-version-{}", std::process::id());
-        if let Some(path) = cache_path_for_project(&project_name) {
+        if let Some(path) = cache_path_for_project(&test_project_dir(&project_name)) {
             if let Some(parent) = path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -418,7 +431,7 @@ mod tests {
             };
             let data = bincode::serialize(&cache).unwrap();
             let _ = std::fs::write(&path, &data);
-            assert!(read_project_cache(&project_name).is_none());
+            assert!(read_project_cache(&test_project_dir(&project_name)).is_none());
             let _ = std::fs::remove_file(path);
         }
     }
@@ -426,7 +439,7 @@ mod tests {
     #[test]
     fn wrong_magic_returns_none() {
         let project_name = format!("test-magic-{}", std::process::id());
-        if let Some(path) = cache_path_for_project(&project_name) {
+        if let Some(path) = cache_path_for_project(&test_project_dir(&project_name)) {
             if let Some(parent) = path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -437,13 +450,13 @@ mod tests {
             };
             let data = bincode::serialize(&cache).unwrap();
             let _ = std::fs::write(&path, &data);
-            assert!(read_project_cache(&project_name).is_none());
+            assert!(read_project_cache(&test_project_dir(&project_name)).is_none());
             let _ = std::fs::remove_file(path);
         }
     }
 
     #[test]
     fn missing_cache_returns_none() {
-        assert!(read_project_cache("nonexistent-project-xyz-12345").is_none());
+        assert!(read_project_cache(&test_project_dir("nonexistent-project-xyz-12345")).is_none());
     }
 }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -51,8 +51,16 @@ pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let root = super::get_claude_projects_root()?;
-    let projects = list_projects(&root)?;
+    let roots = super::get_claude_projects_roots()?;
+    let mut projects: Vec<(PathBuf, Project)> = Vec::new();
+    for root in &roots {
+        if !root.exists() {
+            continue;
+        }
+        for project in list_projects(root)? {
+            projects.push((root.clone(), project));
+        }
+    }
 
     debug::info(
         debug_level,
@@ -62,9 +70,9 @@ pub fn load_all_conversations(
     // Load conversations from all projects in parallel
     let mut all_conversations: Vec<Conversation> = projects
         .par_iter()
-        .flat_map(|project| {
+        .flat_map(|(root, project)| {
             let project_dir = root.join(&project.name);
-            match load_conversations(&project_dir, show_last, &project.name, debug_level) {
+            match load_conversations(&project_dir, show_last, debug_level) {
                 Ok(mut convs) => {
                     // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
@@ -129,8 +137,8 @@ fn load_all_streaming_inner(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) {
-    // First, validate that the projects root exists (fatal if not)
-    let root = match super::get_claude_projects_root() {
+    // First, validate that at least one projects root exists (fatal if none)
+    let roots = match super::get_claude_projects_roots() {
         Ok(r) => r,
         Err(e) => {
             let _ = tx.send(LoaderMessage::Fatal(e));
@@ -138,21 +146,29 @@ fn load_all_streaming_inner(
         }
     };
 
-    if !root.exists() {
+    let existing_roots: Vec<_> = roots.iter().filter(|r| r.exists()).collect();
+    if existing_roots.is_empty() {
         let _ = tx.send(LoaderMessage::Fatal(AppError::ProjectsDirNotFound(
-            root.display().to_string(),
+            roots
+                .iter()
+                .map(|r| r.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
         )));
         return;
     }
 
-    // List projects (fatal if this fails)
-    let projects = match list_projects(&root) {
-        Ok(p) => p,
-        Err(e) => {
-            let _ = tx.send(LoaderMessage::Fatal(e));
-            return;
+    // List projects across all roots (fatal if any listing fails)
+    let mut projects: Vec<(PathBuf, Project)> = Vec::new();
+    for root in existing_roots {
+        match list_projects(root) {
+            Ok(p) => projects.extend(p.into_iter().map(|project| (root.clone(), project))),
+            Err(e) => {
+                let _ = tx.send(LoaderMessage::Fatal(e));
+                return;
+            }
         }
-    };
+    }
 
     debug::info(
         debug_level,
@@ -160,10 +176,10 @@ fn load_all_streaming_inner(
     );
 
     // Process projects in parallel and send batches as they complete
-    projects.par_iter().for_each(|project| {
+    projects.par_iter().for_each(|(root, project)| {
         let project_dir = root.join(&project.name);
 
-        match load_conversations(&project_dir, show_last, &project.name, debug_level) {
+        match load_conversations(&project_dir, show_last, debug_level) {
             Ok(mut convs) => {
                 if convs.is_empty() {
                     return;
@@ -203,23 +219,23 @@ pub fn find_jsonl_by_uuid(uuid: &str) -> Result<Option<PathBuf>> {
 /// Find all session JSONL files by UUID across all projects.
 /// A session may exist in multiple project directories due to cross-project forking.
 fn find_all_jsonl_by_uuid(uuid: &str) -> Result<Vec<PathBuf>> {
-    let root = super::get_claude_projects_root()?;
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-
     let filename = format!("{}.jsonl", uuid);
     let mut matches = Vec::new();
 
-    for entry in read_dir(&root)? {
-        let entry = entry?;
-        let project_dir = entry.path();
-        if !project_dir.is_dir() {
+    for root in super::get_claude_projects_roots()? {
+        if !root.exists() {
             continue;
         }
-        let candidate = project_dir.join(&filename);
-        if candidate.exists() {
-            matches.push(candidate);
+        for entry in read_dir(&root)? {
+            let entry = entry?;
+            let project_dir = entry.path();
+            if !project_dir.is_dir() {
+                continue;
+            }
+            let candidate = project_dir.join(&filename);
+            if candidate.exists() {
+                matches.push(candidate);
+            }
         }
     }
 
@@ -283,31 +299,51 @@ pub fn delete_empty_transcripts(
 }
 
 fn find_empty_transcripts(scope: DeleteEmptyScope) -> Result<Vec<EmptyTranscript>> {
-    let root = super::get_claude_projects_root()?;
-    if !root.exists() {
-        return Err(AppError::ProjectsDirNotFound(root.display().to_string()));
+    let roots = super::get_claude_projects_roots()?;
+    let existing_roots: Vec<_> = roots.iter().filter(|r| r.exists()).cloned().collect();
+    if existing_roots.is_empty() {
+        return Err(AppError::ProjectsDirNotFound(
+            roots
+                .iter()
+                .map(|r| r.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
     }
 
-    let projects = match scope {
-        DeleteEmptyScope::All => list_projects(&root)?,
+    let mut projects: Vec<(PathBuf, Project)> = Vec::new();
+    match scope {
+        DeleteEmptyScope::All => {
+            for root in &existing_roots {
+                projects.extend(
+                    list_projects(root)?
+                        .into_iter()
+                        .map(|project| (root.clone(), project)),
+                );
+            }
+        }
         DeleteEmptyScope::Local => {
             let current_dir = std::env::current_dir()?;
             let project_dir_name = super::convert_path_to_project_dir_name(&current_dir);
-            let project_dir = root.join(&project_dir_name);
-            if !project_dir.exists() {
-                return Ok(Vec::new());
+            for root in &existing_roots {
+                if !root.join(&project_dir_name).exists() {
+                    continue;
+                }
+                projects.push((
+                    root.clone(),
+                    Project {
+                        name: project_dir_name.clone(),
+                        display_name: current_dir.display().to_string(),
+                        modified: SystemTime::UNIX_EPOCH,
+                    },
+                ));
             }
-            vec![Project {
-                name: project_dir_name,
-                display_name: current_dir.display().to_string(),
-                modified: SystemTime::UNIX_EPOCH,
-            }]
         }
-    };
+    }
 
     let mut candidates: Vec<EmptyTranscript> = projects
         .par_iter()
-        .flat_map(|project| {
+        .flat_map(|(root, project)| {
             let project_dir = root.join(&project.name);
             let entries = match read_dir(project_dir) {
                 Ok(entries) => entries,
@@ -467,11 +503,10 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
 pub fn load_conversations(
     projects_dir: &Path,
     show_last: bool,
-    project_dir_name: &str,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
     // Load existing cache for this project
-    let cached_entries = cache::read_project_cache(project_dir_name).unwrap_or_default();
+    let cached_entries = cache::read_project_cache(projects_dir).unwrap_or_default();
 
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
@@ -652,7 +687,7 @@ pub fn load_conversations(
             }
         }
 
-        cache::write_project_cache(project_dir_name, new_cache);
+        cache::write_project_cache(projects_dir, new_cache);
     }
 
     debug::info(

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -99,22 +99,39 @@ pub enum LoaderMessage {
     Done,
 }
 
-/// Get the root Claude projects directory (~/.claude/projects)
-/// Respects CLAUDE_CONFIG_DIR env variable if set.
-pub fn get_claude_projects_root() -> Result<PathBuf> {
-    let claude_dir = if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
-        PathBuf::from(config_dir)
-    } else {
-        let home_dir = home::home_dir().ok_or_else(|| {
-            AppError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Could not determine home directory",
-            ))
-        })?;
-        home_dir.join(".claude")
-    };
+/// Get all Claude projects directories.
+/// Respects CLAUDE_CONFIG_DIR env variable if set, which may contain multiple
+/// config directories separated by the platform's PATH separator (`:` on Unix),
+/// e.g. `CLAUDE_CONFIG_DIR=~/.claude-personal:~/.claude-work`.
+pub fn get_claude_projects_roots() -> Result<Vec<PathBuf>> {
+    if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        let roots: Vec<PathBuf> = std::env::split_paths(&config_dir)
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(|p| p.join("projects"))
+            .collect();
+        if !roots.is_empty() {
+            return Ok(roots);
+        }
+    }
 
-    Ok(claude_dir.join("projects"))
+    let home_dir = home::home_dir().ok_or_else(|| {
+        AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not determine home directory",
+        ))
+    })?;
+
+    Ok(vec![home_dir.join(".claude").join("projects")])
+}
+
+/// Get the root Claude projects directory (~/.claude/projects)
+/// Respects CLAUDE_CONFIG_DIR env variable if set. When CLAUDE_CONFIG_DIR
+/// contains multiple directories, returns the first one.
+pub fn get_claude_projects_root() -> Result<PathBuf> {
+    Ok(get_claude_projects_roots()?
+        .into_iter()
+        .next()
+        .expect("get_claude_projects_roots returns at least one root"))
 }
 
 /// Get the Claude projects directory for the current working directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -1541,7 +1541,13 @@ fn resolve_claude_resume_action(
             "Cannot determine conversation's project directory".to_string(),
         )
     })?;
-    let cwd_projects_dir = history::get_claude_projects_dir(cwd)?;
+    // Resolve sibling project dirs under the conversation's own projects root, so
+    // comparisons and copies stay within the config dir the session belongs to
+    // when CLAUDE_CONFIG_DIR lists multiple config dirs.
+    let projects_root = conv_projects_dir.parent().ok_or_else(|| {
+        AppError::ClaudeExecutionError("Cannot determine conversation's projects root".to_string())
+    })?;
+    let cwd_projects_dir = projects_root.join(history::convert_path_to_project_dir_name(cwd));
     let project_dir = project_path.filter(|p| p.exists() && p.is_dir());
 
     if project_dir.is_none() || (fork_session && cwd_projects_dir != conv_projects_dir) {
@@ -1555,7 +1561,8 @@ fn resolve_claude_resume_action(
     }
 
     let project_dir = project_dir.unwrap();
-    let project_projects_dir = history::get_claude_projects_dir(project_dir)?;
+    let project_projects_dir =
+        projects_root.join(history::convert_path_to_project_dir_name(project_dir));
     if project_projects_dir == conv_projects_dir {
         Ok(ClaudeResumeAction::Run {
             current_dir: project_dir.clone(),
@@ -1592,6 +1599,17 @@ fn resume_with_claude(
         )
     })?;
 
+    // When CLAUDE_CONFIG_DIR lists multiple config dirs, the spawned claude needs
+    // the single config dir the selected session belongs to.
+    let conv_config_dir = if std::env::var_os("CLAUDE_CONFIG_DIR").is_some() {
+        conv_projects_dir
+            .parent()
+            .and_then(Path::parent)
+            .map(Path::to_path_buf)
+    } else {
+        None
+    };
+
     match resolve_claude_resume_action(selected_path, project_path, &cwd, fork_session)? {
         ClaudeResumeAction::CopyToCurrent { cwd_projects_dir } => {
             std::fs::create_dir_all(&cwd_projects_dir).map_err(AppError::Io)?;
@@ -1606,6 +1624,9 @@ fn resume_with_claude(
             command.args(["--resume", &conversation_id]);
             command.args(default_args);
             command.current_dir(&cwd);
+            if let Some(config_dir) = &conv_config_dir {
+                command.env("CLAUDE_CONFIG_DIR", config_dir);
+            }
             run_claude_command(command)
         }
         ClaudeResumeAction::Run { current_dir } => {
@@ -1616,6 +1637,9 @@ fn resume_with_claude(
             }
             command.args(default_args);
             command.current_dir(current_dir);
+            if let Some(config_dir) = &conv_config_dir {
+                command.env("CLAUDE_CONFIG_DIR", config_dir);
+            }
 
             run_claude_command(command)
         }

--- a/tests/agent_cli.rs
+++ b/tests/agent_cli.rs
@@ -238,3 +238,36 @@ fn agent_filesystem_failures_use_io_envelope() {
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).starts_with("protocol agent-error kind=io"));
 }
+
+#[test]
+fn multiple_config_dirs_are_merged() {
+    let personal = tempfile::tempdir().expect("personal config");
+    let work = tempfile::tempdir().expect("work config");
+    let personal_transcript =
+        project(personal.path()).join("11111111-1234-4234-9234-123456789abc.jsonl");
+    write_transcript(&personal_transcript, "phase three needle");
+    let work_transcript = project(work.path()).join("22222222-1234-4234-9234-123456789abc.jsonl");
+    write_transcript(&work_transcript, "phase three needle");
+
+    let joined = std::env::join_paths([personal.path(), work.path()]).expect("join config dirs");
+
+    let output = Command::new(binary())
+        .env("CLAUDE_CONFIG_DIR", &joined)
+        .args(["agent", "search", "--lexical", "phase three needle"])
+        .output()
+        .expect("run claude-history");
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("11111111-1234-4234-9234-123456789abc"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("22222222-1234-4234-9234-123456789abc"),
+        "{stdout}"
+    );
+}


### PR DESCRIPTION
Adds support for `CLAUDE_CONFIG_DIR` containing multiple config directories separated by the platform's `PATH` separator (`:` on Unix, `;` on Windows), for people who keep separate Claude Code accounts (e.g. work and personal):

```sh
CLAUDE_CONFIG_DIR="$HOME/.claude-personal:$HOME/.claude-work" claude-history
```

Conversations from all config dirs show up in one list, and search/agent commands cover all of them.

## What changed

- `get_claude_projects_roots()` parses the variable with `std::env::split_paths` and returns all roots; the existing `get_claude_projects_root()` now returns the first root, so single-dir behavior is unchanged.
- The loaders (streaming and non-streaming), `delete-empty`, UUID lookup, and agent discovery iterate all roots. Missing roots are skipped; it's only fatal when none exist.
- **Resume picks the right account**: `resume_with_claude` derives the session's config dir from the transcript path and sets `CLAUDE_CONFIG_DIR` on the spawned `claude` (only when the variable was set at all), so the resumed session runs under the account it belongs to. Cross-project fork copies also stay within the session's own config dir instead of landing in the first root.
- **Cache collisions fixed**: the metadata cache was keyed by project dir name only, so the same project name under two config roots would collide. Cache paths are now namespaced by the projects root derived from the project path (and the cache layer no longer reads the env var directly). Existing caches for non-default config dirs are invalidated once and rebuilt automatically; default-location caches are untouched.

## Behavior when unchanged

- No `CLAUDE_CONFIG_DIR`: identical behavior, identical cache paths.
- Single dir in `CLAUDE_CONFIG_DIR`: identical behavior; cache namespace derivation changed from env-string hash to root-path hash, causing a one-time cache rebuild.

## Testing

- `cargo test` (725 tests) and `cargo clippy` pass; no new warnings.
- New integration test `multiple_config_dirs_are_merged` covers two config dirs with the same project name.
- Tested manually against two real config dirs (`~/.claude-home:~/.claude-work`): merged list, search across both, and resume launching `claude` with the correct config dir.

Related: #30 proposes multi-profile support via CCS integration; this is a dependency-free generic take on the same need.