### PR TITLE
centralize provider behavior behind a registry

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -55,8 +55,11 @@ guards this.
 | Cache magic / schema | `CLHIST01` / 11 | `PIHIST01` / 1 | `OMHIST01` / 1 |
 | Size limit | none | none | none |
 
-Caches live under `~/.cache/claude-history/`. The root hash keeps two roots apart. A
-root that moves misses the cache. It does not read stale entries.
+Caches live under `~/.cache/claude-history/`. `SessionCacheStore` holds the
+directory and the identity together, and takes both from `storage.cache()`, so a
+provider cannot stamp a file with one identity and file it under another. The
+root hash keeps two roots apart. A root that moves misses the cache. It does not
+read stale entries.
 
 `max_session_bytes()` returns `None` for all three providers. A provider that returns
 a limit makes the load loop skip larger transcripts and log a warning.
@@ -72,21 +75,33 @@ in the source they attribute a transcript to.
 | Session header | none | `{"type":"session", ...}` | same, after `title` slot |
 | Header fields | — | `id`, `timestamp`, `cwd`, `version` 1–3 | same |
 | File states its agent | — | no | yes, through `title` slot |
-| Agent when the file is silent | — | Pi | agent that owns the root |
+| Agent when the file is silent | — | Pi | OMP in OMP's own tree, Pi in a redirected one |
 | Branching | linear | `parentId` chain; only active branch projects | same |
 
 A transcript with no `title` slot reads equally well as Pi or as OMP. The root that
 holds the file decides. This is not cosmetic: it labels every assistant turn in the
 viewer.
 
-Two registry queries answer the two possible questions:
+`SessionRoot::origin()` answers which case a root is. The resolver in
+`omp_loader.rs` records it, because only the resolver knows: the config tree and
+the XDG data directory are OMP's own, and the `PI_CODING_AGENT_DIR` and
+`PI_CODING_AGENT_SESSION_DIR` overrides point at a directory the user chose,
+where Pi can write too. The answer is not recoverable from the path afterwards —
+a home directory can itself be named `omp`. Roots are redirected unless
+`SessionRoot::in_agent_tree()` says otherwise, so a provider that says nothing
+cannot claim a transcript that names no agent.
+
+Three registry queries answer the questions a caller can have:
 
 | Question | Function |
 |---|---|
 | Which format reads this file? | `format::parse_transcript(path)` |
-| Does this source own this file? | `format::parse_owned_transcript(source, path)` / `owns_transcript` |
+| Does this source own this file? | `format::parse_owned_transcript(source, path)` |
+| May this source delete this file? | `format::require_owned_transcript(source, path)` |
 
-Use the second one to guard a delete or a rename. "Parses" is weaker than "owns".
+"Parses" is weaker than "owns". All three fail rather than answer when the file
+cannot be read, so a guard never mistakes an unreadable transcript for one that
+belongs to somebody else.
 
 ## Session operations
 
@@ -119,7 +134,9 @@ launcher returns a command instead of running one.
    `Source::provider()`.
 4. Return `RefNamespaces` values that no other provider uses.
 5. Implement `SessionStorage` if the agent keeps sessions under roots. Otherwise
-   return `None` from `storage()`.
+   return `None` from `storage()`. Return the same `Source` from `storage()` as
+   from the provider, and mark a root the agent installs itself with
+   `SessionRoot::in_agent_tree()`.
 6. Implement `SessionFormat` in `src/history/format/` if transcripts carry a session
    header. Otherwise return `None` from `format()`.
 

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -13,47 +13,29 @@ provider::providers()              // iterate every registered provider
 Code lives in `src/history/provider/` (policy) and `src/history/format/` (wire
 formats).
 
-## Capability matrix
+The rules the registry enforces for every provider come first. Each provider then
+has a section of its own; Pi and OMP share one because they share a wire format.
+
+## Registry contract
 
 `storage` and `format` return `Option`. A provider returns `None` when it does not
 have that capability. The other methods are mandatory.
 
-| Capability | Claude | Pi | OMP |
-|---|---|---|---|
-| `labels().name` / `.list` / `.display` | `claude` / `CC` / `Claude` | `pi` / `Pi` / `Pi` | `omp` / `OMP` / `OMP` |
-| `storage()` | `None` | `PiStorage` | `OmpStorage` |
-| `format()` | `None` | `PI_LOG` | `OMP_LOG` |
-| `launcher()` | `ClaudeLauncher` | `PathResumeLauncher` | `PathResumeLauncher` |
-| `rename_session()` | yes | yes | yes |
-| `delete_session()` | yes | yes | yes |
-| `ref_namespaces().conversation` | `None` | `agent-pi-v1` | `agent-omp-v1` |
-| `ref_namespaces().project` | `agent-project-v1` | `agent-pi-project-v1` | `agent-omp-project-v1` |
+Reference namespaces are a compatibility contract. Users record references. If you
+change a namespace, every recorded reference breaks.
+`emitted_refs_and_project_ids_are_pinned` guards this.
 
-Claude returns `None` twice for two different reasons:
+Three registry queries answer the questions a caller can have:
 
-- **`storage()`** — Claude partitions sessions by project directory, not by session
-  root. It excludes `agent-*.jsonl`, caches per project, and streams project batches
-  to the TUI.
-- **`format()`** — Claude writes `LogEntry` records with no session header. There is
-  no id, start time, or cwd to project. A file that no format claims is read as a
-  Claude transcript.
+| Question                          | Function                                         |
+|-----------------------------------|--------------------------------------------------|
+| Which format reads this file?     | `format::parse_transcript(path)`                 |
+| Does this source own this file?   | `format::parse_owned_transcript(source, path)`   |
+| May this source delete this file? | `format::require_owned_transcript(source, path)` |
 
-Namespaces are a compatibility contract. Users record references. If you change a
-namespace, every recorded reference breaks. `emitted_refs_and_project_ids_are_pinned`
-guards this.
-
-## Storage and discovery
-
-| Property | Claude | Pi | OMP |
-|---|---|---|---|
-| Default root | `~/.claude/projects/<encoded-cwd>/` | `~/.pi/agent/sessions/` | `~/.omp/agent/sessions/` |
-| Layout | one directory per project | child directories | child directories |
-| Root overrides | `CLAUDE_CONFIG_DIR` | `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `sessionDir` in `settings.json` | same three, plus `PI_CONFIG_DIR`, `OMP_PROFILE`, `PI_PROFILE`, `XDG_DATA_HOME` |
-| Override layout | — | flat root | flat root |
-| Excluded files | `agent-*.jsonl` | none | none |
-| Cache file | `projects/<name>.bin` | `pi/root-<hash>/sessions.bin` | `omp/root-<hash>/sessions.bin` |
-| Cache magic / schema | `CLHIST01` / 11 | `PIHIST01` / 1 | `OMHIST01` / 1 |
-| Size limit | none | none | none |
+"Parses" is weaker than "owns". All three fail rather than answer when the file
+cannot be read, so a guard never mistakes an unreadable transcript for one that
+belongs to somebody else.
 
 Caches live under `~/.cache/claude-history/`. `SessionCacheStore` holds the
 directory and the identity together, and takes both from `storage.cache()`, so a
@@ -61,22 +43,92 @@ provider cannot stamp a file with one identity and file it under another. The
 root hash keeps two roots apart. A root that moves misses the cache. It does not
 read stale entries.
 
-`max_session_bytes()` returns `None` for all three providers. A provider that returns
-a limit makes the load loop skip larger transcripts and log a warning.
+A provider whose `max_session_bytes()` returns a limit makes the load loop skip
+larger transcripts and log a warning. Every registered provider returns `None`:
+no transcript is skipped for size.
 
-## Transcript format
+`[resume].default_args` documents arguments for the `claude` CLI.
+`SessionLaunch::configured_args` carries them to every launcher, and only Claude's
+applies them.
+
+## Claude
+
+| Capability                             | Value                      |
+|----------------------------------------|----------------------------|
+| `labels().name` / `.list` / `.display` | `claude` / `CC` / `Claude` |
+| `storage()`                            | `None`                     |
+| `format()`                             | `None`                     |
+| `launcher()`                           | `ClaudeLauncher`           |
+| `ref_namespaces().conversation`        | `None`                     |
+| `ref_namespaces().project`             | `agent-project-v1`         |
+
+The conversation namespace is `None` because Claude references predate per-source
+digests; they derive from the project directory and session filename.
+
+Claude returns `None` from both optional capabilities, for two different reasons:
+
+- **`storage()`** — Claude partitions sessions by project directory, not by session
+  root. It excludes `agent-*.jsonl`, caches per project, and streams project batches
+  to the TUI.
+- **`format()`** — Claude writes `LogEntry` records with no session header. There is
+  no id, start time, or cwd to project, and entries chain linearly. A file that no
+  format claims is read as a Claude transcript.
+
+| Storage              | Value                               |
+|----------------------|-------------------------------------|
+| Default root         | `~/.claude/projects/<encoded-cwd>/` |
+| Layout               | one directory per project           |
+| Root override        | `CLAUDE_CONFIG_DIR`                 |
+| Excluded files       | `agent-*.jsonl`                     |
+| Cache file           | `projects/<name>.bin`               |
+| Cache magic / schema | `CLHIST01` / 11                     |
+
+| Operation               | Behavior                                                                       |
+|-------------------------|--------------------------------------------------------------------------------|
+| Resume                  | `claude --resume <id>`, in the directory that maps to the transcript's project |
+| Fork                    | `claude --resume <id> --fork-session`, in the current directory                |
+| Cross-project fork      | copies transcript and session directory                                        |
+| `[resume].default_args` | applied                                                                        |
+| Rename                  | appends `custom-title` and `agent-name` records                                |
+| Delete                  | removes every copy, by session id                                              |
+
+Claude resumes by id and finds the transcript through the directory it runs in. When
+the session sits under a project Claude does not search, the launcher copies the files
+to one it does. Building a Claude command therefore writes to disk. This is why a
+launcher returns a command instead of running one.
+
+## Pi and OMP
 
 Pi and OMP share one wire format. Two `PiLogFormat` statics read it. They differ only
 in the source they attribute a transcript to.
 
-| Property | Claude | Pi | OMP |
-|---|---|---|---|
-| Records | `LogEntry` JSONL | Pi log JSONL | Pi log JSONL |
-| Session header | none | `{"type":"session", ...}` | same, after `title` slot |
-| Header fields | — | `id`, `timestamp`, `cwd`, `version` 1–3 | same |
-| File states its agent | — | no | yes, through `title` slot |
-| Agent when the file is silent | — | Pi | OMP in OMP's own tree, Pi in a redirected one |
-| Branching | linear | `parentId` chain; only active branch projects | same |
+| Capability                             | Pi                    | OMP                    |
+|----------------------------------------|-----------------------|------------------------|
+| `labels().name` / `.list` / `.display` | `pi` / `Pi` / `Pi`    | `omp` / `OMP` / `OMP`  |
+| `storage()`                            | `PiStorage`           | `OmpStorage`           |
+| `format()`                             | `PI_LOG`              | `OMP_LOG`              |
+| `launcher()`                           | `PathResumeLauncher`  | `PathResumeLauncher`   |
+| `ref_namespaces().conversation`        | `agent-pi-v1`         | `agent-omp-v1`         |
+| `ref_namespaces().project`             | `agent-pi-project-v1` | `agent-omp-project-v1` |
+
+| Storage              | Pi                                                                                    | OMP                                                                            |
+|----------------------|---------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| Default root         | `~/.pi/agent/sessions/`                                                               | `~/.omp/agent/sessions/`                                                       |
+| Layout               | child directories                                                                     | child directories                                                              |
+| Root overrides       | `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `sessionDir` in `settings.json` | same three, plus `PI_CONFIG_DIR`, `OMP_PROFILE`, `PI_PROFILE`, `XDG_DATA_HOME` |
+| Override layout      | flat root                                                                             | flat root                                                                      |
+| Excluded files       | none                                                                                  | none                                                                           |
+| Cache file           | `pi/root-<hash>/sessions.bin`                                                         | `omp/root-<hash>/sessions.bin`                                                 |
+| Cache magic / schema | `PIHIST01` / 1                                                                        | `OMHIST01` / 1                                                                 |
+
+| Transcript format             | Pi                                            | OMP                                           |
+|-------------------------------|-----------------------------------------------|-----------------------------------------------|
+| Records                       | Pi log JSONL                                  | Pi log JSONL                                  |
+| Session header                | `{"type":"session", ...}`                     | same, after `title` slot                      |
+| Header fields                 | `id`, `timestamp`, `cwd`, `version` 1–3       | same                                          |
+| File states its agent         | no                                            | yes, through `title` slot                     |
+| Agent when the file is silent | Pi                                            | OMP in OMP's own tree, Pi in a redirected one |
+| Branching                     | `parentId` chain; only active branch projects | same                                          |
 
 A transcript with no `title` slot reads equally well as Pi or as OMP. The root that
 holds the file decides. This is not cosmetic: it labels every assistant turn in the
@@ -91,38 +143,15 @@ a home directory can itself be named `omp`. Roots are redirected unless
 `SessionRoot::in_agent_tree()` says otherwise, so a provider that says nothing
 cannot claim a transcript that names no agent.
 
-Three registry queries answer the questions a caller can have:
-
-| Question | Function |
-|---|---|
-| Which format reads this file? | `format::parse_transcript(path)` |
-| Does this source own this file? | `format::parse_owned_transcript(source, path)` |
-| May this source delete this file? | `format::require_owned_transcript(source, path)` |
-
-"Parses" is weaker than "owns". All three fail rather than answer when the file
-cannot be read, so a guard never mistakes an unreadable transcript for one that
-belongs to somebody else.
-
-## Session operations
-
-| Operation | Claude | Pi | OMP |
-|---|---|---|---|
-| Resume | `claude --resume <id>` | `pi --session <path>` | `omp --resume <path>` |
-| Resume runs in | directory that maps to the transcript's project | session project directory | session project directory |
-| Fork | `claude --resume <id> --fork-session` | `pi --fork <path>` | `omp --fork <path>` |
-| Fork runs in | current directory | current directory | current directory |
-| Cross-project fork | copies transcript and session directory | not applicable | not applicable |
-| `[resume].default_args` | applied | ignored | ignored |
-| Rename | appends `custom-title` and `agent-name` records | appends `session_info` record | rewrites `title` slot, appends `title_change` |
-| Delete | removes every copy, by session id | removes file | removes file and artifact directory |
-
-`[resume].default_args` documents arguments for the `claude` CLI. Only Claude applies
-them. `SessionLaunch::configured_args` carries them.
-
-Claude resumes by id and finds the transcript through the directory it runs in. When
-the session sits under a project Claude does not search, the launcher copies the files
-to one it does. Building a Claude command therefore writes to disk. This is why a
-launcher returns a command instead of running one.
+| Operation               | Pi                            | OMP                                           |
+|-------------------------|-------------------------------|-----------------------------------------------|
+| Resume                  | `pi --session <path>`         | `omp --resume <path>`                         |
+| Resume runs in          | session project directory     | session project directory                     |
+| Fork                    | `pi --fork <path>`            | `omp --fork <path>`                           |
+| Fork runs in            | current directory             | current directory                             |
+| `[resume].default_args` | ignored                       | ignored                                       |
+| Rename                  | appends `session_info` record | rewrites `title` slot, appends `title_change` |
+| Delete                  | removes file                  | removes file and artifact directory           |
 
 ## Add a provider
 
@@ -139,6 +168,8 @@ launcher returns a command instead of running one.
    `SessionRoot::in_agent_tree()`.
 6. Implement `SessionFormat` in `src/history/format/` if transcripts carry a session
    header. Otherwise return `None` from `format()`.
+7. Document the provider in a section of its own in this file, with the same
+   tables as the sections above.
 
 Nothing else needs a change. Every other consumer reads the registry.
 

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -166,7 +166,11 @@ cannot claim a transcript that names no agent.
 5. Implement `SessionStorage` if the agent keeps sessions under roots. Otherwise
    return `None` from `storage()`. Return the same `Source` from `storage()` as
    from the provider, and mark a root the agent installs itself with
-   `SessionRoot::in_agent_tree()`.
+   `SessionRoot::in_agent_tree()`. `discover()` reports each session as a
+   `SessionStub` — locator, cache key, change fingerprint — and the load loop
+   consumes stubs as given — it never stats or opens a locator itself — so a
+   root does not have to be a directory of transcript files. File-backed providers
+   compose the walkers in `provider/walk.rs`.
 6. Implement `SessionFormat` in `src/history/format/` if transcripts carry a session
    header. Otherwise return `None` from `format()`.
 7. Document the provider in a section of its own in this file, with the same

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -37,7 +37,8 @@ Three registry queries answer the questions a caller can have:
 cannot be read, so a guard never mistakes an unreadable transcript for one that
 belongs to somebody else.
 
-Caches live under `~/.cache/claude-history/`. `SessionCacheStore` holds the
+Caches live under `~/.cache/claude-history/`, or under the directory
+`CLAUDE_HISTORY_CACHE_DIR` names. `SessionCacheStore` holds the
 directory and the identity together, and takes both from `storage.cache()`, so a
 provider cannot stamp a file with one identity and file it under another. The
 root hash keeps two roots apart. A root that moves misses the cache. It does not

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,130 @@
+# Provider support
+
+A provider is one coding agent whose history this tool reads. `Source` identifies
+the agent. `SessionProvider` holds everything that differs between agents.
+
+To add an agent, register a provider. Do not add match arms.
+
+```rust
+Source::Pi.provider().launcher()   // reach behavior through the registry
+provider::providers()              // iterate every registered provider
+```
+
+Code lives in `src/history/provider/` (policy) and `src/history/format/` (wire
+formats).
+
+## Capability matrix
+
+`storage` and `format` return `Option`. A provider returns `None` when it does not
+have that capability. The other methods are mandatory.
+
+| Capability | Claude | Pi | OMP |
+|---|---|---|---|
+| `labels().name` / `.list` / `.display` | `claude` / `CC` / `Claude` | `pi` / `Pi` / `Pi` | `omp` / `OMP` / `OMP` |
+| `storage()` | `None` | `PiStorage` | `OmpStorage` |
+| `format()` | `None` | `PI_LOG` | `OMP_LOG` |
+| `launcher()` | `ClaudeLauncher` | `PathResumeLauncher` | `PathResumeLauncher` |
+| `rename_session()` | yes | yes | yes |
+| `delete_session()` | yes | yes | yes |
+| `ref_namespaces().conversation` | `None` | `agent-pi-v1` | `agent-omp-v1` |
+| `ref_namespaces().project` | `agent-project-v1` | `agent-pi-project-v1` | `agent-omp-project-v1` |
+
+Claude returns `None` twice for two different reasons:
+
+- **`storage()`** — Claude partitions sessions by project directory, not by session
+  root. It excludes `agent-*.jsonl`, caches per project, and streams project batches
+  to the TUI.
+- **`format()`** — Claude writes `LogEntry` records with no session header. There is
+  no id, start time, or cwd to project. A file that no format claims is read as a
+  Claude transcript.
+
+Namespaces are a compatibility contract. Users record references. If you change a
+namespace, every recorded reference breaks. `emitted_refs_and_project_ids_are_pinned`
+guards this.
+
+## Storage and discovery
+
+| Property | Claude | Pi | OMP |
+|---|---|---|---|
+| Default root | `~/.claude/projects/<encoded-cwd>/` | `~/.pi/agent/sessions/` | `~/.omp/agent/sessions/` |
+| Layout | one directory per project | child directories | child directories |
+| Root overrides | `CLAUDE_CONFIG_DIR` | `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `sessionDir` in `settings.json` | same three, plus `PI_CONFIG_DIR`, `OMP_PROFILE`, `PI_PROFILE`, `XDG_DATA_HOME` |
+| Override layout | — | flat root | flat root |
+| Excluded files | `agent-*.jsonl` | none | none |
+| Cache file | `projects/<name>.bin` | `pi/root-<hash>/sessions.bin` | `omp/root-<hash>/sessions.bin` |
+| Cache magic / schema | `CLHIST01` / 11 | `PIHIST01` / 1 | `OMHIST01` / 1 |
+| Size limit | none | none | none |
+
+Caches live under `~/.cache/claude-history/`. The root hash keeps two roots apart. A
+root that moves misses the cache. It does not read stale entries.
+
+`max_session_bytes()` returns `None` for all three providers. A provider that returns
+a limit makes the load loop skip larger transcripts and log a warning.
+
+## Transcript format
+
+Pi and OMP share one wire format. Two `PiLogFormat` statics read it. They differ only
+in the source they attribute a transcript to.
+
+| Property | Claude | Pi | OMP |
+|---|---|---|---|
+| Records | `LogEntry` JSONL | Pi log JSONL | Pi log JSONL |
+| Session header | none | `{"type":"session", ...}` | same, after `title` slot |
+| Header fields | — | `id`, `timestamp`, `cwd`, `version` 1–3 | same |
+| File states its agent | — | no | yes, through `title` slot |
+| Agent when the file is silent | — | Pi | agent that owns the root |
+| Branching | linear | `parentId` chain; only active branch projects | same |
+
+A transcript with no `title` slot reads equally well as Pi or as OMP. The root that
+holds the file decides. This is not cosmetic: it labels every assistant turn in the
+viewer.
+
+Two registry queries answer the two possible questions:
+
+| Question | Function |
+|---|---|
+| Which format reads this file? | `format::parse_transcript(path)` |
+| Does this source own this file? | `format::parse_owned_transcript(source, path)` / `owns_transcript` |
+
+Use the second one to guard a delete or a rename. "Parses" is weaker than "owns".
+
+## Session operations
+
+| Operation | Claude | Pi | OMP |
+|---|---|---|---|
+| Resume | `claude --resume <id>` | `pi --session <path>` | `omp --resume <path>` |
+| Resume runs in | directory that maps to the transcript's project | session project directory | session project directory |
+| Fork | `claude --resume <id> --fork-session` | `pi --fork <path>` | `omp --fork <path>` |
+| Fork runs in | current directory | current directory | current directory |
+| Cross-project fork | copies transcript and session directory | not applicable | not applicable |
+| `[resume].default_args` | applied | ignored | ignored |
+| Rename | appends `custom-title` and `agent-name` records | appends `session_info` record | rewrites `title` slot, appends `title_change` |
+| Delete | removes every copy, by session id | removes file | removes file and artifact directory |
+
+`[resume].default_args` documents arguments for the `claude` CLI. Only Claude applies
+them. `SessionLaunch::configured_args` carries them.
+
+Claude resumes by id and finds the transcript through the directory it runs in. When
+the session sits under a project Claude does not search, the launcher copies the files
+to one it does. Building a Claude command therefore writes to disk. This is why a
+launcher returns a command instead of running one.
+
+## Add a provider
+
+1. Add a variant to `Source`. Fix every exhaustiveness error the compiler reports.
+2. Create `src/history/provider/<agent>.rs`. Declare a unit struct in it and
+   implement `SessionProvider` for that struct.
+3. Declare the module in `provider/mod.rs`. Add a `static` for the struct, list that
+   static in `PROVIDERS`, and map the new `Source` variant to it in
+   `Source::provider()`.
+4. Return `RefNamespaces` values that no other provider uses.
+5. Implement `SessionStorage` if the agent keeps sessions under roots. Otherwise
+   return `None` from `storage()`.
+6. Implement `SessionFormat` in `src/history/format/` if transcripts carry a session
+   header. Otherwise return `None` from `format()`.
+
+Nothing else needs a change. Every other consumer reads the registry.
+
+Run `just check`. The tests in `src/history/provider/mod.rs` enforce the registry
+invariants: one entry per source, unique labels, unique reference namespaces, and
+unique cache identities.

--- a/src/agent/refs.rs
+++ b/src/agent/refs.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 const REF_NAMESPACE: &str = "agent-v1";
-const PROJECT_NAMESPACE: &str = "agent-project-v1";
 const MIN_EMITTED_DIGEST_HEX_LEN: usize = 12;
 const PROJECT_DIGEST_HEX_LEN: usize = 16;
 const MIN_PREFIX_HEX_LEN: usize = 8;
@@ -136,47 +135,29 @@ impl AgentConversationKey {
     }
 
     pub fn conversation_ref(&self) -> AgentConversationRef {
-        match self.source {
-            Source::Claude => {
-                AgentConversationRef::from_parts(&self.project_dir_name, &self.session_filename)
-            }
-            Source::Pi => {
-                let digest = digest_parts([
-                    "agent-pi-v1",
-                    self.source.label(),
-                    &self.project_dir_name,
-                    &self.session_id,
-                    &self.session_filename,
-                ]);
-                AgentConversationRef {
-                    uuid: self.session_id.clone(),
-                    digest_hex: format!("{digest:032x}"),
-                    emitted_digest_hex_len: MIN_EMITTED_DIGEST_HEX_LEN,
-                }
-            }
-            Source::Omp => {
-                let digest = digest_parts([
-                    "agent-omp-v1",
-                    self.source.label(),
-                    &self.project_dir_name,
-                    &self.session_id,
-                    &self.session_filename,
-                ]);
-                AgentConversationRef {
-                    uuid: self.session_id.clone(),
-                    digest_hex: format!("{digest:032x}"),
-                    emitted_digest_hex_len: MIN_EMITTED_DIGEST_HEX_LEN,
-                }
-            }
+        let Some(namespace) = self.source.provider().ref_namespaces().conversation else {
+            return AgentConversationRef::from_parts(
+                &self.project_dir_name,
+                &self.session_filename,
+            );
+        };
+        let digest = digest_parts([
+            namespace,
+            self.source.label(),
+            &self.project_dir_name,
+            &self.session_id,
+            &self.session_filename,
+        ]);
+        AgentConversationRef {
+            uuid: self.session_id.clone(),
+            digest_hex: format!("{digest:032x}"),
+            emitted_digest_hex_len: MIN_EMITTED_DIGEST_HEX_LEN,
         }
     }
 
     pub fn project_id(&self) -> String {
-        let identity = match self.source {
-            Source::Claude => format!("{PROJECT_NAMESPACE}\0{}", self.project_dir_name),
-            Source::Pi => format!("agent-pi-project-v1\0{}", self.project_dir_name),
-            Source::Omp => format!("agent-omp-project-v1\0{}", self.project_dir_name),
-        };
+        let namespace = self.source.provider().ref_namespaces().project;
+        let identity = format!("{namespace}\0{}", self.project_dir_name);
         format!(
             "pr_{}",
             &blake3::hash(identity.as_bytes()).to_hex()[..PROJECT_DIGEST_HEX_LEN]
@@ -555,6 +536,43 @@ mod tests {
         match error {
             AppError::Agent(error) => error.kind,
             error => panic!("expected agent error, got {error}"),
+        }
+    }
+
+    /// Emitted references are a compatibility contract: users record them and the
+    /// agent CLI resolves them later. A digest may only move together with the
+    /// namespace version that produced it, never as a side effect of a refactor.
+    #[test]
+    fn emitted_refs_and_project_ids_are_pinned() {
+        let claude = key("-tmp-project", "12345678-1234-4234-9234-123456789abc.jsonl");
+        let pi = AgentConversationKey {
+            source: Source::Pi,
+            project_dir_name: "/tmp/project".to_owned(),
+            session_filename: "session.jsonl".to_owned(),
+            session_id: "pinned-session".to_owned(),
+            path: PathBuf::from("/sessions/session.jsonl"),
+        };
+        let omp = AgentConversationKey {
+            source: Source::Omp,
+            ..pi.clone()
+        };
+
+        for (key, expected_ref, expected_project) in [
+            (claude, "ch_2eb29a5ff6fe", "pr_43f686a8bc2ab51b"),
+            (pi, "ch_659c5686656c", "pr_c9e9570f0b65ac69"),
+            (omp, "ch_4f3fc618223b", "pr_6ce38c1b3f996862"),
+        ] {
+            let label = key.source.label();
+            assert_eq!(
+                key.conversation_ref().canonical(),
+                expected_ref,
+                "{label} conversation ref changed"
+            );
+            assert_eq!(
+                key.project_id(),
+                expected_project,
+                "{label} project id changed"
+            );
         }
     }
 

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -541,7 +541,7 @@ fn root_storage_keys(project_filter: Option<&str>) -> Vec<agent::refs::AgentConv
                 continue;
             };
             for path in files {
-                let Some(projection) =
+                let Ok(Some(projection)) =
                     history::format::parse_owned_transcript(provider.source(), &path)
                 else {
                     continue;

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -504,109 +504,86 @@ fn discover_agent_keys(
             }
         }
     }
-    if let Ok(pi_root) = history::pi_loader::session_root()
-        && let Ok(pi_files) = pi_root.discover_files()
-    {
-        let current = std::env::current_dir()
-            .ok()
-            .map(|path| path.canonicalize().unwrap_or(path));
-        for path in pi_files {
-            let Some(projection) =
-                history::format::parse_owned_transcript(history::Source::Pi, &path)
-            else {
-                continue;
-            };
-            if let Some(filter) = project_filter {
-                let cwd = projection
-                    .header
-                    .cwd
-                    .canonicalize()
-                    .unwrap_or_else(|_| projection.header.cwd.clone());
-                let current_matches_filter = current.as_ref().is_some_and(|current| {
-                    history::is_same_project(
-                        &history::convert_path_to_project_dir_name(current),
-                        filter,
-                    )
-                });
-                if !current_matches_filter || current.as_ref() != Some(&cwd) {
-                    continue;
-                }
-            }
-            let project_identity = projection
-                .header
-                .cwd
-                .canonicalize()
-                .unwrap_or(projection.header.cwd)
-                .to_string_lossy()
-                .into_owned();
-            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            keys.push(agent::refs::AgentConversationKey {
-                source: history::Source::Pi,
-                project_dir_name: project_identity,
-                session_filename: filename.to_owned(),
-                session_id: projection.header.id,
-                path,
-            });
-        }
-    }
-    if let Ok(omp_root) = history::omp_loader::session_root()
-        && let Ok(omp_files) = omp_root.discover_files()
-    {
-        let current = std::env::current_dir()
-            .ok()
-            .map(|path| path.canonicalize().unwrap_or(path));
-        for path in omp_files {
-            let Some(projection) =
-                history::format::parse_owned_transcript(history::Source::Omp, &path)
-            else {
-                continue;
-            };
-            if let Some(filter) = project_filter {
-                let cwd = projection
-                    .header
-                    .cwd
-                    .canonicalize()
-                    .unwrap_or_else(|_| projection.header.cwd.clone());
-                let current_matches_filter = current.as_ref().is_some_and(|current| {
-                    history::is_same_project(
-                        &history::convert_path_to_project_dir_name(current),
-                        filter,
-                    )
-                });
-                if !current_matches_filter || current.as_ref() != Some(&cwd) {
-                    continue;
-                }
-            }
-            let project_identity = projection
-                .header
-                .cwd
-                .canonicalize()
-                .unwrap_or(projection.header.cwd)
-                .to_string_lossy()
-                .into_owned();
-            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            keys.push(agent::refs::AgentConversationKey {
-                source: history::Source::Omp,
-                project_dir_name: project_identity,
-                session_filename: filename.to_owned(),
-                session_id: projection.header.id,
-                path,
-            });
-        }
-    }
+    keys.extend(root_storage_keys(project_filter));
     if keys.is_empty() && !root.exists() {
         return Err(AgentError::io(
             Some(&root.to_string_lossy()),
-            "no Claude, Pi, or OMP history storage is available",
+            format!(
+                "no {} history storage is available",
+                history::provider::display_names_in_prose()
+            ),
         )
         .into());
     }
     keys.sort_by(|left, right| left.path.cmp(&right.path));
     Ok((keys, warnings))
+}
+
+/// Keys for every provider that keeps its sessions under roots.
+///
+/// Claude is scanned separately, by project directory: it has no session root and
+/// its transcripts are named after the session rather than describing one.
+fn root_storage_keys(project_filter: Option<&str>) -> Vec<agent::refs::AgentConversationKey> {
+    let current = std::env::current_dir()
+        .ok()
+        .map(|path| path.canonicalize().unwrap_or(path));
+    let mut keys = Vec::new();
+
+    for provider in history::provider::providers() {
+        let Some(storage) = provider.storage() else {
+            continue;
+        };
+        let Ok(roots) = storage.roots() else {
+            continue;
+        };
+        for root in roots {
+            let Ok(files) = root.discover_files() else {
+                continue;
+            };
+            for path in files {
+                let Some(projection) =
+                    history::format::parse_owned_transcript(provider.source(), &path)
+                else {
+                    continue;
+                };
+                let session_cwd = projection
+                    .header
+                    .cwd
+                    .canonicalize()
+                    .unwrap_or_else(|_| projection.header.cwd.clone());
+                if let Some(filter) = project_filter
+                    && !session_is_in_filtered_project(filter, current.as_deref(), &session_cwd)
+                {
+                    continue;
+                }
+                let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+                    continue;
+                };
+                keys.push(agent::refs::AgentConversationKey {
+                    source: provider.source(),
+                    project_dir_name: session_cwd.to_string_lossy().into_owned(),
+                    session_filename: filename.to_owned(),
+                    session_id: projection.header.id,
+                    path,
+                });
+            }
+        }
+    }
+    keys
+}
+
+/// These sessions are keyed by their own working directory rather than by an
+/// encoded project directory name, so a project filter only matches when the
+/// filter names the directory the agent is running in *and* the session ran there.
+fn session_is_in_filtered_project(
+    filter: &str,
+    current: Option<&std::path::Path>,
+    session_cwd: &std::path::Path,
+) -> bool {
+    current.is_some_and(|current| {
+        history::is_same_project(&history::convert_path_to_project_dir_name(current), filter)
+            && current == session_cwd
+    })
 }
 
 fn warnings_for_skipped_transcripts(

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -511,12 +511,11 @@ fn discover_agent_keys(
             .ok()
             .map(|path| path.canonicalize().unwrap_or(path));
         for path in pi_files {
-            let Ok(Some(projection)) = history::pi::parse_file(&path) else {
+            let Some(projection) =
+                history::format::parse_owned_transcript(history::Source::Pi, &path)
+            else {
                 continue;
             };
-            if projection.source != history::Source::Pi {
-                continue;
-            }
             if let Some(filter) = project_filter {
                 let cwd = projection
                     .header
@@ -559,7 +558,9 @@ fn discover_agent_keys(
             .ok()
             .map(|path| path.canonicalize().unwrap_or(path));
         for path in omp_files {
-            let Ok(Some(projection)) = history::pi::parse_omp_file(&path) else {
+            let Some(projection) =
+                history::format::parse_owned_transcript(history::Source::Omp, &path)
+            else {
                 continue;
             };
             if let Some(filter) = project_filter {

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -124,27 +124,35 @@ impl AgentService {
         }
     }
 
-    fn load_transcript(&self, path: &Path) -> Result<agent::transcript::AgentTranscript> {
+    fn load_transcript(
+        &self,
+        key: &agent::refs::AgentConversationKey,
+    ) -> Result<agent::transcript::AgentTranscript> {
+        let path: &Path = &key.path;
         if let Some(cached) = self.transcripts.borrow().get(path) {
             return cached.clone().map_err(AppError::from);
         }
         #[cfg(test)]
         self.transcript_parse_count
             .set(self.transcript_parse_count.get() + 1);
-        let loaded = agent::transcript::AgentTranscript::load(path).map_err(|error| match error {
-            AppError::Agent(error) => error,
-            AppError::Io(error) => AgentError::io(
-                Some(&path.to_string_lossy()),
-                format!("failed to read transcript: {error}"),
-            ),
-            AppError::Json(error) => AgentError::malformed_transcript(
-                Some(&path.to_string_lossy()),
-                format!("failed to parse transcript JSONL: {error}"),
-            ),
-            error => {
-                AgentError::malformed_transcript(Some(&path.to_string_lossy()), error.to_string())
-            }
-        });
+        let loaded =
+            agent::transcript::AgentTranscript::load_owned(key.source, path).map_err(|error| {
+                match error {
+                    AppError::Agent(error) => error,
+                    AppError::Io(error) => AgentError::io(
+                        Some(&path.to_string_lossy()),
+                        format!("failed to read transcript: {error}"),
+                    ),
+                    AppError::Json(error) => AgentError::malformed_transcript(
+                        Some(&path.to_string_lossy()),
+                        format!("failed to parse transcript JSONL: {error}"),
+                    ),
+                    error => AgentError::malformed_transcript(
+                        Some(&path.to_string_lossy()),
+                        error.to_string(),
+                    ),
+                }
+            });
         self.transcripts
             .borrow_mut()
             .insert(path.to_path_buf(), loaded.clone());
@@ -225,7 +233,7 @@ impl AgentService {
                     &conversations,
                     &keys,
                     &ranked,
-                    |key| self.load_transcript(&key.path),
+                    |key| self.load_transcript(key),
                     |key, error| {
                         warnings.borrow_mut().push(AgentWarning::from_app_error(
                             error,
@@ -269,7 +277,7 @@ impl AgentService {
                     &conversations,
                     &keys,
                     &ranked,
-                    |key| self.load_transcript(&key.path),
+                    |key| self.load_transcript(key),
                     |key, error| {
                         warnings.borrow_mut().push(AgentWarning::from_app_error(
                             error,
@@ -304,7 +312,7 @@ impl AgentService {
                             &conversations,
                             &keys,
                             &ranked,
-                            |key| self.load_transcript(&key.path),
+                            |key| self.load_transcript(key),
                             |key, error| {
                                 warnings.borrow_mut().push(AgentWarning::from_app_error(
                                     error,
@@ -336,7 +344,7 @@ impl AgentService {
         let (keys, _) = discover_agent_keys(None)?;
         let resolved = resolve_agent_conversation_arg(&args.conversation, Some(&keys))?;
         let transcript = self
-            .load_transcript(&resolved.key.path)
+            .load_transcript(&resolved.key)
             .map_err(|error| target_error(error, &resolved))?;
         let conversation = conversation_from_agent_transcript(&transcript, resolved.key.source);
         let transcript_warnings = transcript_warning(&transcript, &resolved.reference.canonical())
@@ -504,7 +512,9 @@ fn discover_agent_keys(
             }
         }
     }
-    keys.extend(root_storage_keys(project_filter));
+    let (root_keys, root_warnings) = root_storage_keys(project_filter);
+    keys.extend(root_keys);
+    warnings.extend(root_warnings);
     if keys.is_empty() && !root.exists() {
         return Err(AgentError::io(
             Some(&root.to_string_lossy()),
@@ -523,24 +533,40 @@ fn discover_agent_keys(
 ///
 /// Claude is scanned separately, by project directory: it has no session root and
 /// its transcripts are named after the session rather than describing one.
-fn root_storage_keys(project_filter: Option<&str>) -> Vec<agent::refs::AgentConversationKey> {
+///
+/// A provider whose sessions cannot be listed contributes a warning rather
+/// than vanishing: the other providers stay searchable, and the caller can
+/// tell a broken store from an absent one.
+fn root_storage_keys(
+    project_filter: Option<&str>,
+) -> (Vec<agent::refs::AgentConversationKey>, Vec<AgentWarning>) {
     let current = std::env::current_dir()
         .ok()
         .map(|path| path.canonicalize().unwrap_or(path));
     let mut keys = Vec::new();
+    let mut warnings = Vec::new();
 
     for provider in history::provider::providers() {
         let Some(storage) = provider.storage() else {
             continue;
         };
-        let Ok(roots) = storage.roots() else {
-            continue;
+        let roots = match storage.roots() {
+            Ok(roots) => roots,
+            Err(error) => {
+                warnings.push(listing_failure_warning(*provider, &error));
+                continue;
+            }
         };
         for root in roots {
-            let Ok(files) = root.discover_files() else {
-                continue;
+            let stubs = match storage.discover(&root) {
+                Ok(stubs) => stubs,
+                Err(error) => {
+                    warnings.push(listing_failure_warning(*provider, &error));
+                    continue;
+                }
             };
-            for path in files {
+            for stub in stubs {
+                let path = stub.locator;
                 let Ok(Some(projection)) =
                     history::format::parse_owned_transcript(provider.source(), &path)
                 else {
@@ -569,7 +595,21 @@ fn root_storage_keys(project_filter: Option<&str>) -> Vec<agent::refs::AgentConv
             }
         }
     }
-    keys
+    (keys, warnings)
+}
+
+fn listing_failure_warning(
+    provider: &dyn history::provider::SessionProvider,
+    error: &AppError,
+) -> AgentWarning {
+    AgentWarning {
+        kind: AgentWarningKind::Io,
+        reference: None,
+        detail: format!(
+            "failed to list {} sessions: {error}",
+            provider.labels().display
+        ),
+    }
 }
 
 /// These sessions are keyed by their own working directory rather than by an
@@ -625,7 +665,7 @@ fn warnings_for_skipped_transcripts(
         let reference = agent::refs::resolved_conversation_for_key(keys, key)
             .reference
             .canonical();
-        match service.load_transcript(&key.path) {
+        match service.load_transcript(key) {
             Ok(transcript) => warnings.push(AgentWarning::skipped(
                 Some(&reference),
                 if transcript.is_empty() {
@@ -806,7 +846,7 @@ fn attach_input_transcript_metadata(
         if !referenced.contains(input.resolved.reference.canonical().as_str()) {
             continue;
         }
-        if let Ok(transcript) = service.load_transcript(&input.resolved.key.path) {
+        if let Ok(transcript) = service.load_transcript(&input.resolved.key) {
             agent::search::attach_transcript_metadata(output, &input.resolved, &transcript);
         }
     }
@@ -1340,7 +1380,7 @@ impl AgentService {
         let transcripts = resolved_refs
             .iter()
             .map(|(_, resolved)| {
-                self.load_transcript(&resolved.key.path)
+                self.load_transcript(&resolved.key)
                     .map_err(|error| target_error(error, resolved))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1417,7 +1457,7 @@ impl AgentService {
         let agent_config = config::load_config()?.agent.unwrap_or_default();
         let resolved = resolve_agent_conversation_arg(&args.conversation, Some(keys))?;
         let transcript = self
-            .load_transcript(&resolved.key.path)
+            .load_transcript(&resolved.key)
             .map_err(|error| target_error(error, &resolved))?;
         let warning = transcript_warning(&transcript, &resolved.reference.canonical());
         Ok(agent::protocol::format_outline_with_warnings(

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -505,7 +505,7 @@ fn discover_agent_keys(
         }
     }
     if let Ok(pi_root) = history::pi_loader::session_root()
-        && let Ok(pi_files) = history::pi_loader::discover_files(&pi_root)
+        && let Ok(pi_files) = pi_root.discover_files()
     {
         let current = std::env::current_dir()
             .ok()
@@ -553,7 +553,7 @@ fn discover_agent_keys(
         }
     }
     if let Ok(omp_root) = history::omp_loader::session_root()
-        && let Ok(omp_files) = history::omp_loader::discover_files(&omp_root)
+        && let Ok(omp_files) = omp_root.discover_files()
     {
         let current = std::env::current_dir()
             .ok()

--- a/src/agent/transcript.rs
+++ b/src/agent/transcript.rs
@@ -78,9 +78,11 @@ impl AgentTranscript {
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         let reference = path.to_string_lossy();
-        if let Some(projection) = crate::history::pi::parse_file(path).map_err(|error| {
-            AgentError::malformed_transcript(Some(&reference), error.to_string())
-        })? {
+        if let Some(projection) =
+            crate::history::format::parse_transcript(path).map_err(|error| {
+                AgentError::malformed_transcript(Some(&reference), error.to_string())
+            })?
+        {
             let normalized = projection
                 .entries
                 .iter()

--- a/src/agent/transcript.rs
+++ b/src/agent/transcript.rs
@@ -75,14 +75,41 @@ pub struct AgentPartSource {
 }
 
 impl AgentTranscript {
+    /// Load a bare file nothing has attributed to a source. The first
+    /// registered format that recognizes it wins; a file no format claims is
+    /// read as a raw Claude transcript. Production reads arrive with a
+    /// resolved key and use [`load_owned`](Self::load_owned); only fixtures
+    /// come in bare.
+    #[cfg(test)]
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         let reference = path.to_string_lossy();
-        if let Some(projection) =
-            crate::history::format::parse_transcript(path).map_err(|error| {
+        let projection = crate::history::format::parse_transcript(path).map_err(|error| {
+            AgentError::malformed_transcript(Some(&reference), error.to_string())
+        })?;
+        Self::from_projection_or_raw(path, projection)
+    }
+
+    /// Load a transcript already attributed to `source`: only that provider's
+    /// format reads it, so a locator never meets a foreign format.
+    pub fn load_owned(source: crate::history::Source, path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let reference = path.to_string_lossy();
+        let projection = match source.provider().format() {
+            Some(format) => format.parse_transcript(path).map_err(|error| {
                 AgentError::malformed_transcript(Some(&reference), error.to_string())
-            })?
-        {
+            })?,
+            None => None,
+        };
+        Self::from_projection_or_raw(path, projection)
+    }
+
+    fn from_projection_or_raw(
+        path: &Path,
+        projection: Option<crate::history::format::SessionProjection>,
+    ) -> Result<Self> {
+        let reference = path.to_string_lossy();
+        if let Some(projection) = projection {
             let normalized = projection
                 .entries
                 .iter()

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -158,7 +158,7 @@ fn write_cache_file(path: &std::path::Path, cache: &impl Serialize) {
 pub fn session_cache_path(source: Source, root: &std::path::Path) -> Option<PathBuf> {
     use std::hash::{Hash, Hasher};
 
-    let cache = source.provider().session_cache()?;
+    let cache = source.provider().storage()?.cache();
     let resolved = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     resolved.hash(&mut hasher);
@@ -179,7 +179,7 @@ pub fn read_session_cache(
     source: Source,
     root: &std::path::Path,
 ) -> Option<HashMap<String, SessionCacheEntry>> {
-    let expected = source.provider().session_cache()?;
+    let expected = source.provider().storage()?.cache();
     let data = std::fs::read(session_cache_path(source, root)?).ok()?;
     let cache: SessionCacheFile = bincode::deserialize(&data).ok()?;
     if cache.magic != expected.magic || cache.schema_version != expected.schema_version {
@@ -193,9 +193,10 @@ pub fn write_session_cache(
     root: &std::path::Path,
     entries: HashMap<String, SessionCacheEntry>,
 ) {
-    let Some(cache) = source.provider().session_cache() else {
+    let Some(storage) = source.provider().storage() else {
         return;
     };
+    let cache = storage.cache();
     let Some(path) = session_cache_path(source, root) else {
         return;
     };

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -405,6 +405,70 @@ mod tests {
         assert!(read_session_cache(Source::Claude, root.path()).is_none());
     }
 
+    /// Where a root's cache lives is a compatibility contract: users carry caches
+    /// across upgrades, and moving or renaming the file silently discards them.
+    #[test]
+    fn session_cache_filenames_keep_their_shape() {
+        let root = tempfile::tempdir().unwrap();
+        let path = session_cache_path(Source::Pi, root.path()).expect("Pi caches by root");
+
+        assert_eq!(path.file_name().unwrap(), "sessions.bin");
+        assert!(contains_segments(&path, &["claude-history", "pi"]));
+        let directory = file_stem_of_parent(&path);
+        let digest = directory
+            .strip_prefix("root-")
+            .expect("a root's directory is named root-<digest>");
+        assert_eq!(digest.len(), 16);
+        assert!(
+            digest
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        );
+
+        assert_eq!(
+            session_cache_path(Source::Pi, root.path()).as_ref(),
+            Some(&path),
+            "a root must resolve to the same file on every run, or its cache is lost"
+        );
+    }
+
+    #[test]
+    fn session_cache_round_trips_through_disk() {
+        let root = tempfile::tempdir().unwrap();
+        let mtime = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let file_size = 4_096;
+        let mut entries = HashMap::new();
+        entries.insert(
+            "nested/session.jsonl".to_owned(),
+            SessionCacheEntry {
+                metadata: entry_from_conversation(&make_test_conversation(), file_size, mtime),
+                session_id: "session-1".to_owned(),
+                project_path: PathBuf::from("/tmp/project"),
+            },
+        );
+
+        write_session_cache(Source::Pi, root.path(), entries);
+        let restored = read_session_cache(Source::Pi, root.path());
+        let foreign = read_session_cache(Source::Omp, root.path());
+        if let Some(path) = session_cache_path(Source::Pi, root.path())
+            && let Some(directory) = path.parent()
+        {
+            let _ = std::fs::remove_dir_all(directory);
+        }
+
+        let restored = restored.expect("the cache just written must read back");
+        let entry = restored
+            .get("nested/session.jsonl")
+            .expect("entries are keyed by path relative to the root");
+        assert_eq!(entry.session_id, "session-1");
+        assert_eq!(entry.project_path, PathBuf::from("/tmp/project"));
+        assert!(entry_matches(&entry.metadata, file_size, mtime));
+        assert!(
+            foreign.is_none(),
+            "OMP must not read Pi's cache for the same root"
+        );
+    }
+
     fn contains_segments(path: &std::path::Path, expected: &[&str]) -> bool {
         let segments = path
             .components()

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -4,7 +4,7 @@
 //! and validated by mtime + file size. Eliminates redundant JSONL parsing and
 //! search text normalization on startup for unchanged files.
 
-use super::{Conversation, ParseError};
+use super::{Conversation, ParseError, Source};
 use crate::agent::refs::MessageRange;
 use chrono::{Local, TimeZone};
 use serde::{Deserialize, Serialize};
@@ -14,21 +14,17 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CACHE_MAGIC: [u8; 8] = *b"CLHIST01";
-const PI_CACHE_MAGIC: [u8; 8] = *b"PIHIST01";
-const OMP_CACHE_MAGIC: [u8; 8] = *b"OMHIST01";
 const SCHEMA_VERSION: u32 = 11;
-const PI_SCHEMA_VERSION: u32 = 1;
-const OMP_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Serialize, Deserialize)]
-struct PiCache {
+struct SessionCacheFile {
     magic: [u8; 8],
     schema_version: u32,
-    entries: HashMap<String, PiCacheEntry>,
+    entries: HashMap<String, SessionCacheEntry>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct PiCacheEntry {
+pub struct SessionCacheEntry {
     pub metadata: CacheEntry,
     pub session_id: String,
     pub project_path: PathBuf,
@@ -154,9 +150,15 @@ fn write_cache_file(path: &std::path::Path, cache: &impl Serialize) {
     let _ = tmp.persist(path);
 }
 
-fn source_cache_path(root: &std::path::Path, source: &str) -> Option<PathBuf> {
+/// Where a source's cache for `root` lives, or `None` for a source that has no
+/// whole-root cache.
+///
+/// Roots are hashed rather than embedded so two roots never collide and a moved
+/// root simply misses instead of reading a stale neighbour's entries.
+pub fn session_cache_path(source: Source, root: &std::path::Path) -> Option<PathBuf> {
     use std::hash::{Hash, Hasher};
 
+    let cache = source.provider().session_cache()?;
     let resolved = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     resolved.hash(&mut hasher);
@@ -164,61 +166,44 @@ fn source_cache_path(root: &std::path::Path, source: &str) -> Option<PathBuf> {
         home::home_dir()?
             .join(".cache")
             .join("claude-history")
-            .join(source)
+            .join(cache.directory)
             .join(format!("root-{:016x}", hasher.finish()))
             .join("sessions.bin"),
     )
 }
 
-pub fn pi_cache_path(root: &std::path::Path) -> Option<PathBuf> {
-    source_cache_path(root, "pi")
-}
-
-pub fn omp_cache_path(root: &std::path::Path) -> Option<PathBuf> {
-    source_cache_path(root, "omp")
-}
-
-pub fn read_pi_cache(root: &std::path::Path) -> Option<HashMap<String, PiCacheEntry>> {
-    let data = std::fs::read(pi_cache_path(root)?).ok()?;
-    let cache: PiCache = bincode::deserialize(&data).ok()?;
-    if cache.magic != PI_CACHE_MAGIC || cache.schema_version != PI_SCHEMA_VERSION {
+/// Cached entries for every session under `root`, keyed by path relative to it.
+/// Returns `None` on any miss: absent, unreadable, or stamped for another source
+/// or schema.
+pub fn read_session_cache(
+    source: Source,
+    root: &std::path::Path,
+) -> Option<HashMap<String, SessionCacheEntry>> {
+    let expected = source.provider().session_cache()?;
+    let data = std::fs::read(session_cache_path(source, root)?).ok()?;
+    let cache: SessionCacheFile = bincode::deserialize(&data).ok()?;
+    if cache.magic != expected.magic || cache.schema_version != expected.schema_version {
         return None;
     }
     Some(cache.entries)
 }
 
-pub fn write_pi_cache(root: &std::path::Path, entries: HashMap<String, PiCacheEntry>) {
-    let Some(path) = pi_cache_path(root) else {
+pub fn write_session_cache(
+    source: Source,
+    root: &std::path::Path,
+    entries: HashMap<String, SessionCacheEntry>,
+) {
+    let Some(cache) = source.provider().session_cache() else {
+        return;
+    };
+    let Some(path) = session_cache_path(source, root) else {
         return;
     };
     write_cache_file(
         &path,
-        &PiCache {
-            magic: PI_CACHE_MAGIC,
-            schema_version: PI_SCHEMA_VERSION,
-            entries,
-        },
-    );
-}
-
-pub fn read_omp_cache(root: &std::path::Path) -> Option<HashMap<String, PiCacheEntry>> {
-    let data = std::fs::read(omp_cache_path(root)?).ok()?;
-    let cache: PiCache = bincode::deserialize(&data).ok()?;
-    if cache.magic != OMP_CACHE_MAGIC || cache.schema_version != OMP_SCHEMA_VERSION {
-        return None;
-    }
-    Some(cache.entries)
-}
-
-pub fn write_omp_cache(root: &std::path::Path, entries: HashMap<String, PiCacheEntry>) {
-    let Some(path) = omp_cache_path(root) else {
-        return;
-    };
-    write_cache_file(
-        &path,
-        &PiCache {
-            magic: OMP_CACHE_MAGIC,
-            schema_version: OMP_SCHEMA_VERSION,
+        &SessionCacheFile {
+            magic: cache.magic,
+            schema_version: cache.schema_version,
             entries,
         },
     );
@@ -392,20 +377,48 @@ mod tests {
     }
 
     #[test]
-    fn pi_cache_roots_are_isolated_from_claude_and_each_other() {
+    fn session_cache_roots_are_isolated_from_claude_and_each_other() {
         let first = tempfile::tempdir().unwrap();
         let second = tempfile::tempdir().unwrap();
-        let first_path = pi_cache_path(first.path()).unwrap();
-        let second_path = pi_cache_path(second.path()).unwrap();
+        let first_path = session_cache_path(Source::Pi, first.path()).unwrap();
+        let second_path = session_cache_path(Source::Pi, second.path()).unwrap();
         let claude_path = cache_path_for_project("same-project").unwrap();
-        let omp_path = omp_cache_path(first.path()).unwrap();
+        let omp_path = session_cache_path(Source::Omp, first.path()).unwrap();
 
         assert_ne!(first_path, second_path);
         assert_ne!(first_path, claude_path);
         assert_ne!(first_path, omp_path);
-        assert!(first_path.to_string_lossy().contains("/pi/root-"));
-        assert!(omp_path.to_string_lossy().contains("/omp/root-"));
-        assert!(claude_path.to_string_lossy().contains("/projects/"));
+        assert!(contains_segments(&first_path, &["pi"]));
+        assert!(contains_segments(&omp_path, &["omp"]));
+        assert!(contains_segments(&claude_path, &["projects"]));
+        assert!(
+            file_stem_of_parent(&first_path).starts_with("root-"),
+            "a session cache lives in a directory named for the hashed root"
+        );
+    }
+
+    #[test]
+    fn claude_has_no_whole_root_session_cache() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(session_cache_path(Source::Claude, root.path()).is_none());
+        assert!(read_session_cache(Source::Claude, root.path()).is_none());
+    }
+
+    fn contains_segments(path: &std::path::Path, expected: &[&str]) -> bool {
+        let segments = path
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        expected
+            .iter()
+            .all(|wanted| segments.iter().any(|segment| segment == wanted))
+    }
+
+    fn file_stem_of_parent(path: &std::path::Path) -> String {
+        path.parent()
+            .and_then(|parent| parent.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default()
     }
 
     #[test]

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -80,9 +80,26 @@ pub struct CachedParseError {
     pub context_after: Vec<String>,
 }
 
-/// Root of every cache this tool writes, or `None` without a home directory.
+/// Root of every cache this tool writes: `$CLAUDE_HISTORY_CACHE_DIR`, or
+/// `~/.cache/claude-history`, or `None` without a home directory.
+///
+/// The override exists so tests that spawn the binary keep cache writes out of
+/// the user's real cache; it also lets a user relocate the cache outright.
 fn user_cache_base() -> Option<PathBuf> {
-    Some(home::home_dir()?.join(".cache").join("claude-history"))
+    cache_base_from(
+        std::env::var_os("CLAUDE_HISTORY_CACHE_DIR"),
+        home::home_dir(),
+    )
+}
+
+fn cache_base_from(
+    override_dir: Option<std::ffi::OsString>,
+    home: Option<PathBuf>,
+) -> Option<PathBuf> {
+    match override_dir.filter(|value| !value.is_empty()) {
+        Some(directory) => Some(PathBuf::from(directory)),
+        None => Some(home?.join(".cache").join("claude-history")),
+    }
 }
 
 /// Get the cache directory for per-project cache files.
@@ -222,6 +239,12 @@ impl SessionCacheStore {
         let Some(path) = self.path_for_root(root) else {
             return;
         };
+        // Nothing to cache and nothing cached: leave no trace, so an absent or
+        // empty root does not grow a cache directory. An existing file is still
+        // overwritten, clearing entries for sessions that no longer exist.
+        if entries.is_empty() && !path.exists() {
+            return;
+        }
         write_cache_file(
             &path,
             &SessionCacheFile {
@@ -407,6 +430,59 @@ mod tests {
             .storage()
             .expect("this source caches whole roots")
             .cache()
+    }
+
+    #[test]
+    fn the_cache_base_override_replaces_the_home_derived_default() {
+        let home = PathBuf::from("/home/user");
+        assert_eq!(
+            cache_base_from(None, Some(home.clone())),
+            Some(home.join(".cache").join("claude-history"))
+        );
+        assert_eq!(
+            cache_base_from(Some("/isolated/cache".into()), Some(home.clone())),
+            Some(PathBuf::from("/isolated/cache")),
+            "the override wins even when a home directory exists"
+        );
+        assert_eq!(
+            cache_base_from(Some("".into()), Some(home.clone())),
+            Some(home.join(".cache").join("claude-history")),
+            "an empty override means unset"
+        );
+        assert_eq!(cache_base_from(None, None), None);
+    }
+
+    /// A run over an absent or empty root must not grow the cache directory:
+    /// every isolated test run and every user without the agent installed
+    /// would otherwise leave a `root-<hash>` directory behind.
+    #[test]
+    fn an_empty_cache_write_leaves_no_file_but_still_clears_an_existing_one() {
+        let base = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let store = SessionCacheStore::under(base.path(), identity(Source::Pi));
+        let path = store.path_for_root(root.path()).unwrap();
+
+        store.write(root.path(), HashMap::new());
+        assert!(!path.exists(), "nothing cached and nothing to cache");
+
+        let mut entries = HashMap::new();
+        entries.insert(
+            "session.jsonl".to_owned(),
+            SessionCacheEntry {
+                metadata: empty_entry(0, SystemTime::UNIX_EPOCH),
+                session_id: "session".to_owned(),
+                project_path: PathBuf::from("/tmp/project"),
+            },
+        );
+        store.write(root.path(), entries);
+        assert!(path.exists());
+
+        store.write(root.path(), HashMap::new());
+        assert!(
+            path.exists(),
+            "an existing cache is cleared, not orphaned, when the root empties"
+        );
+        assert!(store.read(root.path()).is_empty());
     }
 
     #[test]

--- a/src/history/cache.rs
+++ b/src/history/cache.rs
@@ -4,7 +4,8 @@
 //! and validated by mtime + file size. Eliminates redundant JSONL parsing and
 //! search text normalization on startup for unchanged files.
 
-use super::{Conversation, ParseError, Source};
+use super::provider::SessionCache;
+use super::{Conversation, ParseError};
 use crate::agent::refs::MessageRange;
 use chrono::{Local, TimeZone};
 use serde::{Deserialize, Serialize};
@@ -79,10 +80,15 @@ pub struct CachedParseError {
     pub context_after: Vec<String>,
 }
 
+/// Root of every cache this tool writes, or `None` without a home directory.
+fn user_cache_base() -> Option<PathBuf> {
+    Some(home::home_dir()?.join(".cache").join("claude-history"))
+}
+
 /// Get the cache directory for per-project cache files.
 /// Respects CLAUDE_CONFIG_DIR to namespace caches per config root.
 fn cache_dir() -> Option<PathBuf> {
-    let base = home::home_dir()?.join(".cache").join("claude-history");
+    let base = user_cache_base()?;
     if let Ok(config_dir) = std::env::var("CLAUDE_CONFIG_DIR") {
         // Namespace by config dir to avoid cross-config cache collisions
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -150,64 +156,81 @@ fn write_cache_file(path: &std::path::Path, cache: &impl Serialize) {
     let _ = tmp.persist(path);
 }
 
-/// Where a source's cache for `root` lives, or `None` for a source that has no
-/// whole-root cache.
+/// One provider's whole-root session caches on disk.
 ///
-/// Roots are hashed rather than embedded so two roots never collide and a moved
-/// root simply misses instead of reading a stale neighbour's entries.
-pub fn session_cache_path(source: Source, root: &std::path::Path) -> Option<PathBuf> {
-    use std::hash::{Hash, Hasher};
-
-    let cache = source.provider().storage()?.cache();
-    let resolved = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    resolved.hash(&mut hasher);
-    Some(
-        home::home_dir()?
-            .join(".cache")
-            .join("claude-history")
-            .join(cache.directory)
-            .join(format!("root-{:016x}", hasher.finish()))
-            .join("sessions.bin"),
-    )
+/// Carries both the identity stamped into every file it writes and the directory
+/// those files live in. The directory is held rather than looked up so that a
+/// test can run a load against a temporary tree and leave the user's cache
+/// untouched.
+pub struct SessionCacheStore {
+    /// `None` when there is no home directory to cache in. Reads then miss and
+    /// writes are dropped, rather than the load failing.
+    directory: Option<PathBuf>,
+    identity: SessionCache,
 }
 
-/// Cached entries for every session under `root`, keyed by path relative to it.
-/// Returns `None` on any miss: absent, unreadable, or stamped for another source
-/// or schema.
-pub fn read_session_cache(
-    source: Source,
-    root: &std::path::Path,
-) -> Option<HashMap<String, SessionCacheEntry>> {
-    let expected = source.provider().storage()?.cache();
-    let data = std::fs::read(session_cache_path(source, root)?).ok()?;
-    let cache: SessionCacheFile = bincode::deserialize(&data).ok()?;
-    if cache.magic != expected.magic || cache.schema_version != expected.schema_version {
-        return None;
+impl SessionCacheStore {
+    pub fn in_user_cache(identity: SessionCache) -> Self {
+        Self {
+            directory: user_cache_base().map(|base| base.join(identity.directory)),
+            identity,
+        }
     }
-    Some(cache.entries)
-}
 
-pub fn write_session_cache(
-    source: Source,
-    root: &std::path::Path,
-    entries: HashMap<String, SessionCacheEntry>,
-) {
-    let Some(storage) = source.provider().storage() else {
-        return;
-    };
-    let cache = storage.cache();
-    let Some(path) = session_cache_path(source, root) else {
-        return;
-    };
-    write_cache_file(
-        &path,
-        &SessionCacheFile {
-            magic: cache.magic,
-            schema_version: cache.schema_version,
-            entries,
-        },
-    );
+    #[cfg(test)]
+    pub fn under(base: &std::path::Path, identity: SessionCache) -> Self {
+        Self {
+            directory: Some(base.join(identity.directory)),
+            identity,
+        }
+    }
+
+    /// Where `root`'s cache file lives.
+    ///
+    /// Roots are hashed rather than embedded so two roots never collide and a
+    /// moved root simply misses instead of reading a stale neighbour's entries.
+    fn path_for_root(&self, root: &std::path::Path) -> Option<PathBuf> {
+        use std::hash::{Hash, Hasher};
+
+        let resolved = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        resolved.hash(&mut hasher);
+        Some(
+            self.directory
+                .as_ref()?
+                .join(format!("root-{:016x}", hasher.finish()))
+                .join("sessions.bin"),
+        )
+    }
+
+    /// Cached entries for every session under `root`, keyed by path relative to
+    /// it. Absent, unreadable, and stamped for another provider or schema all
+    /// read as nothing cached.
+    pub fn read(&self, root: &std::path::Path) -> HashMap<String, SessionCacheEntry> {
+        let stored = self
+            .path_for_root(root)
+            .and_then(|path| std::fs::read(path).ok())
+            .and_then(|data| bincode::deserialize::<SessionCacheFile>(&data).ok())
+            .filter(|cache| {
+                cache.magic == self.identity.magic
+                    && cache.schema_version == self.identity.schema_version
+            });
+        stored.map(|cache| cache.entries).unwrap_or_default()
+    }
+
+    pub fn write(&self, root: &std::path::Path, entries: HashMap<String, SessionCacheEntry>) {
+        let Some(path) = self.path_for_root(root) else {
+            return;
+        };
+        write_cache_file(
+            &path,
+            &SessionCacheFile {
+                magic: self.identity.magic,
+                schema_version: self.identity.schema_version,
+                entries,
+            },
+        );
+    }
 }
 
 /// Create a negative cache entry for files that parsed to no conversation
@@ -344,6 +367,7 @@ pub fn entry_matches(entry: &CacheEntry, file_size: u64, mtime: SystemTime) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::history::Source;
     use crate::search::normalize_for_search;
     use std::time::Duration;
 
@@ -377,14 +401,26 @@ mod tests {
         }
     }
 
+    fn identity(source: Source) -> SessionCache {
+        source
+            .provider()
+            .storage()
+            .expect("this source caches whole roots")
+            .cache()
+    }
+
     #[test]
     fn session_cache_roots_are_isolated_from_claude_and_each_other() {
+        let base = tempfile::tempdir().unwrap();
         let first = tempfile::tempdir().unwrap();
         let second = tempfile::tempdir().unwrap();
-        let first_path = session_cache_path(Source::Pi, first.path()).unwrap();
-        let second_path = session_cache_path(Source::Pi, second.path()).unwrap();
+        let pi = SessionCacheStore::under(base.path(), identity(Source::Pi));
+        let omp = SessionCacheStore::under(base.path(), identity(Source::Omp));
+
+        let first_path = pi.path_for_root(first.path()).unwrap();
+        let second_path = pi.path_for_root(second.path()).unwrap();
+        let omp_path = omp.path_for_root(first.path()).unwrap();
         let claude_path = cache_path_for_project("same-project").unwrap();
-        let omp_path = session_cache_path(Source::Omp, first.path()).unwrap();
 
         assert_ne!(first_path, second_path);
         assert_ne!(first_path, claude_path);
@@ -398,19 +434,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn claude_has_no_whole_root_session_cache() {
-        let root = tempfile::tempdir().unwrap();
-        assert!(session_cache_path(Source::Claude, root.path()).is_none());
-        assert!(read_session_cache(Source::Claude, root.path()).is_none());
-    }
-
     /// Where a root's cache lives is a compatibility contract: users carry caches
     /// across upgrades, and moving or renaming the file silently discards them.
     #[test]
     fn session_cache_filenames_keep_their_shape() {
         let root = tempfile::tempdir().unwrap();
-        let path = session_cache_path(Source::Pi, root.path()).expect("Pi caches by root");
+        let store = SessionCacheStore::in_user_cache(identity(Source::Pi));
+        let path = store
+            .path_for_root(root.path())
+            .expect("caching needs a home directory");
 
         assert_eq!(path.file_name().unwrap(), "sessions.bin");
         assert!(contains_segments(&path, &["claude-history", "pi"]));
@@ -426,7 +458,7 @@ mod tests {
         );
 
         assert_eq!(
-            session_cache_path(Source::Pi, root.path()).as_ref(),
+            store.path_for_root(root.path()).as_ref(),
             Some(&path),
             "a root must resolve to the same file on every run, or its cache is lost"
         );
@@ -434,7 +466,10 @@ mod tests {
 
     #[test]
     fn session_cache_round_trips_through_disk() {
+        let base = tempfile::tempdir().unwrap();
         let root = tempfile::tempdir().unwrap();
+        let pi = SessionCacheStore::under(base.path(), identity(Source::Pi));
+        let omp = SessionCacheStore::under(base.path(), identity(Source::Omp));
         let mtime = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let file_size = 4_096;
         let mut entries = HashMap::new();
@@ -447,16 +482,9 @@ mod tests {
             },
         );
 
-        write_session_cache(Source::Pi, root.path(), entries);
-        let restored = read_session_cache(Source::Pi, root.path());
-        let foreign = read_session_cache(Source::Omp, root.path());
-        if let Some(path) = session_cache_path(Source::Pi, root.path())
-            && let Some(directory) = path.parent()
-        {
-            let _ = std::fs::remove_dir_all(directory);
-        }
+        pi.write(root.path(), entries);
+        let restored = pi.read(root.path());
 
-        let restored = restored.expect("the cache just written must read back");
         let entry = restored
             .get("nested/session.jsonl")
             .expect("entries are keyed by path relative to the root");
@@ -464,7 +492,7 @@ mod tests {
         assert_eq!(entry.project_path, PathBuf::from("/tmp/project"));
         assert!(entry_matches(&entry.metadata, file_size, mtime));
         assert!(
-            foreign.is_none(),
+            omp.read(root.path()).is_empty(),
             "OMP must not read Pi's cache for the same root"
         );
     }

--- a/src/history/format/mod.rs
+++ b/src/history/format/mod.rs
@@ -1,0 +1,145 @@
+//! Transcript formats: turning a session file on disk into the normalized
+//! [`LogEntry`] stream the rest of the application renders, searches and indexes.
+//!
+//! A format answers two questions about a file — *is this mine* and *what does it
+//! say*. Where the file was found, how it is cached and how the session is resumed
+//! belong to the [`SessionProvider`](super::provider::SessionProvider) instead.
+
+pub mod pi_log;
+
+use super::{Source, provider};
+use crate::claude::LogEntry;
+use crate::error::Result;
+use std::path::{Path, PathBuf};
+
+/// The session-level facts a transcript states about itself before its first
+/// message.
+#[derive(Clone, Debug)]
+pub struct SessionHeader {
+    #[allow(dead_code)]
+    pub version: u64,
+    pub id: String,
+    pub timestamp: String,
+    pub cwd: PathBuf,
+}
+
+/// One transcript, normalized. Each entry keeps the file line it came from so
+/// parse errors and viewer positions can still name a place in the original file.
+#[derive(Clone, Debug)]
+pub struct SessionProjection {
+    pub source: Source,
+    pub header: SessionHeader,
+    pub title: Option<String>,
+    pub entries: Vec<(usize, LogEntry)>,
+    pub leaf_id: Option<String>,
+    pub malformed_lines: Vec<usize>,
+}
+
+pub trait SessionFormat: Sync {
+    /// Parse `path`, or `None` when the file is not a transcript in this format.
+    ///
+    /// Not recognizing a file is an ordinary outcome rather than an error: session
+    /// roots overlap, and a redirected session directory can hold another agent's
+    /// transcripts.
+    fn parse_transcript(&self, path: &Path) -> Result<Option<SessionProjection>>;
+}
+
+/// The first registered format that recognizes `path`.
+///
+/// Used where the caller has only a file — the viewer, export, and the Claude
+/// loader's fallback. Registration order settles files more than one format can
+/// read; today that is the Pi-family log, which Pi and OMP share.
+pub fn parse_transcript(path: &Path) -> Result<Option<SessionProjection>> {
+    for provider in provider::providers() {
+        let Some(format) = provider.format() else {
+            continue;
+        };
+        if let Some(projection) = format.parse_transcript(path)? {
+            return Ok(Some(projection));
+        }
+    }
+    Ok(None)
+}
+
+/// Parse `path` as the format `source` owns, yielding `None` when the file is not
+/// `source`'s transcript.
+///
+/// Ownership is stricter than "parses". Pi and OMP share one wire format, and a
+/// transcript carrying no OMP title slot reads equally well as either — so asking
+/// on behalf of a source both attributes the transcript to it and rejects files
+/// that announce a different one.
+pub fn parse_owned_transcript(source: Source, path: &Path) -> Option<SessionProjection> {
+    source
+        .provider()
+        .format()?
+        .parse_transcript(path)
+        .ok()
+        .flatten()
+        .filter(|projection| projection.source == source)
+}
+
+/// Whether `path` holds a transcript `source` owns. Guards destructive operations
+/// so one agent cannot delete or rewrite another's session file.
+pub fn owns_transcript(source: Source, path: &Path) -> bool {
+    parse_owned_transcript(source, path).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/pi")
+            .join(name)
+    }
+
+    #[test]
+    fn a_transcript_without_a_title_slot_belongs_to_whichever_source_asks() {
+        let path = fixture("v3-branched.jsonl");
+        assert_eq!(
+            parse_owned_transcript(Source::Pi, &path).map(|projection| projection.source),
+            Some(Source::Pi)
+        );
+        assert_eq!(
+            parse_owned_transcript(Source::Omp, &path).map(|projection| projection.source),
+            Some(Source::Omp)
+        );
+    }
+
+    #[test]
+    fn an_omp_title_slot_keeps_pi_from_claiming_the_transcript() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("titled.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"type":"title","v":1,"title":"Named"}"#,
+                "\n",
+                r#"{"type":"session","version":3,"id":"s1","timestamp":"2026-01-01T00:00:00.000Z","cwd":"/tmp"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        assert!(!owns_transcript(Source::Pi, &path));
+        assert!(owns_transcript(Source::Omp, &path));
+        assert_eq!(
+            parse_transcript(&path).unwrap().map(|proj| proj.source),
+            Some(Source::Omp),
+            "a self-identifying transcript keeps its own source whichever format reads it first"
+        );
+    }
+
+    #[test]
+    fn a_claude_transcript_belongs_to_no_registered_format() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("claude.jsonl");
+        std::fs::write(&path, "{\"type\":\"user\"}\n").unwrap();
+
+        assert!(parse_transcript(&path).unwrap().is_none());
+        assert!(!owns_transcript(Source::Pi, &path));
+        assert!(!owns_transcript(Source::Omp, &path));
+        assert!(!owns_transcript(Source::Claude, &path));
+    }
+}

--- a/src/history/format/mod.rs
+++ b/src/history/format/mod.rs
@@ -9,7 +9,7 @@ pub mod pi_log;
 
 use super::{Source, provider};
 use crate::claude::LogEntry;
-use crate::error::Result;
+use crate::error::{AppError, Result};
 use std::path::{Path, PathBuf};
 
 /// The session-level facts a transcript states about itself before its first
@@ -68,20 +68,37 @@ pub fn parse_transcript(path: &Path) -> Result<Option<SessionProjection>> {
 /// transcript carrying no OMP title slot reads equally well as either — so asking
 /// on behalf of a source both attributes the transcript to it and rejects files
 /// that announce a different one.
-pub fn parse_owned_transcript(source: Source, path: &Path) -> Option<SessionProjection> {
-    source
-        .provider()
-        .format()?
-        .parse_transcript(path)
-        .ok()
-        .flatten()
-        .filter(|projection| projection.source == source)
+///
+/// A file that cannot be read is an error rather than a `None`, so that a caller
+/// guarding a destructive operation cannot read "unreadable" as "not yours".
+pub fn parse_owned_transcript(source: Source, path: &Path) -> Result<Option<SessionProjection>> {
+    let Some(format) = source.provider().format() else {
+        return Ok(None);
+    };
+    Ok(format
+        .parse_transcript(path)?
+        .filter(|projection| projection.source == source))
 }
 
-/// Whether `path` holds a transcript `source` owns. Guards destructive operations
-/// so one agent cannot delete or rewrite another's session file.
-pub fn owns_transcript(source: Source, path: &Path) -> bool {
-    parse_owned_transcript(source, path).is_some()
+/// Refuse `path` unless it is a transcript `source` owns, so one agent cannot
+/// delete or rewrite another's session file.
+///
+/// A file that exists but cannot be read fails as the read error it is, named
+/// with its path — never as a missing session.
+pub fn require_owned_transcript(source: Source, path: &Path) -> Result<()> {
+    let not_found = || AppError::SessionNotFound(path.display().to_string());
+    if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl") {
+        return Err(not_found());
+    }
+    match parse_owned_transcript(source, path) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(not_found()),
+        Err(AppError::Io(error)) => Err(AppError::Io(std::io::Error::new(
+            error.kind(),
+            format!("{}: {error}", path.display()),
+        ))),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(test)]
@@ -94,15 +111,23 @@ mod tests {
             .join(name)
     }
 
+    fn owns(source: Source, path: &Path) -> bool {
+        parse_owned_transcript(source, path).unwrap().is_some()
+    }
+
     #[test]
     fn a_transcript_without_a_title_slot_belongs_to_whichever_source_asks() {
         let path = fixture("v3-branched.jsonl");
         assert_eq!(
-            parse_owned_transcript(Source::Pi, &path).map(|projection| projection.source),
+            parse_owned_transcript(Source::Pi, &path)
+                .unwrap()
+                .map(|projection| projection.source),
             Some(Source::Pi)
         );
         assert_eq!(
-            parse_owned_transcript(Source::Omp, &path).map(|projection| projection.source),
+            parse_owned_transcript(Source::Omp, &path)
+                .unwrap()
+                .map(|projection| projection.source),
             Some(Source::Omp)
         );
     }
@@ -122,8 +147,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(!owns_transcript(Source::Pi, &path));
-        assert!(owns_transcript(Source::Omp, &path));
+        assert!(!owns(Source::Pi, &path));
+        assert!(owns(Source::Omp, &path));
         assert_eq!(
             parse_transcript(&path).unwrap().map(|proj| proj.source),
             Some(Source::Omp),
@@ -138,8 +163,48 @@ mod tests {
         std::fs::write(&path, "{\"type\":\"user\"}\n").unwrap();
 
         assert!(parse_transcript(&path).unwrap().is_none());
-        assert!(!owns_transcript(Source::Pi, &path));
-        assert!(!owns_transcript(Source::Omp, &path));
-        assert!(!owns_transcript(Source::Claude, &path));
+        assert!(!owns(Source::Pi, &path));
+        assert!(!owns(Source::Omp, &path));
+        assert!(!owns(Source::Claude, &path));
+    }
+
+    #[test]
+    fn a_file_that_is_not_a_transcript_is_refused_as_a_missing_session() {
+        let directory = tempfile::tempdir().unwrap();
+        let notes = directory.path().join("notes.txt");
+        let claude = directory.path().join("claude.jsonl");
+        std::fs::write(&notes, "keep").unwrap();
+        std::fs::write(&claude, "{\"type\":\"user\"}\n").unwrap();
+
+        for path in [&notes, &claude] {
+            assert!(
+                matches!(
+                    require_owned_transcript(Source::Pi, path),
+                    Err(AppError::SessionNotFound(_))
+                ),
+                "{} is not a Pi transcript",
+                path.display()
+            );
+        }
+    }
+
+    /// A directory cannot be read as a transcript, so the guard has to choose
+    /// between the two failures it is allowed to report.
+    #[test]
+    fn an_unreadable_transcript_is_refused_as_a_read_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("unreadable.jsonl");
+        std::fs::create_dir(&path).unwrap();
+
+        let error = require_owned_transcript(Source::Pi, &path).unwrap_err();
+
+        assert!(
+            matches!(error, AppError::Io(_)),
+            "a transcript that cannot be read must not be reported as absent: {error}"
+        );
+        assert!(
+            error.to_string().contains("unreadable.jsonl"),
+            "a refusal must name the file it refused: {error}"
+        );
     }
 }

--- a/src/history/format/mod.rs
+++ b/src/history/format/mod.rs
@@ -83,13 +83,12 @@ pub fn parse_owned_transcript(source: Source, path: &Path) -> Result<Option<Sess
 /// Refuse `path` unless it is a transcript `source` owns, so one agent cannot
 /// delete or rewrite another's session file.
 ///
-/// A file that exists but cannot be read fails as the read error it is, named
-/// with its path — never as a missing session.
+/// Ownership is established by parsing alone — there is no cheap path-shape
+/// pre-check, because what a locator looks like is the provider's own
+/// business. A file that exists but cannot be read fails as the read error it
+/// is, named with its path — never as a missing session.
 pub fn require_owned_transcript(source: Source, path: &Path) -> Result<()> {
     let not_found = || AppError::SessionNotFound(path.display().to_string());
-    if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl") {
-        return Err(not_found());
-    }
     match parse_owned_transcript(source, path) {
         Ok(Some(_)) => Ok(()),
         Ok(None) => Err(not_found()),

--- a/src/history/format/pi_log.rs
+++ b/src/history/format/pi_log.rs
@@ -1,3 +1,6 @@
+//! The JSONL transcript format Pi and OMP share.
+
+use super::{SessionFormat, SessionHeader, SessionProjection};
 use crate::agent::transcript::bounded_tool_result_text;
 use crate::claude::{
     AssistantMessage, ContentBlock, LogEntry, TokenUsage, UserContent, UserMessage,
@@ -13,25 +16,6 @@ use std::path::{Path, PathBuf};
 
 const MAX_SUPPORTED_VERSION: u64 = 3;
 
-#[derive(Clone, Debug)]
-pub struct PiHeader {
-    #[allow(dead_code)]
-    pub version: u64,
-    pub id: String,
-    pub timestamp: String,
-    pub cwd: PathBuf,
-}
-
-#[derive(Clone, Debug)]
-pub struct PiProjection {
-    pub source: Source,
-    pub header: PiHeader,
-    pub title: Option<String>,
-    pub entries: Vec<(usize, LogEntry)>,
-    pub leaf_id: Option<String>,
-    pub malformed_lines: Vec<usize>,
-}
-
 #[derive(Debug)]
 struct RawEntry {
     line: usize,
@@ -40,31 +24,33 @@ struct RawEntry {
     value: Value,
 }
 
-pub fn parse_file(path: &Path) -> Result<Option<PiProjection>> {
-    let file = File::open(path)?;
-    parse_reader(BufReader::new(file), None)
+/// One reader of the Pi-family log, bound to the source it speaks for.
+///
+/// An OMP session announces itself with a leading `title` slot. Without one the
+/// file is indistinguishable from a Pi session, so it is attributed to
+/// `default_source` — in practice, whichever agent's root it was found under. The
+/// attribution is not cosmetic: it decides whether assistant turns are labelled
+/// `Pi` or `OMP`, so it has to be settled before the entries are normalized.
+pub struct PiLogFormat {
+    default_source: Source,
 }
 
-pub fn parse_omp_file(path: &Path) -> Result<Option<PiProjection>> {
-    let file = File::open(path)?;
-    parse_reader(BufReader::new(file), Some(Source::Omp))
+pub static PI_LOG: PiLogFormat = PiLogFormat {
+    default_source: Source::Pi,
+};
+
+pub static OMP_LOG: PiLogFormat = PiLogFormat {
+    default_source: Source::Omp,
+};
+
+impl SessionFormat for PiLogFormat {
+    fn parse_transcript(&self, path: &Path) -> Result<Option<SessionProjection>> {
+        let file = File::open(path)?;
+        parse_reader(BufReader::new(file), self.default_source)
+    }
 }
 
-pub fn is_pi_file(path: &Path) -> bool {
-    parse_file(path)
-        .ok()
-        .flatten()
-        .is_some_and(|projection| projection.source == Source::Pi)
-}
-
-pub fn is_omp_file(path: &Path) -> bool {
-    parse_omp_file(path).ok().flatten().is_some()
-}
-
-fn parse_reader(
-    reader: impl BufRead,
-    expected_source: Option<Source>,
-) -> Result<Option<PiProjection>> {
+fn parse_reader(reader: impl BufRead, default_source: Source) -> Result<Option<SessionProjection>> {
     let mut parsed = Vec::new();
     let mut malformed_lines = Vec::new();
     for (index, line) in reader.lines().enumerate() {
@@ -97,11 +83,8 @@ fn parse_reader(
     let source = if title_slot.is_some() {
         Source::Omp
     } else {
-        expected_source.unwrap_or(Source::Pi)
+        default_source
     };
-    if expected_source == Some(Source::Omp) && source != Source::Omp {
-        return Ok(None);
-    }
     let title = title_slot
         .and_then(|slot| slot.get("title"))
         .and_then(Value::as_str)
@@ -210,9 +193,9 @@ fn parse_reader(
         normalize_entry(&raw.value, source).map(|entry| (raw.line, entry))
     }));
 
-    Ok(Some(PiProjection {
+    Ok(Some(SessionProjection {
         source,
-        header: PiHeader {
+        header: SessionHeader {
             version,
             id,
             timestamp,
@@ -555,7 +538,7 @@ fn pi_usage(value: &Value) -> Option<TokenUsage> {
 }
 
 pub fn append_session_rename(path: &Path, title: &str) -> Result<()> {
-    let projection = parse_file(path)?.ok_or_else(|| {
+    let projection = PI_LOG.parse_transcript(path)?.ok_or_else(|| {
         AppError::ConfigError(format!("{} is not a valid Pi session", path.display()))
     })?;
     let mut ids = HashSet::new();
@@ -595,7 +578,7 @@ pub fn append_session_rename(path: &Path, title: &str) -> Result<()> {
 pub fn append_omp_session_rename(path: &Path, title: &str) -> Result<()> {
     const TITLE_SLOT_BYTES: usize = 256;
 
-    let projection = parse_omp_file(path)?.ok_or_else(|| {
+    let projection = OMP_LOG.parse_transcript(path)?.ok_or_else(|| {
         AppError::ConfigError(format!("{} is not a valid OMP session", path.display()))
     })?;
     let title = title.replace(['\r', '\n'], " ").trim().to_owned();
@@ -724,7 +707,7 @@ mod tests {
             ),
         ] {
             let before = std::fs::read(fixture(name)).unwrap();
-            let projection = parse_file(&fixture(name)).unwrap().unwrap();
+            let projection = PI_LOG.parse_transcript(&fixture(name)).unwrap().unwrap();
             assert_eq!(projection.header.version, version);
             assert_eq!(projection.header.id, id);
             assert_eq!(std::fs::read(fixture(name)).unwrap(), before);
@@ -733,7 +716,10 @@ mod tests {
 
     #[test]
     fn projects_only_the_active_branch_and_sanitizes_images() {
-        let projection = parse_file(&fixture("v3-branched.jsonl")).unwrap().unwrap();
+        let projection = PI_LOG
+            .parse_transcript(&fixture("v3-branched.jsonl"))
+            .unwrap()
+            .unwrap();
         let json = projection
             .entries
             .iter()
@@ -831,7 +817,7 @@ mod tests {
             "malformed\n",
             "{\"type\":\"branch_summary\",\"id\":\"leaf\",\"parentId\":\"missing\",\"timestamp\":\"2024-01-01T00:00:02Z\",\"summary\":\"leaf suffix\"}\n"
         );
-        let projection = parse_reader(std::io::Cursor::new(content), None)
+        let projection = parse_reader(std::io::Cursor::new(content), Source::Pi)
             .unwrap()
             .unwrap();
         assert_eq!(projection.malformed_lines, vec![3]);
@@ -845,7 +831,7 @@ mod tests {
     #[test]
     fn rejects_header_only_and_invalid_headers_as_conversations() {
         let invalid = std::io::Cursor::new("{\"type\":\"user\",\"id\":\"x\"}\n");
-        assert!(parse_reader(invalid, None).unwrap().is_none());
+        assert!(parse_reader(invalid, Source::Pi).unwrap().is_none());
 
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("header.jsonl");
@@ -885,7 +871,7 @@ mod tests {
             "{\"type\":\"message\",\"id\":\"root\",\"parentId\":null,\"timestamp\":\"2024-01-01T00:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"question\"}}\n",
             "{\"type\":\"message\",\"parentId\":\"root\",\"timestamp\":\"2024-01-01T00:00:02Z\",\"message\":{\"role\":\"user\",\"content\":\"invalid leaf\"}}\n"
         );
-        let projection = parse_reader(std::io::Cursor::new(content), None)
+        let projection = parse_reader(std::io::Cursor::new(content), Source::Pi)
             .unwrap()
             .unwrap();
 
@@ -912,7 +898,7 @@ mod tests {
             .unwrap();
         assert!(conversation.full_text.contains("visible hook"));
         assert_eq!(conversation.total_tokens, 77);
-        let projection = parse_reader(std::io::Cursor::new(content), None)
+        let projection = parse_reader(std::io::Cursor::new(content), Source::Pi)
             .unwrap()
             .unwrap();
         assert!(matches!(
@@ -944,7 +930,7 @@ mod tests {
     #[test]
     fn parses_omp_title_slot_and_active_branch() {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/omp/v3.jsonl");
-        let projection = parse_file(&path).unwrap().unwrap();
+        let projection = PI_LOG.parse_transcript(&path).unwrap().unwrap();
         assert_eq!(projection.source, Source::Omp);
         assert_eq!(projection.header.id, "omp_session_custom_id");
         assert_eq!(projection.title.as_deref(), Some("OMP fixture title"));
@@ -982,7 +968,7 @@ mod tests {
         assert_eq!(last["type"], "title_change");
         assert_eq!(last["parentId"], "a2");
         assert_eq!(last["title"], "renamed OMP");
-        let reparsed = parse_omp_file(&path).unwrap().unwrap();
+        let reparsed = OMP_LOG.parse_transcript(&path).unwrap().unwrap();
         assert_eq!(reparsed.title.as_deref(), Some("renamed OMP"));
     }
 }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -8,7 +8,7 @@ use super::parser::process_conversation_file;
 use super::path::{
     decode_project_dir_name, decode_project_dir_name_to_path, format_short_name_from_path,
 };
-use super::{Conversation, LoaderMessage, Project};
+use super::{Conversation, LoaderMessage, Project, Source};
 use crate::agent::transcript::content_blocks_count_as_agent_message;
 use crate::claude::{LogEntry, extract_search_text_from_user, parse_agent_progress};
 use crate::cli::DebugLevel;
@@ -46,54 +46,94 @@ pub struct DeleteEmptySummary {
     pub deleted: usize,
 }
 
+/// Everything loaded from the providers that keep sessions under roots.
+///
+/// Claude is loaded separately and treated as the primary history: it streams per
+/// project, and its projects directory is what the callers below fall back on.
+/// Whether these providers found anything decides whether a missing Claude
+/// directory is fatal or merely uninteresting.
+struct AuxiliaryHistory {
+    conversations: Vec<Conversation>,
+    /// One entry per provider that failed, in registration order. Kept per
+    /// provider because each is reported under its own name.
+    failures: Vec<(Source, AppError)>,
+    /// At least one provider has a session root on disk that loaded cleanly.
+    usable: bool,
+}
+
+impl AuxiliaryHistory {
+    fn load(show_last: bool, debug_level: Option<DebugLevel>) -> Self {
+        let mut history = Self {
+            conversations: Vec::new(),
+            failures: Vec::new(),
+            usable: false,
+        };
+        for provider in super::provider::providers() {
+            let Some(storage) = provider.storage() else {
+                continue;
+            };
+            let root_on_disk = storage
+                .roots()
+                .is_ok_and(|roots| roots.iter().any(|root| root.path.exists()));
+            match super::provider::load_sessions(provider.source(), storage, show_last, debug_level)
+            {
+                Ok(mut conversations) => {
+                    history.usable |= root_on_disk;
+                    history.conversations.append(&mut conversations);
+                }
+                Err(error) => history.failures.push((provider.source(), error)),
+            }
+        }
+        history
+    }
+
+    /// The failure to report when nothing loaded at all. A real cause beats the
+    /// generic "projects directory not found" the caller would otherwise raise.
+    fn take_first_failure(&mut self) -> Option<AppError> {
+        if self.failures.is_empty() {
+            return None;
+        }
+        Some(self.failures.remove(0).1)
+    }
+
+    fn failure_reports(&self) -> impl Iterator<Item = String> + '_ {
+        self.failures.iter().map(|(source, error)| {
+            format!(
+                "Failed to load {} history: {error}",
+                source.provider().labels().display
+            )
+        })
+    }
+}
+
 /// Load conversations from ALL projects globally
 #[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let pi_root = super::pi_loader::session_root().ok();
-    let pi_available = pi_root.as_ref().is_some_and(|root| root.path.exists());
-    let (mut pi_conversations, pi_error) =
-        match super::pi_loader::load_pi_conversations(show_last, debug_level) {
-            Ok(conversations) => (conversations, None),
-            Err(error) => (Vec::new(), Some(error)),
-        };
-    let omp_root = super::omp_loader::session_root().ok();
-    let omp_available = omp_root.as_ref().is_some_and(|root| root.path.exists());
-    let (mut omp_conversations, omp_error) =
-        match super::omp_loader::load_omp_conversations(show_last, debug_level) {
-            Ok(conversations) => (conversations, None),
-            Err(error) => (Vec::new(), Some(error)),
-        };
-    let auxiliary_usable =
-        (pi_available && pi_error.is_none()) || (omp_available && omp_error.is_none());
+    let mut auxiliary = AuxiliaryHistory::load(show_last, debug_level);
     let root = match super::get_claude_projects_root() {
         Ok(root) => root,
         Err(error) => {
-            if auxiliary_usable {
-                pi_conversations.append(&mut omp_conversations);
-                finalize_conversations(&mut pi_conversations);
-                return Ok(pi_conversations);
+            if auxiliary.usable {
+                finalize_conversations(&mut auxiliary.conversations);
+                return Ok(auxiliary.conversations);
             }
-            return Err(pi_error.or(omp_error).unwrap_or(error));
+            return Err(auxiliary.take_first_failure().unwrap_or(error));
         }
     };
     if !root.exists() {
-        if auxiliary_usable {
-            pi_conversations.append(&mut omp_conversations);
-            return Ok(pi_conversations);
+        if auxiliary.usable {
+            return Ok(auxiliary.conversations);
         }
-        if let Some(error) = pi_error.or(omp_error) {
+        if let Some(error) = auxiliary.take_first_failure() {
             return Err(error);
         }
         return Err(AppError::ProjectsDirNotFound(root.display().to_string()));
     }
-    if let Some(error) = pi_error {
-        debug::warn(debug_level, &format!("Failed to load Pi history: {error}"));
-    }
-    if let Some(error) = omp_error {
-        debug::warn(debug_level, &format!("Failed to load OMP history: {error}"));
+    for report in auxiliary.failure_reports() {
+        debug::warn(debug_level, &report);
     }
     let projects = list_projects(&root)?;
 
@@ -133,8 +173,7 @@ pub fn load_all_conversations(
         })
         .collect();
 
-    all_conversations.append(&mut pi_conversations);
-    all_conversations.append(&mut omp_conversations);
+    all_conversations.append(&mut auxiliary.conversations);
     finalize_conversations(&mut all_conversations);
 
     debug::info(
@@ -189,39 +228,24 @@ fn load_all_streaming_inner(
     debug_level: Option<DebugLevel>,
     time: TimeFilter,
 ) {
-    let pi_root = super::pi_loader::session_root().ok();
-    let pi_available = pi_root.as_ref().is_some_and(|root| root.path.exists());
-    let (mut pi_conversations, pi_error) =
-        match super::pi_loader::load_pi_conversations(show_last, debug_level) {
-            Ok(conversations) => (conversations, None),
-            Err(error) => (Vec::new(), Some(error)),
-        };
-    let omp_root = super::omp_loader::session_root().ok();
-    let omp_available = omp_root.as_ref().is_some_and(|root| root.path.exists());
-    let (mut omp_conversations, omp_error) =
-        match super::omp_loader::load_omp_conversations(show_last, debug_level) {
-            Ok(conversations) => (conversations, None),
-            Err(error) => (Vec::new(), Some(error)),
-        };
-    let auxiliary_usable =
-        (pi_available && pi_error.is_none()) || (omp_available && omp_error.is_none());
-    pi_conversations.append(&mut omp_conversations);
-    deduplicate_conversations(&mut pi_conversations);
+    let mut auxiliary = AuxiliaryHistory::load(show_last, debug_level);
+    let mut conversations = std::mem::take(&mut auxiliary.conversations);
+    deduplicate_conversations(&mut conversations);
     if time.is_active() {
-        pi_conversations.retain(|conversation| time.matches(conversation.timestamp));
+        conversations.retain(|conversation| time.matches(conversation.timestamp));
     }
-    if !pi_conversations.is_empty() {
-        let _ = tx.send(LoaderMessage::Batch(pi_conversations));
+    if !conversations.is_empty() {
+        let _ = tx.send(LoaderMessage::Batch(conversations));
     }
 
     let root = match super::get_claude_projects_root() {
         Ok(root) => root,
         Err(error) => {
-            if auxiliary_usable {
+            if auxiliary.usable {
                 let _ = tx.send(LoaderMessage::Done);
             } else {
                 let _ = tx.send(LoaderMessage::Fatal(
-                    pi_error.or(omp_error).unwrap_or(error),
+                    auxiliary.take_first_failure().unwrap_or(error),
                 ));
             }
             return;
@@ -229,30 +253,26 @@ fn load_all_streaming_inner(
     };
 
     if !root.exists() {
-        if auxiliary_usable {
+        if auxiliary.usable {
             let _ = tx.send(LoaderMessage::Done);
         } else {
-            let error = pi_error
-                .or(omp_error)
+            let error = auxiliary
+                .take_first_failure()
                 .unwrap_or_else(|| AppError::ProjectsDirNotFound(root.display().to_string()));
             let _ = tx.send(LoaderMessage::Fatal(error));
         }
         return;
     }
 
-    if let Some(error) = pi_error {
-        debug::warn(debug_level, &format!("Failed to load Pi history: {error}"));
-        let _ = tx.send(LoaderMessage::ProjectError);
-    }
-    if let Some(error) = omp_error {
-        debug::warn(debug_level, &format!("Failed to load OMP history: {error}"));
+    for report in auxiliary.failure_reports() {
+        debug::warn(debug_level, &report);
         let _ = tx.send(LoaderMessage::ProjectError);
     }
 
     let projects = match list_projects(&root) {
         Ok(p) => p,
         Err(error) => {
-            if auxiliary_usable {
+            if auxiliary.usable {
                 let _ = tx.send(LoaderMessage::Done);
             } else {
                 let _ = tx.send(LoaderMessage::Fatal(error));

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -75,8 +75,7 @@ impl AuxiliaryHistory {
             let root_on_disk = storage
                 .roots()
                 .is_ok_and(|roots| roots.iter().any(|root| root.path.exists()));
-            match super::provider::load_sessions(provider.source(), storage, show_last, debug_level)
-            {
+            match super::provider::load_sessions(storage, show_last, debug_level) {
                 Ok(mut conversations) => {
                     history.usable |= root_on_disk;
                     history.conversations.append(&mut conversations);

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -12,11 +12,11 @@
 //! - `path` - Path encoding/decoding utilities
 
 pub mod cache;
+pub mod format;
 mod loader;
 pub mod omp_loader;
 pub mod parser;
 pub mod path;
-pub mod pi;
 pub mod pi_loader;
 pub mod provider;
 mod rename;
@@ -57,7 +57,7 @@ impl Source {
 pub fn normalized_log_entries(
     path: &std::path::Path,
 ) -> Result<Vec<(usize, crate::claude::LogEntry)>> {
-    if let Some(projection) = pi::parse_file(path)? {
+    if let Some(projection) = format::parse_transcript(path)? {
         return Ok(projection.entries);
     }
     let file = std::fs::File::open(path)?;

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -54,12 +54,42 @@ impl Source {
     }
 }
 
+/// The entries of the session at `path` as `source` records it, normalized.
+/// What the viewer and export read.
+///
+/// Only `source`'s own format reads the locator — a session the list already
+/// attributed to a provider never meets a foreign format, which is what lets a
+/// provider's locators be something other than openable files.
 pub fn normalized_log_entries(
+    source: Source,
+    path: &std::path::Path,
+) -> Result<Vec<(usize, crate::claude::LogEntry)>> {
+    let projection = match source.provider().format() {
+        Some(format) => format.parse_transcript(path)?,
+        None => None,
+    };
+    if let Some(projection) = projection {
+        return Ok(projection.entries);
+    }
+    raw_log_entries(path)
+}
+
+/// [`normalized_log_entries`] for a bare file nothing has attributed —
+/// `--render` and direct path arguments. The first registered format that
+/// recognizes the file wins; a file no format claims is read as a raw Claude
+/// transcript.
+pub fn sniffed_log_entries(
     path: &std::path::Path,
 ) -> Result<Vec<(usize, crate::claude::LogEntry)>> {
     if let Some(projection) = format::parse_transcript(path)? {
         return Ok(projection.entries);
     }
+    raw_log_entries(path)
+}
+
+/// Claude records [`LogEntry`](crate::claude::LogEntry) values directly, one
+/// per line.
+fn raw_log_entries(path: &std::path::Path) -> Result<Vec<(usize, crate::claude::LogEntry)>> {
     let file = std::fs::File::open(path)?;
     let reader = std::io::BufReader::new(file);
     use std::io::BufRead;

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -18,6 +18,7 @@ pub mod parser;
 pub mod path;
 pub mod pi;
 pub mod pi_loader;
+pub mod provider;
 mod rename;
 
 use crate::error::{AppError, Result};
@@ -45,19 +46,11 @@ pub enum Source {
 
 impl Source {
     pub fn label(self) -> &'static str {
-        match self {
-            Self::Claude => "claude",
-            Self::Pi => "pi",
-            Self::Omp => "omp",
-        }
+        self.provider().labels().name
     }
 
     pub fn list_label(self) -> &'static str {
-        match self {
-            Self::Claude => "CC",
-            Self::Pi => "Pi",
-            Self::Omp => "OMP",
-        }
+        self.provider().labels().list
     }
 }
 

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -1,8 +1,6 @@
-use super::parser::process_omp_conversation_file;
-use super::provider::SessionRoot;
-use super::{Conversation, Source, format_short_name_from_path};
+use super::provider::{self, SessionRoot};
+use super::{Conversation, Source};
 use crate::cli::DebugLevel;
-use crate::debug;
 use crate::error::{AppError, Result};
 use std::path::{Path, PathBuf};
 
@@ -94,95 +92,10 @@ pub fn load_omp_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let root = session_root()?;
-    let files = root.discover_files()?;
-    let cached = super::cache::read_session_cache(Source::Omp, &root.path).unwrap_or_default();
-    let mut updated_cache = std::collections::HashMap::new();
-    let mut conversations = Vec::new();
-    for path in files {
-        let Ok(metadata) = std::fs::metadata(&path) else {
-            continue;
-        };
-        let modified = metadata.modified().ok();
-        let cache_key = path
-            .strip_prefix(&root.path)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .into_owned();
-        let mut conversation = modified
-            .and_then(|mtime| {
-                cached.get(&cache_key).filter(|entry| {
-                    super::cache::entry_matches(&entry.metadata, metadata.len(), mtime)
-                })
-            })
-            .map(|entry| {
-                let mut conversation =
-                    super::cache::conversation_from_entry(&entry.metadata, path.clone(), show_last);
-                conversation.source = Source::Omp;
-                conversation.session_id = entry.session_id.clone();
-                conversation.cwd = Some(entry.project_path.clone());
-                conversation.project_path = Some(entry.project_path.clone());
-                conversation.project_name = Some(format_short_name_from_path(&entry.project_path));
-                conversation
-            });
-        if conversation.is_none() {
-            let root_is_omp_owned = root
-                .path
-                .components()
-                .any(|component| matches!(component.as_os_str().to_str(), Some(".omp" | "omp")));
-            let parsed = if root_is_omp_owned {
-                process_omp_conversation_file(path.clone(), modified, debug_level)
-            } else {
-                super::parser::process_conversation_file(path.clone(), modified, debug_level)
-            };
-            conversation = match parsed {
-                Ok(Some(conversation)) if conversation.source == Source::Omp => Some(conversation),
-                Ok(_) => None,
-                Err(error) => {
-                    debug::warn(
-                        debug_level,
-                        &format!("Failed to parse OMP session {}: {error}", path.display()),
-                    );
-                    None
-                }
-            };
-        }
-        let Some(mut conversation) = conversation else {
-            continue;
-        };
-        conversation.preview = if show_last {
-            conversation.preview_last.clone()
-        } else {
-            conversation.preview_first.clone()
-        };
-        let project_path = conversation
-            .cwd
-            .clone()
-            .unwrap_or_else(|| PathBuf::from("unknown"));
-        conversation.project_name = Some(format_short_name_from_path(&project_path));
-        conversation.project_path = Some(project_path.clone());
-        if let Some(mtime) = modified {
-            updated_cache.insert(
-                cache_key,
-                super::cache::SessionCacheEntry {
-                    metadata: super::cache::entry_from_conversation(
-                        &conversation,
-                        metadata.len(),
-                        mtime,
-                    ),
-                    session_id: conversation.session_id.clone(),
-                    project_path,
-                },
-            );
-        }
-        conversations.push(conversation);
-    }
-    super::cache::write_session_cache(Source::Omp, &root.path, updated_cache);
-    conversations.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
-    for (index, conversation) in conversations.iter_mut().enumerate() {
-        conversation.index = index;
-    }
-    Ok(conversations)
+    let Some(storage) = Source::Omp.provider().storage() else {
+        return Ok(Vec::new());
+    };
+    provider::load_sessions(Source::Omp, storage, show_last, debug_level)
 }
 
 pub fn delete_session(path: &Path) -> Result<()> {

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -1,6 +1,4 @@
-use super::provider::{self, SessionRoot};
-use super::{Conversation, Source};
-use crate::cli::DebugLevel;
+use super::provider::SessionRoot;
 use crate::error::{AppError, Result};
 use std::path::{Path, PathBuf};
 
@@ -86,16 +84,6 @@ fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
             .unwrap_or_else(|_| PathBuf::from("."))
             .join(expanded)
     }
-}
-
-pub fn load_omp_conversations(
-    show_last: bool,
-    debug_level: Option<DebugLevel>,
-) -> Result<Vec<Conversation>> {
-    let Some(storage) = Source::Omp.provider().storage() else {
-        return Ok(Vec::new());
-    };
-    provider::load_sessions(Source::Omp, storage, show_last, debug_level)
 }
 
 #[cfg(test)]

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -14,6 +14,13 @@ pub fn session_root() -> Result<SessionRoot> {
     )
 }
 
+/// Resolve OMP's session root, and record whether it is OMP's own tree.
+///
+/// The two environment overrides point OMP somewhere the user chose, where Pi
+/// may write too, so those roots stay redirected. The config tree and the XDG
+/// data directory are OMP's own, and untitled transcripts in them are OMP's.
+/// Only this function can tell the two apart — the resulting paths look alike,
+/// and a home directory can itself be named `omp`.
 fn session_root_from(
     config_dir: Option<PathBuf>,
     agent_override: Option<PathBuf>,
@@ -47,10 +54,13 @@ fn session_root_from(
     let agent_dir = if profile.is_none() {
         agent_override
             .map(|path| expand_path_with_home(path, &home))
-            .unwrap_or(default_agent)
+            .unwrap_or_else(|| default_agent.clone())
     } else {
-        default_agent
+        default_agent.clone()
     };
+    if agent_dir != default_agent {
+        return Ok(SessionRoot::child_directories(agent_dir.join("sessions")));
+    }
 
     let xdg_profile_root = xdg_data_home.map(|root| {
         let root = root.join("omp");
@@ -58,15 +68,11 @@ fn session_root_from(
             .map(|profile| root.join("profiles").join(profile))
             .unwrap_or(root)
     });
-    let path = if agent_dir == profile_root.join("agent")
-        && let Some(xdg_root) = xdg_profile_root
-        && xdg_root.exists()
-    {
-        xdg_root.join("sessions")
-    } else {
-        agent_dir.join("sessions")
-    };
-    Ok(SessionRoot::child_directories(path))
+    let path = xdg_profile_root
+        .filter(|root| root.exists())
+        .unwrap_or(agent_dir)
+        .join("sessions");
+    Ok(SessionRoot::child_directories(path).in_agent_tree())
 }
 
 fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
@@ -89,6 +95,7 @@ fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::history::provider::RootOrigin;
 
     #[test]
     fn resolves_default_profile_overrides_and_xdg_roots() {
@@ -105,7 +112,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             default,
-            SessionRoot::child_directories(home.path().join(".omp/agent/sessions"))
+            SessionRoot::child_directories(home.path().join(".omp/agent/sessions")).in_agent_tree()
         );
 
         let profile = session_root_from(
@@ -136,6 +143,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(xdg_root.path, xdg.join("sessions"));
+        assert_eq!(xdg_root.origin(), RootOrigin::AgentTree);
 
         let custom = session_root_from(
             None,
@@ -148,5 +156,69 @@ mod tests {
         )
         .unwrap();
         assert_eq!(custom, SessionRoot::flat(home.path().join("sessions")));
+    }
+
+    /// The old test for this asked whether the path had a component called `omp`,
+    /// which a home directory can supply on its own.
+    #[test]
+    fn a_home_directory_named_omp_does_not_make_a_redirected_root_omps() {
+        let parent = tempfile::tempdir().unwrap();
+        let home = parent.path().join("omp");
+        std::fs::create_dir_all(&home).unwrap();
+
+        for redirect in [
+            // PI_CODING_AGENT_SESSION_DIR
+            session_root_from(
+                None,
+                None,
+                Some(PathBuf::from("~/shared-sessions")),
+                None,
+                None,
+                None,
+                Some(home.clone()),
+            ),
+            // PI_CODING_AGENT_DIR
+            session_root_from(
+                None,
+                Some(PathBuf::from("~/shared-agent")),
+                None,
+                None,
+                None,
+                None,
+                Some(home.clone()),
+            ),
+        ] {
+            let root = redirect.unwrap();
+            assert_eq!(
+                root.origin(),
+                RootOrigin::Redirected,
+                "{} was chosen by the user, so Pi may write there too",
+                root.path.display()
+            );
+        }
+
+        assert_eq!(
+            session_root_from(None, None, None, None, None, None, Some(home))
+                .unwrap()
+                .origin(),
+            RootOrigin::AgentTree
+        );
+    }
+
+    #[test]
+    fn a_profile_root_stays_omps_own_tree_even_beside_an_agent_override() {
+        let home = tempfile::tempdir().unwrap();
+        let profile = session_root_from(
+            None,
+            Some(PathBuf::from("~/ignored")),
+            None,
+            Some("work".into()),
+            None,
+            None,
+            Some(home.path().to_path_buf()),
+        )
+        .unwrap();
+
+        assert_eq!(profile.origin(), RootOrigin::AgentTree);
     }
 }

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -1,18 +1,12 @@
 use super::parser::process_omp_conversation_file;
+use super::provider::SessionRoot;
 use super::{Conversation, Source, format_short_name_from_path};
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
-use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct OmpSessionRoot {
-    pub path: PathBuf,
-    pub flat: bool,
-}
-
-pub fn session_root() -> Result<OmpSessionRoot> {
+pub fn session_root() -> Result<SessionRoot> {
     session_root_from(
         std::env::var_os("PI_CONFIG_DIR").map(PathBuf::from),
         std::env::var_os("PI_CODING_AGENT_DIR").map(PathBuf::from),
@@ -32,7 +26,7 @@ fn session_root_from(
     pi_profile: Option<std::ffi::OsString>,
     xdg_data_home: Option<PathBuf>,
     home_dir: Option<PathBuf>,
-) -> Result<OmpSessionRoot> {
+) -> Result<SessionRoot> {
     let home = home_dir.ok_or_else(|| {
         AppError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -40,10 +34,7 @@ fn session_root_from(
         ))
     })?;
     if let Some(path) = session_override {
-        return Ok(OmpSessionRoot {
-            path: expand_path_with_home(path, &home),
-            flat: true,
-        });
+        return Ok(SessionRoot::flat(expand_path_with_home(path, &home)));
     }
 
     let profile_value = omp_profile.or(pi_profile);
@@ -79,7 +70,7 @@ fn session_root_from(
     } else {
         agent_dir.join("sessions")
     };
-    Ok(OmpSessionRoot { path, flat: false })
+    Ok(SessionRoot::child_directories(path))
 }
 
 fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
@@ -99,41 +90,12 @@ fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
     }
 }
 
-pub fn discover_files(root: &OmpSessionRoot) -> Result<Vec<PathBuf>> {
-    if !root.path.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    if root.flat {
-        collect_jsonl(&root.path, &mut files)?;
-    } else {
-        for entry in read_dir(&root.path)? {
-            let path = entry?.path();
-            if path.is_dir() {
-                collect_jsonl(&path, &mut files)?;
-            }
-        }
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn collect_jsonl(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in read_dir(directory)? {
-        let path = entry?.path();
-        if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
 pub fn load_omp_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
     let root = session_root()?;
-    let files = discover_files(&root)?;
+    let files = root.discover_files()?;
     let cached = super::cache::read_omp_cache(&root.path).unwrap_or_default();
     let mut updated_cache = std::collections::HashMap::new();
     let mut conversations = Vec::new();
@@ -254,8 +216,10 @@ mod tests {
             Some(home.path().to_path_buf()),
         )
         .unwrap();
-        assert_eq!(default.path, home.path().join(".omp/agent/sessions"));
-        assert!(!default.flat);
+        assert_eq!(
+            default,
+            SessionRoot::child_directories(home.path().join(".omp/agent/sessions"))
+        );
 
         let profile = session_root_from(
             None,
@@ -296,7 +260,6 @@ mod tests {
             Some(home.path().to_path_buf()),
         )
         .unwrap();
-        assert_eq!(custom.path, home.path().join("sessions"));
-        assert!(custom.flat);
+        assert_eq!(custom, SessionRoot::flat(home.path().join("sessions")));
     }
 }

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -98,20 +98,6 @@ pub fn load_omp_conversations(
     provider::load_sessions(Source::Omp, storage, show_last, debug_level)
 }
 
-pub fn delete_session(path: &Path) -> Result<()> {
-    if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-        || !super::format::owns_transcript(Source::Omp, path)
-    {
-        return Err(AppError::SessionNotFound(path.display().to_string()));
-    }
-    std::fs::remove_file(path)?;
-    let artifacts = path.with_extension("");
-    if artifacts.is_dir() {
-        std::fs::remove_dir_all(artifacts)?;
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -96,7 +96,7 @@ pub fn load_omp_conversations(
 ) -> Result<Vec<Conversation>> {
     let root = session_root()?;
     let files = root.discover_files()?;
-    let cached = super::cache::read_omp_cache(&root.path).unwrap_or_default();
+    let cached = super::cache::read_session_cache(Source::Omp, &root.path).unwrap_or_default();
     let mut updated_cache = std::collections::HashMap::new();
     let mut conversations = Vec::new();
     for path in files {
@@ -164,7 +164,7 @@ pub fn load_omp_conversations(
         if let Some(mtime) = modified {
             updated_cache.insert(
                 cache_key,
-                super::cache::PiCacheEntry {
+                super::cache::SessionCacheEntry {
                     metadata: super::cache::entry_from_conversation(
                         &conversation,
                         metadata.len(),
@@ -177,7 +177,7 @@ pub fn load_omp_conversations(
         }
         conversations.push(conversation);
     }
-    super::cache::write_omp_cache(&root.path, updated_cache);
+    super::cache::write_session_cache(Source::Omp, &root.path, updated_cache);
     conversations.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
     for (index, conversation) in conversations.iter_mut().enumerate() {
         conversation.index = index;

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -1,8 +1,13 @@
 use super::provider::SessionRoot;
+use super::provider::walk::FileRoot;
 use crate::error::{AppError, Result};
 use std::path::{Path, PathBuf};
 
-pub fn session_root() -> Result<SessionRoot> {
+/// Resolve OMP's session root together with its walk depth: a redirected
+/// session directory holds transcripts beside itself, every other arrangement
+/// holds them in a directory per project. Only this resolution knows which is
+/// which, so the pairing is returned rather than guessed from the path later.
+pub fn session_root() -> Result<FileRoot> {
     session_root_from(
         std::env::var_os("PI_CONFIG_DIR").map(PathBuf::from),
         std::env::var_os("PI_CODING_AGENT_DIR").map(PathBuf::from),
@@ -29,7 +34,7 @@ fn session_root_from(
     pi_profile: Option<std::ffi::OsString>,
     xdg_data_home: Option<PathBuf>,
     home_dir: Option<PathBuf>,
-) -> Result<SessionRoot> {
+) -> Result<FileRoot> {
     let home = home_dir.ok_or_else(|| {
         AppError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -37,7 +42,10 @@ fn session_root_from(
         ))
     })?;
     if let Some(path) = session_override {
-        return Ok(SessionRoot::flat(expand_path_with_home(path, &home)));
+        return Ok(FileRoot {
+            root: SessionRoot::new(expand_path_with_home(path, &home)),
+            depth: 0,
+        });
     }
 
     let profile_value = omp_profile.or(pi_profile);
@@ -59,7 +67,10 @@ fn session_root_from(
         default_agent.clone()
     };
     if agent_dir != default_agent {
-        return Ok(SessionRoot::child_directories(agent_dir.join("sessions")));
+        return Ok(FileRoot {
+            root: SessionRoot::new(agent_dir.join("sessions")),
+            depth: 1,
+        });
     }
 
     let xdg_profile_root = xdg_data_home.map(|root| {
@@ -72,7 +83,10 @@ fn session_root_from(
         .filter(|root| root.exists())
         .unwrap_or(agent_dir)
         .join("sessions");
-    Ok(SessionRoot::child_directories(path).in_agent_tree())
+    Ok(FileRoot {
+        root: SessionRoot::new(path).in_agent_tree(),
+        depth: 1,
+    })
 }
 
 fn expand_path_with_home(path: PathBuf, home: &Path) -> PathBuf {
@@ -112,7 +126,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             default,
-            SessionRoot::child_directories(home.path().join(".omp/agent/sessions")).in_agent_tree()
+            FileRoot {
+                root: SessionRoot::new(home.path().join(".omp/agent/sessions")).in_agent_tree(),
+                depth: 1,
+            }
         );
 
         let profile = session_root_from(
@@ -126,7 +143,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            profile.path,
+            profile.root.path,
             home.path().join(".omp/profiles/work/agent/sessions")
         );
 
@@ -142,8 +159,8 @@ mod tests {
             Some(home.path().to_path_buf()),
         )
         .unwrap();
-        assert_eq!(xdg_root.path, xdg.join("sessions"));
-        assert_eq!(xdg_root.origin(), RootOrigin::AgentTree);
+        assert_eq!(xdg_root.root.path, xdg.join("sessions"));
+        assert_eq!(xdg_root.root.origin(), RootOrigin::AgentTree);
 
         let custom = session_root_from(
             None,
@@ -155,7 +172,13 @@ mod tests {
             Some(home.path().to_path_buf()),
         )
         .unwrap();
-        assert_eq!(custom, SessionRoot::flat(home.path().join("sessions")));
+        assert_eq!(
+            custom,
+            FileRoot {
+                root: SessionRoot::new(home.path().join("sessions")),
+                depth: 0,
+            }
+        );
     }
 
     /// The old test for this asked whether the path had a component called `omp`,
@@ -188,7 +211,7 @@ mod tests {
                 Some(home.clone()),
             ),
         ] {
-            let root = redirect.unwrap();
+            let root = redirect.unwrap().root;
             assert_eq!(
                 root.origin(),
                 RootOrigin::Redirected,
@@ -200,6 +223,7 @@ mod tests {
         assert_eq!(
             session_root_from(None, None, None, None, None, None, Some(home))
                 .unwrap()
+                .root
                 .origin(),
             RootOrigin::AgentTree
         );
@@ -219,6 +243,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(profile.origin(), RootOrigin::AgentTree);
+        assert_eq!(profile.root.origin(), RootOrigin::AgentTree);
     }
 }

--- a/src/history/omp_loader.rs
+++ b/src/history/omp_loader.rs
@@ -100,7 +100,7 @@ pub fn load_omp_conversations(
 
 pub fn delete_session(path: &Path) -> Result<()> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-        || !super::pi::is_omp_file(path)
+        || !super::format::owns_transcript(Source::Omp, path)
     {
         return Err(AppError::SessionNotFound(path.display().to_string()));
     }

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -3,6 +3,7 @@
 //! This module handles parsing Claude conversation JSONL files and extracting
 //! conversation metadata like preview text, message counts, and working directory.
 
+use super::format::{SessionFormat, SessionProjection};
 use super::{Conversation, ParseError};
 use crate::agent::refs::MessageRange;
 use crate::agent::transcript::{
@@ -26,33 +27,40 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-/// Process a single conversation file and extract all necessary information
+/// Process a single conversation file, letting the registry decide which format
+/// owns it.
 pub fn process_conversation_file(
     path: PathBuf,
     modified: Option<SystemTime>,
     debug_level: Option<DebugLevel>,
 ) -> Result<Option<Conversation>> {
-    process_conversation_file_with_source(path, modified, debug_level, None)
+    let projection = super::format::parse_transcript(&path)?;
+    build_conversation(path, projection, modified, debug_level)
 }
 
-pub fn process_omp_conversation_file(
+/// Process a conversation file as `format` rather than asking the registry.
+///
+/// A caller that knows which root a transcript came from knows more than the file
+/// does: a Pi-family transcript with no OMP title slot belongs to whichever agent
+/// owns the directory holding it.
+pub fn process_session_file(
     path: PathBuf,
+    format: &dyn SessionFormat,
     modified: Option<SystemTime>,
     debug_level: Option<DebugLevel>,
 ) -> Result<Option<Conversation>> {
-    process_conversation_file_with_source(path, modified, debug_level, Some(super::Source::Omp))
+    let projection = format.parse_transcript(&path)?;
+    build_conversation(path, projection, modified, debug_level)
 }
 
-fn process_conversation_file_with_source(
+/// Claude records [`LogEntry`] values directly, so a file no format projected is
+/// read as a raw Claude transcript.
+fn build_conversation(
     path: PathBuf,
+    projection: Option<SessionProjection>,
     modified: Option<SystemTime>,
     debug_level: Option<DebugLevel>,
-    source: Option<super::Source>,
 ) -> Result<Option<Conversation>> {
-    let projection = match source {
-        Some(super::Source::Omp) => super::pi::parse_omp_file(&path)?,
-        _ => super::pi::parse_file(&path)?,
-    };
     if let Some(projection) = projection {
         return Ok(conversation_from_projection(
             path,
@@ -74,7 +82,7 @@ fn process_conversation_file_with_source(
 /// file's content in memory, on the path every non-Claude provider takes.
 fn conversation_from_projection(
     path: PathBuf,
-    projection: super::pi::PiProjection,
+    projection: SessionProjection,
     modified: Option<SystemTime>,
     debug_level: Option<DebugLevel>,
 ) -> Option<Conversation> {

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -54,57 +54,66 @@ fn process_conversation_file_with_source(
         _ => super::pi::parse_file(&path)?,
     };
     if let Some(projection) = projection {
-        let normalized = projection
-            .entries
-            .iter()
-            .filter_map(|(_, entry)| serde_json::to_string(entry).ok())
-            .collect::<Vec<_>>()
-            .join("\n");
-        let mut conversation = process_conversation_reader(
-            path.clone(),
-            std::io::Cursor::new(normalized),
+        return Ok(conversation_from_projection(
+            path,
+            projection,
             modified,
             debug_level,
-        )?;
-        if let Some(conversation) = conversation.as_mut() {
-            conversation.source = projection.source;
-            conversation.session_id = projection.header.id;
-            conversation.cwd = Some(projection.header.cwd.clone());
-            conversation.project_path = Some(projection.header.cwd.clone());
-            conversation.project_name =
-                Some(super::format_short_name_from_path(&projection.header.cwd));
-            conversation
-                .parse_errors
-                .extend(
-                    projection
-                        .malformed_lines
-                        .into_iter()
-                        .map(|line_number| ParseError {
-                            line_number,
-                            line_content: String::new(),
-                            error_message: format!(
-                                "malformed {} JSONL record",
-                                projection.source.label()
-                            ),
-                            context_before: Vec::new(),
-                            context_after: Vec::new(),
-                        }),
-                );
-            conversation.timestamp = latest_activity_timestamp(&projection.entries)
-                .or_else(|| {
-                    DateTime::parse_from_rfc3339(&projection.header.timestamp)
-                        .ok()
-                        .map(|timestamp| timestamp.with_timezone(&Local))
-                })
-                .or_else(|| modified.map(DateTime::<Local>::from))
-                .unwrap_or_else(Local::now);
-        }
-        return Ok(conversation);
+        ));
     }
 
     let file = File::open(&path)?;
     let reader = BufReader::new(file);
     process_conversation_reader(path, reader, modified, debug_level)
+}
+
+/// Build a conversation from an already normalized transcript.
+///
+/// The entries are handed to the builder directly. Serializing them back to JSON
+/// so a reader could parse them again would hold two more full copies of the
+/// file's content in memory, on the path every non-Claude provider takes.
+fn conversation_from_projection(
+    path: PathBuf,
+    projection: super::pi::PiProjection,
+    modified: Option<SystemTime>,
+    debug_level: Option<DebugLevel>,
+) -> Option<Conversation> {
+    // Prefer the last message's own timestamp; the header's start time and the
+    // file mtime are progressively weaker stand-ins.
+    let timestamp = latest_activity_timestamp(&projection.entries)
+        .or_else(|| {
+            DateTime::parse_from_rfc3339(&projection.header.timestamp)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&Local))
+        })
+        .or_else(|| modified.map(DateTime::<Local>::from))
+        .unwrap_or_else(Local::now);
+
+    let mut builder = ConversationBuilder {
+        parse_errors: projection
+            .malformed_lines
+            .iter()
+            .map(|line_number| ParseError {
+                line_number: *line_number,
+                line_content: String::new(),
+                error_message: format!("malformed {} JSONL record", projection.source.label()),
+                context_before: Vec::new(),
+                context_after: Vec::new(),
+            })
+            .collect(),
+        ..ConversationBuilder::default()
+    };
+    for (_, entry) in projection.entries {
+        builder.push(entry);
+    }
+
+    let mut conversation = builder.finish(path, timestamp, debug_level)?;
+    conversation.source = projection.source;
+    conversation.session_id = projection.header.id;
+    conversation.cwd = Some(projection.header.cwd.clone());
+    conversation.project_path = Some(projection.header.cwd.clone());
+    conversation.project_name = Some(super::format_short_name_from_path(&projection.header.cwd));
+    Some(conversation)
 }
 
 fn latest_activity_timestamp(entries: &[(usize, LogEntry)]) -> Option<DateTime<Local>> {
@@ -121,6 +130,420 @@ fn latest_activity_timestamp(entries: &[(usize, LogEntry)]) -> Option<DateTime<L
         .max()
 }
 
+/// Accumulates one conversation as its log entries stream past in file order.
+///
+/// Separating accumulation from line reading lets a caller that already holds
+/// parsed entries — every provider whose transcript is normalized before it
+/// reaches here — feed them straight in, rather than re-serializing them to JSON
+/// only to parse that JSON back.
+#[derive(Default)]
+struct ConversationBuilder {
+    all_parts: Vec<String>,
+    agent_search_parts: Vec<String>,
+    semantic_turns: Vec<String>,
+    semantic_turn_ranges: Vec<MessageRange>,
+    preview_parts: Vec<String>,
+    user_messages: Vec<String>,
+    seen_real_user_message: bool,
+    skip_next_assistant: bool,
+    extracted_cwd: Option<PathBuf>,
+    message_count: usize,
+    parse_errors: Vec<ParseError>,
+    extracted_summary: Option<String>,
+    extracted_custom_title: Option<String>,
+    extracted_model: Option<String>,
+    /// Token usage per message id, so the several streaming entries that can
+    /// describe one message are counted once. Entries carrying no id accumulate
+    /// into `anonymous_token_count` instead.
+    token_usage_by_msg: HashMap<String, TokenUsage>,
+    assistant_id_ordinals: HashMap<String, usize>,
+    assistant_id_semantic_indices: HashMap<String, usize>,
+    assistant_id_preview_indices: HashMap<String, usize>,
+    anonymous_token_count: u64,
+    first_timestamp: Option<chrono::DateTime<chrono::FixedOffset>>,
+    last_timestamp: Option<chrono::DateTime<chrono::FixedOffset>>,
+}
+
+impl ConversationBuilder {
+    fn push(&mut self, entry: LogEntry) {
+        match entry {
+            LogEntry::User {
+                message,
+                cwd,
+                timestamp,
+                usage,
+                ..
+            } => {
+                if let Some(usage) = usage {
+                    self.anonymous_token_count += usage.input_tokens
+                        + usage.output_tokens
+                        + usage.cache_creation_input_tokens
+                        + usage.cache_read_input_tokens;
+                }
+                // Track timestamps for conversation duration
+                if let Some(ref ts_str) = timestamp
+                    && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(ts_str)
+                {
+                    if self.first_timestamp.is_none() {
+                        self.first_timestamp = Some(ts);
+                    }
+                    self.last_timestamp = Some(ts);
+                }
+
+                // Extract cwd from the first user message that has it
+                if self.extracted_cwd.is_none()
+                    && let Some(cwd_str) = cwd
+                {
+                    self.extracted_cwd = Some(PathBuf::from(cwd_str));
+                }
+
+                let preview_text = extract_text_from_user(&message);
+                let search_text = extract_search_text_from_user(&message);
+
+                if preview_text.is_empty() && search_text.is_empty() {
+                    return;
+                }
+
+                if !preview_text.is_empty() {
+                    self.user_messages.push(preview_text.clone());
+                }
+
+                // Check for skill invocations first - extract clean preview
+                // (e.g. "/consult how to do X?" from command XML tags)
+                let semantic_input = preview_text.clone();
+                let effective_preview =
+                    if let Some(skill_preview) = extract_skill_preview(&preview_text) {
+                        skill_preview
+                    } else if !preview_text.is_empty() && is_clear_metadata_message(&preview_text) {
+                        if !search_text.is_empty() {
+                            self.all_parts.push(search_text);
+                        }
+                        return;
+                    } else {
+                        preview_text
+                    };
+
+                let has_search_text = !search_text.is_empty();
+                if has_search_text {
+                    self.all_parts.push(search_text);
+                }
+
+                // Check if this is a warmup message (first user message is "Warmup")
+                let is_warmup =
+                    !self.seen_real_user_message && effective_preview.trim() == "Warmup";
+                if is_warmup {
+                    self.skip_next_assistant = true;
+                } else if !effective_preview.is_empty() || has_search_text {
+                    self.message_count += 1;
+                    let message_range = MessageRange::single(self.message_count);
+                    if !effective_preview.is_empty() {
+                        if let Some(turn) = filter_turn(SemanticTurnRole::User, &semantic_input) {
+                            self.semantic_turns.push(turn);
+                            self.semantic_turn_ranges.push(message_range);
+                        }
+                        self.preview_parts.push(effective_preview);
+                        self.seen_real_user_message = true;
+                    }
+                }
+            }
+            LogEntry::Assistant {
+                message, timestamp, ..
+            } => {
+                let assistant_message_id = message.id.clone();
+                let canonical_ordinal = assistant_message_id
+                    .as_ref()
+                    .and_then(|id| self.assistant_id_ordinals.get(id).copied())
+                    .unwrap_or(self.message_count + 1);
+                // Track timestamps for conversation duration
+                if let Some(ref ts_str) = timestamp
+                    && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(ts_str)
+                {
+                    if self.first_timestamp.is_none() {
+                        self.first_timestamp = Some(ts);
+                    }
+                    self.last_timestamp = Some(ts);
+                }
+
+                // Extract model name from first assistant message that has it
+                if self.extracted_model.is_none()
+                    && let Some(model) = &message.model
+                {
+                    self.extracted_model = Some(model.clone());
+                }
+
+                // Track token usage by message ID to avoid double-counting
+                // Multiple JSONL entries can exist for the same message (streaming)
+                if let Some(usage) = &message.usage {
+                    if let Some(msg_id) = &message.id {
+                        // Store/update usage for this message ID (last one wins)
+                        self.token_usage_by_msg
+                            .insert(msg_id.clone(), usage.clone());
+                    } else {
+                        // No message ID - accumulate directly (legacy format)
+                        self.anonymous_token_count += usage.input_tokens
+                            + usage.output_tokens
+                            + usage.cache_creation_input_tokens
+                            + usage.cache_read_input_tokens;
+                    }
+                }
+
+                let preview_text = extract_text_from_assistant(&message);
+                let search_text = extract_search_text_from_assistant(&message);
+
+                if !search_text.is_empty() {
+                    self.all_parts.push(search_text);
+                }
+
+                // Skip this assistant message if it follows a warmup user message
+                if self.skip_next_assistant {
+                    self.skip_next_assistant = false;
+                } else if self.seen_real_user_message
+                    && content_blocks_count_as_agent_message(&message.content)
+                {
+                    if canonical_ordinal == self.message_count + 1 {
+                        self.message_count += 1;
+                    }
+                    let message_range = MessageRange::single(canonical_ordinal);
+                    let semantic_turn = filter_turn(SemanticTurnRole::Assistant, &preview_text);
+                    if let Some(id) = assistant_message_id.as_ref() {
+                        if let Some(existing_index) =
+                            self.assistant_id_semantic_indices.get(id).copied()
+                        {
+                            if let Some(turn) = semantic_turn {
+                                self.semantic_turns[existing_index] = turn;
+                                self.semantic_turn_ranges[existing_index] = message_range;
+                            } else {
+                                self.semantic_turns[existing_index].clear();
+                            }
+                        } else if let Some(turn) = semantic_turn {
+                            self.assistant_id_semantic_indices
+                                .insert(id.clone(), self.semantic_turns.len());
+                            self.semantic_turns.push(turn);
+                            self.semantic_turn_ranges.push(message_range);
+                        }
+
+                        if !preview_text.is_empty() {
+                            if let Some(existing_index) =
+                                self.assistant_id_preview_indices.get(id).copied()
+                            {
+                                self.preview_parts[existing_index] = preview_text;
+                            } else {
+                                self.assistant_id_preview_indices
+                                    .insert(id.clone(), self.preview_parts.len());
+                                self.preview_parts.push(preview_text);
+                            }
+                        }
+                        self.assistant_id_ordinals
+                            .insert(id.clone(), canonical_ordinal);
+                    } else if !preview_text.is_empty() {
+                        if let Some(turn) = semantic_turn {
+                            self.semantic_turns.push(turn);
+                            self.semantic_turn_ranges.push(message_range);
+                        }
+                        self.preview_parts.push(preview_text);
+                    }
+                }
+            }
+            LogEntry::Summary { summary } => {
+                if self.extracted_summary.is_none() {
+                    self.extracted_summary = Some(summary.clone());
+                }
+            }
+            LogEntry::AiTitle { ai_title } => {
+                let trimmed = ai_title.trim();
+                if !trimmed.is_empty() {
+                    self.extracted_summary = Some(trimmed.to_owned());
+                }
+            }
+            LogEntry::CustomTitle { custom_title } => {
+                let trimmed = custom_title.trim();
+                self.extracted_custom_title = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_owned())
+                };
+            }
+            LogEntry::PiMetadata {
+                label,
+                text,
+                searchable,
+                usage,
+                ..
+            } => {
+                if let Some(usage) = usage {
+                    self.anonymous_token_count += usage.input_tokens
+                        + usage.output_tokens
+                        + usage.cache_creation_input_tokens
+                        + usage.cache_read_input_tokens;
+                }
+                if label == "Model" && !text.is_empty() {
+                    self.extracted_model = Some(text.clone());
+                }
+                if searchable && !text.is_empty() {
+                    self.all_parts.push(text.clone());
+                    self.message_count += 1;
+                    if let Some(turn) = filter_turn(SemanticTurnRole::User, &text) {
+                        self.semantic_turns.push(turn);
+                        self.semantic_turn_ranges
+                            .push(MessageRange::single(self.message_count));
+                    }
+                }
+            }
+            LogEntry::Progress { data, .. } => {
+                if let Some(progress) = parse_agent_progress(&data)
+                    && matches!(progress.message.message_type.as_str(), "user" | "assistant")
+                {
+                    let AgentContent::Blocks(blocks) = progress.message.message.content;
+                    if content_blocks_count_as_agent_message(&blocks) {
+                        self.message_count += 1;
+                    }
+                    let role = match progress.message.message_type.as_str() {
+                        "user" => AgentMessageRole::User,
+                        "assistant" => AgentMessageRole::Assistant,
+                        _ => unreachable!("progress message type was checked above"),
+                    };
+                    let agent_search_text = agent_search_text_from_blocks(role, &blocks);
+                    if !agent_search_text.is_empty() {
+                        self.agent_search_parts.push(agent_search_text);
+                    }
+                }
+            }
+            LogEntry::AgentName { .. } => {}
+            LogEntry::System { .. } => {}
+            _ => {}
+        }
+    }
+
+    /// The accumulated conversation, or `None` when it holds nothing worth
+    /// listing: a `/clear`-only session, or one with no previewable text.
+    fn finish(
+        self,
+        path: PathBuf,
+        timestamp: DateTime<Local>,
+        debug_level: Option<DebugLevel>,
+    ) -> Option<Conversation> {
+        let filename = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown");
+
+        if is_clear_only_conversation(&self.user_messages) {
+            debug::debug(
+                debug_level,
+                &format!("Filtered {}: clear-only conversation", filename),
+            );
+            return None;
+        }
+
+        if self.all_parts.is_empty() || self.preview_parts.is_empty() {
+            debug::debug(
+                debug_level,
+                &format!(
+                    "Filtered {}: empty conversation (all_parts={}, preview_parts={})",
+                    filename,
+                    self.all_parts.len(),
+                    self.preview_parts.len()
+                ),
+            );
+            return None;
+        }
+
+        // Both previews come from preview_parts rather than all_parts, so leading
+        // assistant messages don't displace the user's opening message.
+        let preview_first = self
+            .preview_parts
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ");
+        let preview_last = self
+            .preview_parts
+            .iter()
+            .rev()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ");
+
+        // Full text for searching: all messages, preceded by summary and title.
+        let mut full_text = self.all_parts.join(" ");
+        if let Some(ref summary) = self.extracted_summary {
+            full_text = format!("{} {}", summary, full_text);
+        }
+        if let Some(ref custom_title) = self.extracted_custom_title {
+            full_text = format!("{} {}", custom_title, full_text);
+        }
+
+        let preview_first = normalize_whitespace(&preview_first);
+        let preview_last = normalize_whitespace(&preview_last);
+        let full_text = normalize_whitespace(&full_text);
+        let agent_search_text = normalize_whitespace(&self.agent_search_parts.join(" "));
+        let semantic_route_text = super::semantic_route_text(&full_text, &agent_search_text);
+
+        // Pre-normalize search text to avoid re-normalizing on every startup
+        let search_text_lower = normalize_for_search(&full_text);
+
+        let (semantic_turns, semantic_turn_ranges): (Vec<_>, Vec<_>) = self
+            .semantic_turns
+            .into_iter()
+            .zip(self.semantic_turn_ranges)
+            .filter(|(turn, _)| !turn.is_empty())
+            .unzip();
+
+        let total_tokens: u64 = self
+            .token_usage_by_msg
+            .values()
+            .map(|usage| {
+                usage.input_tokens
+                    + usage.output_tokens
+                    + usage.cache_creation_input_tokens
+                    + usage.cache_read_input_tokens
+            })
+            .sum::<u64>()
+            + self.anonymous_token_count;
+
+        let duration_minutes = match (self.first_timestamp, self.last_timestamp) {
+            (Some(first), Some(last)) => {
+                let minutes = last.signed_duration_since(first).num_minutes();
+                (minutes > 0).then_some(minutes as u64)
+            }
+            _ => None,
+        };
+
+        Some(Conversation {
+            source: super::Source::Claude,
+            session_id: path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default()
+                .to_owned(),
+            path,
+            index: 0,
+            timestamp,
+            preview: preview_first.clone(),
+            preview_first,
+            preview_last,
+            full_text,
+            agent_search_text,
+            semantic_route_text,
+            semantic_turns,
+            semantic_turn_ranges,
+            search_text_lower,
+            project_name: None,
+            project_path: None,
+            cwd: self.extracted_cwd,
+            message_count: self.message_count,
+            parse_errors: self.parse_errors,
+            summary: self.extracted_summary,
+            custom_title: self.extracted_custom_title,
+            model: self.extracted_model,
+            total_tokens,
+            duration_minutes,
+        })
+    }
+}
+
 /// Process a conversation from any BufRead source (for testability)
 pub fn process_conversation_reader<R: BufRead>(
     path: PathBuf,
@@ -131,7 +554,8 @@ pub fn process_conversation_reader<R: BufRead>(
     let filename = path
         .file_name()
         .and_then(|f| f.to_str())
-        .unwrap_or("unknown");
+        .unwrap_or("unknown")
+        .to_owned();
 
     // Stream lines with a sliding window for parse error context.
     // A VecDeque lookahead holds the current line + up to 2 context_after lines,
@@ -150,30 +574,7 @@ pub fn process_conversation_reader<R: BufRead>(
         }
     }
 
-    let mut all_parts = Vec::new();
-    let mut agent_search_parts = Vec::new();
-    let mut semantic_turns = Vec::new();
-    let mut semantic_turn_ranges = Vec::new();
-    let mut preview_parts = Vec::new();
-    let mut user_messages = Vec::new();
-    let mut seen_real_user_message = false;
-    let mut skip_next_assistant = false;
-    let mut extracted_cwd: Option<PathBuf> = None;
-    let mut message_count: usize = 0;
-    let mut parse_errors: Vec<ParseError> = Vec::new();
-    let mut extracted_summary: Option<String> = None;
-    let mut extracted_custom_title: Option<String> = None;
-    let mut extracted_model: Option<String> = None;
-    // Track token usage per message ID to avoid double-counting streaming entries
-    let mut token_usage_by_msg: HashMap<String, TokenUsage> = HashMap::new();
-    let mut assistant_id_ordinals: HashMap<String, usize> = HashMap::new();
-    let mut assistant_id_semantic_indices: HashMap<String, usize> = HashMap::new();
-    let mut assistant_id_preview_indices: HashMap<String, usize> = HashMap::new();
-    let mut anonymous_token_count: u64 = 0;
-    // Track first and last message timestamps for conversation duration
-    let mut first_timestamp: Option<chrono::DateTime<chrono::FixedOffset>> = None;
-    let mut last_timestamp: Option<chrono::DateTime<chrono::FixedOffset>> = None;
-
+    let mut builder = ConversationBuilder::default();
     let mut line_idx: usize = 0;
 
     while let Some(line) = context_window.pop_front() {
@@ -184,290 +585,30 @@ pub fn process_conversation_reader<R: BufRead>(
             None => {}
         }
 
-        if line.trim().is_empty() {
-            // Blank lines participate in context buffers but are not parsed
-            context_before.push_back(line);
-            if context_before.len() > 2 {
-                context_before.pop_front();
-            }
-            line_idx += 1;
-            continue;
-        }
+        // Blank lines participate in the context buffers but are not parsed.
+        if !line.trim().is_empty() {
+            match serde_json::from_str::<LogEntry>(&line) {
+                Ok(entry) => builder.push(entry),
+                Err(error) => {
+                    // Capture parse error with surrounding context from the sliding window
+                    builder.parse_errors.push(ParseError {
+                        line_number: line_idx + 1, // 1-indexed for display
+                        line_content: line.clone(),
+                        error_message: error.to_string(),
+                        context_before: context_before.iter().cloned().collect(),
+                        context_after: context_window.iter().cloned().collect(),
+                    });
 
-        match serde_json::from_str::<LogEntry>(&line) {
-            Ok(entry) => {
-                // Extract text content
-                match entry {
-                    LogEntry::User {
-                        message,
-                        cwd,
-                        timestamp,
-                        usage,
-                        ..
-                    } => {
-                        if let Some(usage) = usage {
-                            anonymous_token_count += usage.input_tokens
-                                + usage.output_tokens
-                                + usage.cache_creation_input_tokens
-                                + usage.cache_read_input_tokens;
-                        }
-                        // Track timestamps for conversation duration
-                        if let Some(ref ts_str) = timestamp
-                            && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(ts_str)
-                        {
-                            if first_timestamp.is_none() {
-                                first_timestamp = Some(ts);
-                            }
-                            last_timestamp = Some(ts);
-                        }
-
-                        // Extract cwd from the first user message that has it
-                        if extracted_cwd.is_none()
-                            && let Some(cwd_str) = cwd
-                        {
-                            extracted_cwd = Some(PathBuf::from(cwd_str));
-                        }
-
-                        let preview_text = extract_text_from_user(&message);
-                        let search_text = extract_search_text_from_user(&message);
-
-                        if preview_text.is_empty() && search_text.is_empty() {
-                            continue;
-                        }
-
-                        if !preview_text.is_empty() {
-                            user_messages.push(preview_text.clone());
-                        }
-
-                        // Check for skill invocations first - extract clean preview
-                        // (e.g. "/consult how to do X?" from command XML tags)
-                        let semantic_input = preview_text.clone();
-                        let effective_preview =
-                            if let Some(skill_preview) = extract_skill_preview(&preview_text) {
-                                skill_preview
-                            } else if !preview_text.is_empty()
-                                && is_clear_metadata_message(&preview_text)
-                            {
-                                if !search_text.is_empty() {
-                                    all_parts.push(search_text);
-                                }
-                                continue;
-                            } else {
-                                preview_text
-                            };
-
-                        let has_search_text = !search_text.is_empty();
-                        if has_search_text {
-                            all_parts.push(search_text);
-                        }
-
-                        // Check if this is a warmup message (first user message is "Warmup")
-                        let is_warmup =
-                            !seen_real_user_message && effective_preview.trim() == "Warmup";
-                        if is_warmup {
-                            skip_next_assistant = true;
-                        } else if !effective_preview.is_empty() || has_search_text {
-                            message_count += 1;
-                            let message_range = MessageRange::single(message_count);
-                            if !effective_preview.is_empty() {
-                                if let Some(turn) =
-                                    filter_turn(SemanticTurnRole::User, &semantic_input)
-                                {
-                                    semantic_turns.push(turn);
-                                    semantic_turn_ranges.push(message_range);
-                                }
-                                preview_parts.push(effective_preview);
-                                seen_real_user_message = true;
-                            }
-                        }
-                    }
-                    LogEntry::Assistant {
-                        message, timestamp, ..
-                    } => {
-                        let assistant_message_id = message.id.clone();
-                        let canonical_ordinal = assistant_message_id
-                            .as_ref()
-                            .and_then(|id| assistant_id_ordinals.get(id).copied())
-                            .unwrap_or(message_count + 1);
-                        // Track timestamps for conversation duration
-                        if let Some(ref ts_str) = timestamp
-                            && let Ok(ts) = chrono::DateTime::parse_from_rfc3339(ts_str)
-                        {
-                            if first_timestamp.is_none() {
-                                first_timestamp = Some(ts);
-                            }
-                            last_timestamp = Some(ts);
-                        }
-
-                        // Extract model name from first assistant message that has it
-                        if extracted_model.is_none()
-                            && let Some(model) = &message.model
-                        {
-                            extracted_model = Some(model.clone());
-                        }
-
-                        // Track token usage by message ID to avoid double-counting
-                        // Multiple JSONL entries can exist for the same message (streaming)
-                        if let Some(usage) = &message.usage {
-                            if let Some(msg_id) = &message.id {
-                                // Store/update usage for this message ID (last one wins)
-                                token_usage_by_msg.insert(msg_id.clone(), usage.clone());
-                            } else {
-                                // No message ID - accumulate directly (legacy format)
-                                anonymous_token_count += usage.input_tokens
-                                    + usage.output_tokens
-                                    + usage.cache_creation_input_tokens
-                                    + usage.cache_read_input_tokens;
-                            }
-                        }
-
-                        let preview_text = extract_text_from_assistant(&message);
-                        let search_text = extract_search_text_from_assistant(&message);
-
-                        if !search_text.is_empty() {
-                            all_parts.push(search_text);
-                        }
-
-                        // Skip this assistant message if it follows a warmup user message
-                        if skip_next_assistant {
-                            skip_next_assistant = false;
-                        } else if seen_real_user_message
-                            && content_blocks_count_as_agent_message(&message.content)
-                        {
-                            if canonical_ordinal == message_count + 1 {
-                                message_count += 1;
-                            }
-                            let message_range = MessageRange::single(canonical_ordinal);
-                            let semantic_turn =
-                                filter_turn(SemanticTurnRole::Assistant, &preview_text);
-                            if let Some(id) = assistant_message_id.as_ref() {
-                                if let Some(existing_index) =
-                                    assistant_id_semantic_indices.get(id).copied()
-                                {
-                                    if let Some(turn) = semantic_turn {
-                                        semantic_turns[existing_index] = turn;
-                                        semantic_turn_ranges[existing_index] = message_range;
-                                    } else {
-                                        semantic_turns[existing_index].clear();
-                                    }
-                                } else if let Some(turn) = semantic_turn {
-                                    assistant_id_semantic_indices
-                                        .insert(id.clone(), semantic_turns.len());
-                                    semantic_turns.push(turn);
-                                    semantic_turn_ranges.push(message_range);
-                                }
-
-                                if !preview_text.is_empty() {
-                                    if let Some(existing_index) =
-                                        assistant_id_preview_indices.get(id).copied()
-                                    {
-                                        preview_parts[existing_index] = preview_text;
-                                    } else {
-                                        assistant_id_preview_indices
-                                            .insert(id.clone(), preview_parts.len());
-                                        preview_parts.push(preview_text);
-                                    }
-                                }
-                                assistant_id_ordinals.insert(id.clone(), canonical_ordinal);
-                            } else if !preview_text.is_empty() {
-                                if let Some(turn) = semantic_turn {
-                                    semantic_turns.push(turn);
-                                    semantic_turn_ranges.push(message_range);
-                                }
-                                preview_parts.push(preview_text);
-                            }
-                        }
-                    }
-                    LogEntry::Summary { summary } => {
-                        if extracted_summary.is_none() {
-                            extracted_summary = Some(summary.clone());
-                        }
-                    }
-                    LogEntry::AiTitle { ai_title } => {
-                        let trimmed = ai_title.trim();
-                        if !trimmed.is_empty() {
-                            extracted_summary = Some(trimmed.to_owned());
-                        }
-                    }
-                    LogEntry::CustomTitle { custom_title } => {
-                        let trimmed = custom_title.trim();
-                        extracted_custom_title = if trimmed.is_empty() {
-                            None
-                        } else {
-                            Some(trimmed.to_owned())
-                        };
-                    }
-                    LogEntry::PiMetadata {
-                        label,
-                        text,
-                        searchable,
-                        usage,
-                        ..
-                    } => {
-                        if let Some(usage) = usage {
-                            anonymous_token_count += usage.input_tokens
-                                + usage.output_tokens
-                                + usage.cache_creation_input_tokens
-                                + usage.cache_read_input_tokens;
-                        }
-                        if label == "Model" && !text.is_empty() {
-                            extracted_model = Some(text.clone());
-                        }
-                        if searchable && !text.is_empty() {
-                            all_parts.push(text.clone());
-                            message_count += 1;
-                            if let Some(turn) = filter_turn(SemanticTurnRole::User, &text) {
-                                semantic_turns.push(turn);
-                                semantic_turn_ranges.push(MessageRange::single(message_count));
-                            }
-                        }
-                    }
-                    LogEntry::Progress { data, .. } => {
-                        if let Some(progress) = parse_agent_progress(&data)
-                            && matches!(
-                                progress.message.message_type.as_str(),
-                                "user" | "assistant"
-                            )
-                        {
-                            let AgentContent::Blocks(blocks) = progress.message.message.content;
-                            if content_blocks_count_as_agent_message(&blocks) {
-                                message_count += 1;
-                            }
-                            let role = match progress.message.message_type.as_str() {
-                                "user" => AgentMessageRole::User,
-                                "assistant" => AgentMessageRole::Assistant,
-                                _ => unreachable!("progress message type was checked above"),
-                            };
-                            let agent_search_text = agent_search_text_from_blocks(role, &blocks);
-                            if !agent_search_text.is_empty() {
-                                agent_search_parts.push(agent_search_text);
-                            }
-                        }
-                    }
-                    LogEntry::AgentName { .. } => {}
-                    LogEntry::System { .. } => {}
-                    _ => {}
+                    debug::warn(
+                        debug_level,
+                        &format!(
+                            "Parse error in {} at line {}: {}",
+                            filename,
+                            line_idx + 1,
+                            error
+                        ),
+                    );
                 }
-            }
-            Err(e) => {
-                // Capture parse error with surrounding context from the sliding window
-                parse_errors.push(ParseError {
-                    line_number: line_idx + 1, // 1-indexed for display
-                    line_content: line.clone(),
-                    error_message: e.to_string(),
-                    context_before: context_before.iter().cloned().collect(),
-                    context_after: context_window.iter().cloned().collect(),
-                });
-
-                debug::warn(
-                    debug_level,
-                    &format!(
-                        "Parse error in {} at line {}: {}",
-                        filename,
-                        line_idx + 1,
-                        e
-                    ),
-                );
             }
         }
 
@@ -479,132 +620,12 @@ pub fn process_conversation_reader<R: BufRead>(
         line_idx += 1;
     }
 
-    // Check if this is a clear-only conversation or if preview is empty after filtering
-    if is_clear_only_conversation(&user_messages) {
-        debug::debug(
-            debug_level,
-            &format!("Filtered {}: clear-only conversation", filename),
-        );
-        return Ok(None);
-    }
-
-    if all_parts.is_empty() || preview_parts.is_empty() {
-        debug::debug(
-            debug_level,
-            &format!(
-                "Filtered {}: empty conversation (all_parts={}, preview_parts={})",
-                filename,
-                all_parts.len(),
-                preview_parts.len()
-            ),
-        );
-        return Ok(None);
-    }
-
     // Use file modification time, falling back to current time if unavailable
     let timestamp = modified
         .map(DateTime::<Local>::from)
         .unwrap_or_else(Local::now);
 
-    // Create both preview variants (first and last 3 messages)
-    // Skip leading assistant messages by using preview_parts instead of all_parts
-    let preview_first = preview_parts
-        .iter()
-        .take(3)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(" ... ");
-    let preview_last = preview_parts
-        .iter()
-        .rev()
-        .take(3)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(" ... ");
-
-    // Create full text for searching (all messages + summary + custom title)
-    let mut full_text = all_parts.join(" ");
-    if let Some(ref summary) = extracted_summary {
-        full_text = format!("{} {}", summary, full_text);
-    }
-    if let Some(ref custom_title) = extracted_custom_title {
-        full_text = format!("{} {}", custom_title, full_text);
-    }
-
-    // Normalize whitespace
-    let preview_first = normalize_whitespace(&preview_first);
-    let preview_last = normalize_whitespace(&preview_last);
-    let full_text = normalize_whitespace(&full_text);
-    let agent_search_text = normalize_whitespace(&agent_search_parts.join(" "));
-    let semantic_route_text = super::semantic_route_text(&full_text, &agent_search_text);
-
-    // Pre-normalize search text to avoid re-normalizing on every startup
-    let search_text_lower = normalize_for_search(&full_text);
-
-    let semantic_pairs = semantic_turns
-        .into_iter()
-        .zip(semantic_turn_ranges)
-        .filter(|(turn, _)| !turn.is_empty())
-        .collect::<Vec<_>>();
-    let (semantic_turns, semantic_turn_ranges): (Vec<_>, Vec<_>) =
-        semantic_pairs.into_iter().unzip();
-
-    // Sum token usage from deduplicated messages (all token types)
-    let total_tokens: u64 = token_usage_by_msg
-        .values()
-        .map(|u| {
-            u.input_tokens
-                + u.output_tokens
-                + u.cache_creation_input_tokens
-                + u.cache_read_input_tokens
-        })
-        .sum::<u64>()
-        + anonymous_token_count;
-
-    // Calculate conversation duration in minutes
-    let duration_minutes = match (first_timestamp, last_timestamp) {
-        (Some(first), Some(last)) => {
-            let duration = last.signed_duration_since(first);
-            let minutes = duration.num_minutes();
-            if minutes > 0 {
-                Some(minutes as u64)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    };
-
-    Ok(Some(Conversation {
-        source: super::Source::Claude,
-        session_id: path
-            .file_stem()
-            .and_then(|name| name.to_str())
-            .unwrap_or_default()
-            .to_owned(),
-        path,
-        index: 0,
-        timestamp,
-        preview: preview_first.clone(),
-        preview_first,
-        preview_last,
-        full_text,
-        agent_search_text,
-        semantic_route_text,
-        semantic_turns,
-        semantic_turn_ranges,
-        search_text_lower,
-        project_name: None,
-        project_path: None,
-        cwd: extracted_cwd,
-        message_count,
-        parse_errors,
-        summary: extracted_summary,
-        custom_title: extracted_custom_title,
-        model: extracted_model,
-        total_tokens,
-        duration_minutes,
-    }))
+    Ok(builder.finish(path, timestamp, debug_level))
 }
 
 /// Detects metadata emitted by the /clear command wrapper messages and
@@ -934,6 +955,24 @@ mod tests {
         assert_eq!(error.context_before.len(), 1);
         // Context after should have line 3
         assert_eq!(error.context_after.len(), 1);
+    }
+
+    #[test]
+    fn parse_error_line_numbers_survive_a_skipped_metadata_message() {
+        let content = [
+            user_msg("<local-command-stdout>ok</local-command-stdout>", None),
+            user_msg("Line 2", None),
+            "invalid json here".to_string(),
+            assistant_msg("Response"),
+        ]
+        .join("\n");
+
+        let conv = parse_jsonl(&content).unwrap().unwrap();
+        assert_eq!(conv.parse_errors.len(), 1);
+        assert_eq!(
+            conv.parse_errors[0].line_number, 3,
+            "a message filtered out of the preview still occupies its line"
+        );
     }
 
     #[test]

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -1,19 +1,13 @@
 use super::parser::process_conversation_file;
+use super::provider::SessionRoot;
 use super::{Conversation, Source, format_short_name_from_path};
 use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::{AppError, Result};
 use serde_json::Value;
-use std::fs::read_dir;
 use std::path::{Path, PathBuf};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PiSessionRoot {
-    pub path: PathBuf,
-    pub flat: bool,
-}
-
-pub fn session_root() -> Result<PiSessionRoot> {
+pub fn session_root() -> Result<SessionRoot> {
     session_root_from(
         std::env::var_os("PI_CODING_AGENT_DIR").map(PathBuf::from),
         std::env::var_os("PI_CODING_AGENT_SESSION_DIR").map(PathBuf::from),
@@ -27,7 +21,7 @@ fn session_root_from(
     session_override: Option<PathBuf>,
     home_dir: Option<PathBuf>,
     cwd: Option<PathBuf>,
-) -> Result<PiSessionRoot> {
+) -> Result<SessionRoot> {
     let agent_dir = if let Some(value) = agent_override {
         expand_path_with_home(value, home_dir.as_deref())?
     } else {
@@ -44,10 +38,10 @@ fn session_root_from(
     };
 
     if let Some(value) = session_override {
-        return Ok(PiSessionRoot {
-            path: expand_path_with_home(value, home_dir.as_deref())?,
-            flat: true,
-        });
+        return Ok(SessionRoot::flat(expand_path_with_home(
+            value,
+            home_dir.as_deref(),
+        )?));
     }
 
     let global_setting = configured_session_dir(&agent_dir.join("settings.json"));
@@ -55,16 +49,13 @@ fn session_root_from(
         .as_deref()
         .and_then(|cwd| configured_session_dir(&cwd.join(".pi/settings.json")));
     if let Some(Some(value)) = project_setting.or(global_setting) {
-        return Ok(PiSessionRoot {
-            path: expand_path_with_home(value, home_dir.as_deref())?,
-            flat: true,
-        });
+        return Ok(SessionRoot::flat(expand_path_with_home(
+            value,
+            home_dir.as_deref(),
+        )?));
     }
 
-    Ok(PiSessionRoot {
-        path: agent_dir.join("sessions"),
-        flat: false,
-    })
+    Ok(SessionRoot::child_directories(agent_dir.join("sessions")))
 }
 
 fn configured_session_dir(path: &Path) -> Option<Option<PathBuf>> {
@@ -100,43 +91,12 @@ fn expand_path_with_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathB
     })
 }
 
-pub fn discover_files(root: &PiSessionRoot) -> Result<Vec<PathBuf>> {
-    if !root.path.exists() {
-        return Ok(Vec::new());
-    }
-    let mut files = Vec::new();
-    if root.flat {
-        collect_jsonl(&root.path, &mut files)?;
-    } else {
-        for entry in read_dir(&root.path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.is_dir() {
-                collect_jsonl(&path, &mut files)?;
-            }
-        }
-    }
-    files.sort();
-    Ok(files)
-}
-
-fn collect_jsonl(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in read_dir(directory)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
 pub fn load_pi_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
     let root = session_root()?;
-    let files = discover_files(&root)?;
+    let files = root.discover_files()?;
     let cached = super::cache::read_pi_cache(&root.path).unwrap_or_default();
     let mut updated_cache = std::collections::HashMap::new();
     let mut conversations = Vec::new();
@@ -249,8 +209,10 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(settings.path, home.path().join("settings-sessions"));
-        assert!(settings.flat);
+        assert_eq!(
+            settings,
+            SessionRoot::flat(home.path().join("settings-sessions"))
+        );
 
         let project = home.path().join("project");
         std::fs::create_dir_all(project.join(".pi")).unwrap();
@@ -267,10 +229,9 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            project_settings.path,
-            std::env::current_dir().unwrap().join("project-sessions")
+            project_settings,
+            SessionRoot::flat(std::env::current_dir().unwrap().join("project-sessions"))
         );
-        assert!(project_settings.flat);
 
         let environment = session_root_from(
             Some(agent),
@@ -279,8 +240,10 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(environment.path, home.path().join("environment-sessions"));
-        assert!(environment.flat);
+        assert_eq!(
+            environment,
+            SessionRoot::flat(home.path().join("environment-sessions"))
+        );
     }
 
     #[test]
@@ -296,11 +259,9 @@ mod tests {
         .unwrap();
         std::fs::write(project.join("not-pi.jsonl"), "{\"type\":\"user\"}\n").unwrap();
 
-        let nested_files = discover_files(&PiSessionRoot {
-            path: nested,
-            flat: false,
-        })
-        .unwrap();
+        let nested_files = SessionRoot::child_directories(nested)
+            .discover_files()
+            .unwrap();
         assert_eq!(nested_files.len(), 2);
         assert!(
             crate::history::pi::is_pi_file(&nested_files[0])
@@ -314,15 +275,7 @@ mod tests {
             flat.join("flat.jsonl"),
         )
         .unwrap();
-        assert_eq!(
-            discover_files(&PiSessionRoot {
-                path: flat,
-                flat: true,
-            })
-            .unwrap()
-            .len(),
-            1
-        );
+        assert_eq!(SessionRoot::flat(flat).discover_files().unwrap().len(), 1);
     }
 
     #[test]
@@ -340,31 +293,5 @@ mod tests {
         delete_session(&session).unwrap();
         assert!(!session.exists());
         assert!(sibling.exists());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn nested_discovery_follows_symlinked_project_directories() {
-        use std::os::unix::fs::symlink;
-
-        let directory = tempfile::tempdir().unwrap();
-        let target = directory.path().join("target");
-        let root = directory.path().join("sessions");
-        std::fs::create_dir_all(&target).unwrap();
-        std::fs::create_dir_all(&root).unwrap();
-        std::fs::copy(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pi/v3-branched.jsonl"),
-            target.join("session.jsonl"),
-        )
-        .unwrap();
-        symlink(&target, root.join("--linked--")).unwrap();
-
-        let files = discover_files(&PiSessionRoot {
-            path: root,
-            flat: false,
-        })
-        .unwrap();
-        assert_eq!(files.len(), 1);
-        assert!(crate::history::pi::is_pi_file(&files[0]));
     }
 }

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -101,7 +101,7 @@ pub fn load_pi_conversations(
 
 pub fn delete_session(path: &Path) -> Result<()> {
     if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-        || !super::pi::is_pi_file(path)
+        || !super::format::owns_transcript(Source::Pi, path)
     {
         return Err(AppError::SessionNotFound(path.display().to_string()));
     }
@@ -186,8 +186,8 @@ mod tests {
             .unwrap();
         assert_eq!(nested_files.len(), 2);
         assert!(
-            crate::history::pi::is_pi_file(&nested_files[0])
-                || crate::history::pi::is_pi_file(&nested_files[1])
+            crate::history::format::owns_transcript(Source::Pi, &nested_files[0])
+                || crate::history::format::owns_transcript(Source::Pi, &nested_files[1])
         );
 
         let flat = directory.path().join("flat");

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -97,7 +97,7 @@ pub fn load_pi_conversations(
 ) -> Result<Vec<Conversation>> {
     let root = session_root()?;
     let files = root.discover_files()?;
-    let cached = super::cache::read_pi_cache(&root.path).unwrap_or_default();
+    let cached = super::cache::read_session_cache(Source::Pi, &root.path).unwrap_or_default();
     let mut updated_cache = std::collections::HashMap::new();
     let mut conversations = Vec::new();
     for path in files {
@@ -156,7 +156,7 @@ pub fn load_pi_conversations(
         if let Some(mtime) = modified {
             updated_cache.insert(
                 cache_key,
-                super::cache::PiCacheEntry {
+                super::cache::SessionCacheEntry {
                     metadata: super::cache::entry_from_conversation(
                         &conversation,
                         metadata.len(),
@@ -169,7 +169,7 @@ pub fn load_pi_conversations(
         }
         conversations.push(conversation);
     }
-    super::cache::write_pi_cache(&root.path, updated_cache);
+    super::cache::write_session_cache(Source::Pi, &root.path, updated_cache);
     conversations.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
     for (index, conversation) in conversations.iter_mut().enumerate() {
         conversation.index = index;

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -99,16 +99,6 @@ pub fn load_pi_conversations(
     provider::load_sessions(Source::Pi, storage, show_last, debug_level)
 }
 
-pub fn delete_session(path: &Path) -> Result<()> {
-    if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-        || !super::format::owns_transcript(Source::Pi, path)
-    {
-        return Err(AppError::SessionNotFound(path.display().to_string()));
-    }
-    std::fs::remove_file(path)?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,22 +188,5 @@ mod tests {
         )
         .unwrap();
         assert_eq!(SessionRoot::flat(flat).discover_files().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn delete_removes_only_the_valid_pi_jsonl() {
-        let directory = tempfile::tempdir().unwrap();
-        let session = directory.path().join("session.jsonl");
-        std::fs::copy(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pi/v1.jsonl"),
-            &session,
-        )
-        .unwrap();
-        let sibling = directory.path().join("sibling.txt");
-        std::fs::write(&sibling, "keep").unwrap();
-
-        delete_session(&session).unwrap();
-        assert!(!session.exists());
-        assert!(sibling.exists());
     }
 }

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -12,12 +12,17 @@ pub fn session_root() -> Result<SessionRoot> {
     )
 }
 
+/// Resolve Pi's session root, and record whether it is Pi's own tree.
+///
+/// A root the user redirected Pi to can hold another Pi-family agent's
+/// transcripts, so only the default location is marked as Pi's own.
 fn session_root_from(
     agent_override: Option<PathBuf>,
     session_override: Option<PathBuf>,
     home_dir: Option<PathBuf>,
     cwd: Option<PathBuf>,
 ) -> Result<SessionRoot> {
+    let redirected_agent_dir = agent_override.is_some();
     let agent_dir = if let Some(value) = agent_override {
         expand_path_with_home(value, home_dir.as_deref())?
     } else {
@@ -51,7 +56,12 @@ fn session_root_from(
         )?));
     }
 
-    Ok(SessionRoot::child_directories(agent_dir.join("sessions")))
+    let sessions = SessionRoot::child_directories(agent_dir.join("sessions"));
+    Ok(if redirected_agent_dir {
+        sessions
+    } else {
+        sessions.in_agent_tree()
+    })
 }
 
 fn configured_session_dir(path: &Path) -> Option<Option<PathBuf>> {
@@ -165,8 +175,12 @@ mod tests {
             .unwrap();
         assert_eq!(nested_files.len(), 2);
         assert!(
-            crate::history::format::owns_transcript(Source::Pi, &nested_files[0])
-                || crate::history::format::owns_transcript(Source::Pi, &nested_files[1])
+            nested_files.iter().any(|path| {
+                crate::history::format::parse_owned_transcript(Source::Pi, path)
+                    .unwrap()
+                    .is_some()
+            }),
+            "the Pi transcript written into the project directory was not discovered"
         );
 
         let flat = directory.path().join("flat");

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -1,6 +1,4 @@
-use super::provider::{self, SessionRoot};
-use super::{Conversation, Source};
-use crate::cli::DebugLevel;
+use super::provider::SessionRoot;
 use crate::error::{AppError, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
@@ -89,19 +87,10 @@ fn expand_path_with_home(path: PathBuf, home_dir: Option<&Path>) -> Result<PathB
     })
 }
 
-pub fn load_pi_conversations(
-    show_last: bool,
-    debug_level: Option<DebugLevel>,
-) -> Result<Vec<Conversation>> {
-    let Some(storage) = Source::Pi.provider().storage() else {
-        return Ok(Vec::new());
-    };
-    provider::load_sessions(Source::Pi, storage, show_last, debug_level)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::history::Source;
 
     #[test]
     fn session_directory_precedence_matches_pi() {

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -1,8 +1,6 @@
-use super::parser::process_conversation_file;
-use super::provider::SessionRoot;
-use super::{Conversation, Source, format_short_name_from_path};
+use super::provider::{self, SessionRoot};
+use super::{Conversation, Source};
 use crate::cli::DebugLevel;
-use crate::debug;
 use crate::error::{AppError, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
@@ -95,86 +93,10 @@ pub fn load_pi_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let root = session_root()?;
-    let files = root.discover_files()?;
-    let cached = super::cache::read_session_cache(Source::Pi, &root.path).unwrap_or_default();
-    let mut updated_cache = std::collections::HashMap::new();
-    let mut conversations = Vec::new();
-    for path in files {
-        let Ok(metadata) = std::fs::metadata(&path) else {
-            continue;
-        };
-        let modified = metadata.modified().ok();
-        let cache_key = path
-            .strip_prefix(&root.path)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .into_owned();
-        let mut conversation = modified
-            .and_then(|mtime| {
-                cached.get(&cache_key).filter(|entry| {
-                    super::cache::entry_matches(&entry.metadata, metadata.len(), mtime)
-                })
-            })
-            .map(|entry| {
-                let mut conversation =
-                    super::cache::conversation_from_entry(&entry.metadata, path.clone(), show_last);
-                conversation.source = Source::Pi;
-                conversation.session_id = entry.session_id.clone();
-                conversation.cwd = Some(entry.project_path.clone());
-                conversation.project_path = Some(entry.project_path.clone());
-                conversation.project_name = Some(format_short_name_from_path(&entry.project_path));
-                conversation
-            });
-        if conversation.is_none() {
-            conversation = match process_conversation_file(path.clone(), modified, debug_level) {
-                Ok(Some(conversation)) if conversation.source == Source::Pi => Some(conversation),
-                Ok(_) => None,
-                Err(error) => {
-                    debug::warn(
-                        debug_level,
-                        &format!("Failed to parse Pi session {}: {error}", path.display()),
-                    );
-                    None
-                }
-            };
-        }
-        let Some(mut conversation) = conversation else {
-            continue;
-        };
-        conversation.preview = if show_last {
-            conversation.preview_last.clone()
-        } else {
-            conversation.preview_first.clone()
-        };
-        let project_path = conversation
-            .cwd
-            .clone()
-            .unwrap_or_else(|| PathBuf::from("unknown"));
-        conversation.project_name = Some(format_short_name_from_path(&project_path));
-        conversation.project_path = Some(project_path.clone());
-        if let Some(mtime) = modified {
-            updated_cache.insert(
-                cache_key,
-                super::cache::SessionCacheEntry {
-                    metadata: super::cache::entry_from_conversation(
-                        &conversation,
-                        metadata.len(),
-                        mtime,
-                    ),
-                    session_id: conversation.session_id.clone(),
-                    project_path,
-                },
-            );
-        }
-        conversations.push(conversation);
-    }
-    super::cache::write_session_cache(Source::Pi, &root.path, updated_cache);
-    conversations.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
-    for (index, conversation) in conversations.iter_mut().enumerate() {
-        conversation.index = index;
-    }
-    Ok(conversations)
+    let Some(storage) = Source::Pi.provider().storage() else {
+        return Ok(Vec::new());
+    };
+    provider::load_sessions(Source::Pi, storage, show_last, debug_level)
 }
 
 pub fn delete_session(path: &Path) -> Result<()> {

--- a/src/history/pi_loader.rs
+++ b/src/history/pi_loader.rs
@@ -1,9 +1,14 @@
 use super::provider::SessionRoot;
+use super::provider::walk::FileRoot;
 use crate::error::{AppError, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 
-pub fn session_root() -> Result<SessionRoot> {
+/// Resolve Pi's session root together with its walk depth: a redirected
+/// session directory holds transcripts beside itself, the default tree holds
+/// them in a directory per project. Only this resolution knows which is which,
+/// so the pairing is returned rather than guessed from the path later.
+pub fn session_root() -> Result<FileRoot> {
     session_root_from(
         std::env::var_os("PI_CODING_AGENT_DIR").map(PathBuf::from),
         std::env::var_os("PI_CODING_AGENT_SESSION_DIR").map(PathBuf::from),
@@ -12,8 +17,6 @@ pub fn session_root() -> Result<SessionRoot> {
     )
 }
 
-/// Resolve Pi's session root, and record whether it is Pi's own tree.
-///
 /// A root the user redirected Pi to can hold another Pi-family agent's
 /// transcripts, so only the default location is marked as Pi's own.
 fn session_root_from(
@@ -21,7 +24,7 @@ fn session_root_from(
     session_override: Option<PathBuf>,
     home_dir: Option<PathBuf>,
     cwd: Option<PathBuf>,
-) -> Result<SessionRoot> {
+) -> Result<FileRoot> {
     let redirected_agent_dir = agent_override.is_some();
     let agent_dir = if let Some(value) = agent_override {
         expand_path_with_home(value, home_dir.as_deref())?
@@ -39,7 +42,7 @@ fn session_root_from(
     };
 
     if let Some(value) = session_override {
-        return Ok(SessionRoot::flat(expand_path_with_home(
+        return Ok(flat_root(expand_path_with_home(
             value,
             home_dir.as_deref(),
         )?));
@@ -50,18 +53,26 @@ fn session_root_from(
         .as_deref()
         .and_then(|cwd| configured_session_dir(&cwd.join(".pi/settings.json")));
     if let Some(Some(value)) = project_setting.or(global_setting) {
-        return Ok(SessionRoot::flat(expand_path_with_home(
+        return Ok(flat_root(expand_path_with_home(
             value,
             home_dir.as_deref(),
         )?));
     }
 
-    let sessions = SessionRoot::child_directories(agent_dir.join("sessions"));
-    Ok(if redirected_agent_dir {
+    let sessions = SessionRoot::new(agent_dir.join("sessions"));
+    let root = if redirected_agent_dir {
         sessions
     } else {
         sessions.in_agent_tree()
-    })
+    };
+    Ok(FileRoot { root, depth: 1 })
+}
+
+fn flat_root(path: PathBuf) -> FileRoot {
+    FileRoot {
+        root: SessionRoot::new(path),
+        depth: 0,
+    }
 }
 
 fn configured_session_dir(path: &Path) -> Option<Option<PathBuf>> {
@@ -120,10 +131,7 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(
-            settings,
-            SessionRoot::flat(home.path().join("settings-sessions"))
-        );
+        assert_eq!(settings, flat_root(home.path().join("settings-sessions")));
 
         let project = home.path().join("project");
         std::fs::create_dir_all(project.join(".pi")).unwrap();
@@ -141,7 +149,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             project_settings,
-            SessionRoot::flat(std::env::current_dir().unwrap().join("project-sessions"))
+            flat_root(std::env::current_dir().unwrap().join("project-sessions"))
         );
 
         let environment = session_root_from(
@@ -153,7 +161,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             environment,
-            SessionRoot::flat(home.path().join("environment-sessions"))
+            flat_root(home.path().join("environment-sessions"))
         );
     }
 
@@ -170,9 +178,8 @@ mod tests {
         .unwrap();
         std::fs::write(project.join("not-pi.jsonl"), "{\"type\":\"user\"}\n").unwrap();
 
-        let nested_files = SessionRoot::child_directories(nested)
-            .discover_files()
-            .unwrap();
+        let nested_files =
+            crate::history::provider::walk::jsonl_files_at_depth(&nested, 1).unwrap();
         assert_eq!(nested_files.len(), 2);
         assert!(
             nested_files.iter().any(|path| {
@@ -190,6 +197,11 @@ mod tests {
             flat.join("flat.jsonl"),
         )
         .unwrap();
-        assert_eq!(SessionRoot::flat(flat).discover_files().unwrap().len(), 1);
+        assert_eq!(
+            crate::history::provider::walk::jsonl_files_at_depth(&flat, 0)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -39,6 +39,20 @@ impl SessionProvider for ClaudeProvider {
     fn launcher(&self) -> &dyn SessionLauncher {
         &ClaudeLauncher
     }
+
+    fn rename_session(&self, path: &Path, title: &str) -> Result<()> {
+        crate::history::append_session_rename(path, title)
+    }
+
+    /// Claude deletes by session id rather than by path: the same transcript can
+    /// exist under several project directories, and all of its copies go.
+    fn delete_session(&self, path: &Path) -> Result<()> {
+        let session_id = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("");
+        crate::history::delete_session_by_uuid(session_id).map(|_| ())
+    }
 }
 
 struct ClaudeLauncher;

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -2,6 +2,7 @@
 
 use super::{SessionProvider, SessionStorage, SourceLabels};
 use crate::history::Source;
+use crate::history::format::SessionFormat;
 
 pub struct ClaudeProvider;
 
@@ -22,6 +23,13 @@ impl SessionProvider for ClaudeProvider {
     /// is per project, and loading streams project batches to the TUI. None of
     /// that fits [`SessionStorage`], so Claude keeps its own loader.
     fn storage(&self) -> Option<&dyn SessionStorage> {
+        None
+    }
+
+    /// Claude writes [`LogEntry`](crate::claude::LogEntry) records directly, with
+    /// no session header stating an id, start time or cwd. There is nothing to
+    /// project, so a file no other format claims is read as a Claude transcript.
+    fn format(&self) -> Option<&dyn SessionFormat> {
         None
     }
 }

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -1,6 +1,6 @@
 //! Claude Code sessions, stored under `~/.claude/projects/<encoded-cwd>/`.
 
-use super::{SessionProvider, SourceLabels};
+use super::{SessionCache, SessionProvider, SourceLabels};
 use crate::history::Source;
 
 pub struct ClaudeProvider;
@@ -15,5 +15,11 @@ impl SessionProvider for ClaudeProvider {
             name: "claude",
             list: "CC",
         }
+    }
+
+    /// Claude's transcripts are already partitioned by project directory and are
+    /// cached that way, so there is nothing to cache per session root.
+    fn session_cache(&self) -> Option<SessionCache> {
+        None
     }
 }

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -1,6 +1,8 @@
 //! Claude Code sessions, stored under `~/.claude/projects/<encoded-cwd>/`.
 
-use super::{SessionLaunch, SessionLauncher, SessionProvider, SessionStorage, SourceLabels};
+use super::{
+    RefNamespaces, SessionLaunch, SessionLauncher, SessionProvider, SessionStorage, SourceLabels,
+};
 use crate::error::{AppError, Result};
 use crate::history::Source;
 use crate::history::format::SessionFormat;
@@ -18,6 +20,14 @@ impl SessionProvider for ClaudeProvider {
         SourceLabels {
             name: "claude",
             list: "CC",
+            display: "Claude",
+        }
+    }
+
+    fn ref_namespaces(&self) -> RefNamespaces {
+        RefNamespaces {
+            conversation: None,
+            project: "agent-project-v1",
         }
     }
 

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -1,8 +1,11 @@
 //! Claude Code sessions, stored under `~/.claude/projects/<encoded-cwd>/`.
 
-use super::{SessionProvider, SessionStorage, SourceLabels};
+use super::{SessionLaunch, SessionLauncher, SessionProvider, SessionStorage, SourceLabels};
+use crate::error::{AppError, Result};
 use crate::history::Source;
 use crate::history::format::SessionFormat;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub struct ClaudeProvider;
 
@@ -31,5 +34,228 @@ impl SessionProvider for ClaudeProvider {
     /// project, so a file no other format claims is read as a Claude transcript.
     fn format(&self) -> Option<&dyn SessionFormat> {
         None
+    }
+
+    fn launcher(&self) -> &dyn SessionLauncher {
+        &ClaudeLauncher
+    }
+}
+
+struct ClaudeLauncher;
+
+impl SessionLauncher for ClaudeLauncher {
+    fn resume_command(&self, launch: &SessionLaunch) -> Result<Command> {
+        claude_command(launch, false)
+    }
+
+    fn fork_command(&self, launch: &SessionLaunch) -> Result<Command> {
+        claude_command(launch, true)
+    }
+}
+
+/// Claude resumes by conversation id and finds the transcript by the project
+/// directory it runs in, so the command is only half the work: when the session
+/// lives under a project Claude would not look in, its files are copied to one it
+/// would.
+fn claude_command(launch: &SessionLaunch, fork_session: bool) -> Result<Command> {
+    let conversation_id = launch
+        .path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .ok_or_else(|| {
+            AppError::ClaudeExecutionError("Conversation filename is not valid Unicode".to_string())
+        })?
+        .to_owned();
+
+    let cwd = std::env::current_dir().map_err(|error| {
+        AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Failed to get current directory: {error}"),
+        ))
+    })?;
+
+    let conv_projects_dir = conversation_projects_dir(launch.path)?;
+
+    let mut command = Command::new("claude");
+    command.args(["--resume", &conversation_id]);
+    match resolve_resume_action(launch.path, launch.project_path, &cwd, fork_session)? {
+        ResumeAction::CopyToCurrent { cwd_projects_dir } => {
+            std::fs::create_dir_all(&cwd_projects_dir).map_err(AppError::Io)?;
+            copy_session_files(
+                launch.path,
+                &conversation_id,
+                conv_projects_dir,
+                &cwd_projects_dir,
+            )?;
+            command.args(launch.configured_args);
+            command.current_dir(&cwd);
+        }
+        ResumeAction::Run { current_dir } => {
+            if fork_session {
+                command.arg("--fork-session");
+            }
+            command.args(launch.configured_args);
+            command.current_dir(current_dir);
+        }
+    }
+    Ok(command)
+}
+
+fn conversation_projects_dir(selected_path: &Path) -> Result<&Path> {
+    selected_path.parent().ok_or_else(|| {
+        AppError::ClaudeExecutionError(
+            "Cannot determine conversation's project directory".to_string(),
+        )
+    })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ResumeAction {
+    Run { current_dir: PathBuf },
+    CopyToCurrent { cwd_projects_dir: PathBuf },
+}
+
+fn resolve_resume_action(
+    selected_path: &Path,
+    project_path: Option<&Path>,
+    cwd: &Path,
+    fork_session: bool,
+) -> Result<ResumeAction> {
+    let conv_projects_dir = conversation_projects_dir(selected_path)?;
+    let cwd_projects_dir = crate::history::get_claude_projects_dir(cwd)?;
+    let project_dir = project_path.filter(|path| path.exists() && path.is_dir());
+
+    if project_dir.is_none() || (fork_session && cwd_projects_dir != conv_projects_dir) {
+        return Ok(ResumeAction::CopyToCurrent { cwd_projects_dir });
+    }
+
+    if cwd_projects_dir == conv_projects_dir {
+        return Ok(ResumeAction::Run {
+            current_dir: cwd.to_path_buf(),
+        });
+    }
+
+    let project_dir = project_dir.unwrap();
+    let project_projects_dir = crate::history::get_claude_projects_dir(project_dir)?;
+    if project_projects_dir == conv_projects_dir {
+        Ok(ResumeAction::Run {
+            current_dir: project_dir.to_path_buf(),
+        })
+    } else {
+        Ok(ResumeAction::CopyToCurrent { cwd_projects_dir })
+    }
+}
+
+/// Copy a session into another project directory so a cross-project fork can find
+/// it: the transcript, plus the session subdirectory holding tool results and
+/// sub-agent transcripts.
+///
+/// `~/.claude/file-history/<uuid>/` is global rather than per project, and Claude
+/// finds it by session id, so it needs no copy.
+fn copy_session_files(
+    jsonl_path: &Path,
+    session_id: &str,
+    source_projects_dir: &Path,
+    target_projects_dir: &Path,
+) -> Result<()> {
+    let target_jsonl = target_projects_dir.join(jsonl_path.file_name().unwrap());
+    std::fs::copy(jsonl_path, &target_jsonl).map_err(AppError::Io)?;
+
+    let session_dir = source_projects_dir.join(session_id);
+    if session_dir.is_dir() {
+        copy_dir_recursive(&session_dir, &target_projects_dir.join(session_id))?;
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination).map_err(AppError::Io)?;
+    for entry in std::fs::read_dir(source).map_err(AppError::Io)? {
+        let entry = entry.map_err(AppError::Io)?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            std::fs::copy(&source_path, &destination_path).map_err(AppError::Io)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::get_claude_projects_dir;
+
+    fn transcript_in_project_of(directory: &Path) -> PathBuf {
+        get_claude_projects_dir(directory)
+            .unwrap()
+            .join("12345678-1234-4234-9234-123456789abc.jsonl")
+    }
+
+    #[test]
+    fn resume_action_uses_cwd_when_it_maps_to_selected_project_dir() {
+        let cwd = tempfile::tempdir().unwrap();
+        let stale_project = tempfile::tempdir().unwrap();
+
+        let action = resolve_resume_action(
+            &transcript_in_project_of(cwd.path()),
+            Some(stale_project.path()),
+            cwd.path(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            action,
+            ResumeAction::Run {
+                current_dir: cwd.path().to_path_buf()
+            }
+        );
+    }
+
+    #[test]
+    fn resume_action_uses_project_path_when_it_maps_to_selected_project_dir() {
+        let cwd = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+
+        let action = resolve_resume_action(
+            &transcript_in_project_of(project.path()),
+            Some(project.path()),
+            cwd.path(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            action,
+            ResumeAction::Run {
+                current_dir: project.path().to_path_buf()
+            }
+        );
+    }
+
+    #[test]
+    fn resume_action_copies_selected_transcript_when_project_path_maps_elsewhere() {
+        let cwd = tempfile::tempdir().unwrap();
+        let selected_project = tempfile::tempdir().unwrap();
+        let stale_project = tempfile::tempdir().unwrap();
+
+        let action = resolve_resume_action(
+            &transcript_in_project_of(selected_project.path()),
+            Some(stale_project.path()),
+            cwd.path(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            action,
+            ResumeAction::CopyToCurrent {
+                cwd_projects_dir: get_claude_projects_dir(cwd.path()).unwrap()
+            }
+        );
     }
 }

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -1,0 +1,19 @@
+//! Claude Code sessions, stored under `~/.claude/projects/<encoded-cwd>/`.
+
+use super::{SessionProvider, SourceLabels};
+use crate::history::Source;
+
+pub struct ClaudeProvider;
+
+impl SessionProvider for ClaudeProvider {
+    fn source(&self) -> Source {
+        Source::Claude
+    }
+
+    fn labels(&self) -> SourceLabels {
+        SourceLabels {
+            name: "claude",
+            list: "CC",
+        }
+    }
+}

--- a/src/history/provider/claude.rs
+++ b/src/history/provider/claude.rs
@@ -1,6 +1,6 @@
 //! Claude Code sessions, stored under `~/.claude/projects/<encoded-cwd>/`.
 
-use super::{SessionCache, SessionProvider, SourceLabels};
+use super::{SessionProvider, SessionStorage, SourceLabels};
 use crate::history::Source;
 
 pub struct ClaudeProvider;
@@ -17,9 +17,11 @@ impl SessionProvider for ClaudeProvider {
         }
     }
 
-    /// Claude's transcripts are already partitioned by project directory and are
-    /// cached that way, so there is nothing to cache per session root.
-    fn session_cache(&self) -> Option<SessionCache> {
+    /// Claude's transcripts are partitioned by project directory rather than
+    /// gathered under a session root: discovery excludes `agent-*.jsonl`, caching
+    /// is per project, and loading streams project batches to the TUI. None of
+    /// that fits [`SessionStorage`], so Claude keeps its own loader.
+    fn storage(&self) -> Option<&dyn SessionStorage> {
         None
     }
 }

--- a/src/history/provider/discovery.rs
+++ b/src/history/provider/discovery.rs
@@ -1,0 +1,143 @@
+//! Where a provider keeps its session transcripts, and how to enumerate them.
+
+use crate::error::Result;
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
+
+/// How transcripts are arranged beneath a [`SessionRoot`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionLayout {
+    /// Transcripts sit directly in the root, as when the user pins a session
+    /// directory and every project shares it.
+    Flat,
+    /// Transcripts sit one level down, in a directory per project.
+    ChildDirectories,
+}
+
+/// A directory a provider stores sessions under, together with the arrangement
+/// of transcripts inside it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionRoot {
+    pub path: PathBuf,
+    layout: SessionLayout,
+}
+
+impl SessionRoot {
+    pub fn flat(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            layout: SessionLayout::Flat,
+        }
+    }
+
+    pub fn child_directories(path: impl Into<PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            layout: SessionLayout::ChildDirectories,
+        }
+    }
+
+    /// Transcript paths under this root, sorted so successive runs agree.
+    ///
+    /// A root that does not exist yields no files rather than an error: an agent
+    /// the user has not installed is an absence, not a failure.
+    pub fn discover_files(&self) -> Result<Vec<PathBuf>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let mut files = Vec::new();
+        match self.layout {
+            SessionLayout::Flat => collect_transcripts(&self.path, &mut files)?,
+            SessionLayout::ChildDirectories => {
+                for entry in read_dir(&self.path)? {
+                    let path = entry?.path();
+                    // `is_dir` follows symlinks, so a project directory linked
+                    // into the root is still searched.
+                    if path.is_dir() {
+                        collect_transcripts(&path, &mut files)?;
+                    }
+                }
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
+}
+
+fn collect_transcripts(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in read_dir(directory)? {
+        let path = entry?.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_transcript(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "{}\n").unwrap();
+    }
+
+    #[test]
+    fn missing_root_yields_no_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = SessionRoot::flat(directory.path().join("never-created"));
+        assert!(root.discover_files().unwrap().is_empty());
+    }
+
+    #[test]
+    fn flat_layout_takes_only_jsonl_beside_the_root() {
+        let directory = tempfile::tempdir().unwrap();
+        write_transcript(&directory.path().join("session.jsonl"));
+        write_transcript(&directory.path().join("notes.txt"));
+        write_transcript(&directory.path().join("nested/deeper.jsonl"));
+
+        let files = SessionRoot::flat(directory.path())
+            .discover_files()
+            .unwrap();
+        assert_eq!(files, vec![directory.path().join("session.jsonl")]);
+    }
+
+    #[test]
+    fn child_directory_layout_skips_transcripts_in_the_root_itself() {
+        let directory = tempfile::tempdir().unwrap();
+        write_transcript(&directory.path().join("stray.jsonl"));
+        write_transcript(&directory.path().join("project-b/second.jsonl"));
+        write_transcript(&directory.path().join("project-a/first.jsonl"));
+
+        let files = SessionRoot::child_directories(directory.path())
+            .discover_files()
+            .unwrap();
+        assert_eq!(
+            files,
+            vec![
+                directory.path().join("project-a/first.jsonl"),
+                directory.path().join("project-b/second.jsonl"),
+            ],
+            "child directories are searched, the root is not, and results are sorted"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_directory_layout_follows_symlinked_project_directories() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("elsewhere");
+        let root = directory.path().join("sessions");
+        write_transcript(&target.join("session.jsonl"));
+        std::fs::create_dir_all(&root).unwrap();
+        symlink(&target, root.join("linked-project")).unwrap();
+
+        let files = SessionRoot::child_directories(&root)
+            .discover_files()
+            .unwrap();
+        assert_eq!(files, vec![root.join("linked-project/session.jsonl")]);
+    }
+}

--- a/src/history/provider/discovery.rs
+++ b/src/history/provider/discovery.rs
@@ -14,12 +14,34 @@ pub enum SessionLayout {
     ChildDirectories,
 }
 
+/// Where a root came from, which decides whether a transcript in it that names
+/// no agent belongs to the provider that listed the root.
+///
+/// Only the code that resolves a root knows this. It cannot be recovered from
+/// the path afterwards: a home directory can be named after an agent, and a
+/// redirected directory can sit anywhere.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RootOrigin {
+    /// The agent's own installation tree. A transcript here is that agent's even
+    /// when the file itself says nothing about which agent wrote it.
+    AgentTree,
+    /// A directory the user pointed the agent at, through configuration or the
+    /// environment. Pi-family agents share one wire format and can be aimed at
+    /// the same directory, so an unmarked transcript here names no owner.
+    Redirected,
+}
+
 /// A directory a provider stores sessions under, together with the arrangement
 /// of transcripts inside it.
+///
+/// Roots are [`RootOrigin::Redirected`] unless [`SessionRoot::in_agent_tree`]
+/// says otherwise. That default is the cautious one: a provider that does not
+/// declare a root as its own cannot claim transcripts that name no agent.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SessionRoot {
     pub path: PathBuf,
     layout: SessionLayout,
+    origin: RootOrigin,
 }
 
 impl SessionRoot {
@@ -27,6 +49,7 @@ impl SessionRoot {
         Self {
             path: path.into(),
             layout: SessionLayout::Flat,
+            origin: RootOrigin::Redirected,
         }
     }
 
@@ -34,7 +57,22 @@ impl SessionRoot {
         Self {
             path: path.into(),
             layout: SessionLayout::ChildDirectories,
+            origin: RootOrigin::Redirected,
         }
+    }
+
+    /// Mark this root as part of the agent's own tree rather than a directory
+    /// the user redirected it to.
+    #[must_use]
+    pub fn in_agent_tree(self) -> Self {
+        Self {
+            origin: RootOrigin::AgentTree,
+            ..self
+        }
+    }
+
+    pub fn origin(&self) -> RootOrigin {
+        self.origin
     }
 
     /// Transcript paths under this root, sorted so successive runs agree.

--- a/src/history/provider/discovery.rs
+++ b/src/history/provider/discovery.rs
@@ -1,18 +1,6 @@
-//! Where a provider keeps its session transcripts, and how to enumerate them.
+//! Where a provider keeps its sessions.
 
-use crate::error::Result;
-use std::fs::read_dir;
-use std::path::{Path, PathBuf};
-
-/// How transcripts are arranged beneath a [`SessionRoot`].
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SessionLayout {
-    /// Transcripts sit directly in the root, as when the user pins a session
-    /// directory and every project shares it.
-    Flat,
-    /// Transcripts sit one level down, in a directory per project.
-    ChildDirectories,
-}
+use std::path::PathBuf;
 
 /// Where a root came from, which decides whether a transcript in it that names
 /// no agent belongs to the provider that listed the root.
@@ -31,8 +19,11 @@ pub enum RootOrigin {
     Redirected,
 }
 
-/// A directory a provider stores sessions under, together with the arrangement
-/// of transcripts inside it.
+/// One place a provider stores sessions — a directory tree for file-backed
+/// providers, but any container a provider can enumerate: each root carries its
+/// own session cache, keyed by `path`. How sessions are found inside it is the
+/// provider's own knowledge, stated in its
+/// [`discover`](super::SessionStorage::discover).
 ///
 /// Roots are [`RootOrigin::Redirected`] unless [`SessionRoot::in_agent_tree`]
 /// says otherwise. That default is the cautious one: a provider that does not
@@ -40,23 +31,13 @@ pub enum RootOrigin {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SessionRoot {
     pub path: PathBuf,
-    layout: SessionLayout,
     origin: RootOrigin,
 }
 
 impl SessionRoot {
-    pub fn flat(path: impl Into<PathBuf>) -> Self {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
         Self {
             path: path.into(),
-            layout: SessionLayout::Flat,
-            origin: RootOrigin::Redirected,
-        }
-    }
-
-    pub fn child_directories(path: impl Into<PathBuf>) -> Self {
-        Self {
-            path: path.into(),
-            layout: SessionLayout::ChildDirectories,
             origin: RootOrigin::Redirected,
         }
     }
@@ -73,109 +54,5 @@ impl SessionRoot {
 
     pub fn origin(&self) -> RootOrigin {
         self.origin
-    }
-
-    /// Transcript paths under this root, sorted so successive runs agree.
-    ///
-    /// A root that does not exist yields no files rather than an error: an agent
-    /// the user has not installed is an absence, not a failure.
-    pub fn discover_files(&self) -> Result<Vec<PathBuf>> {
-        if !self.path.exists() {
-            return Ok(Vec::new());
-        }
-        let mut files = Vec::new();
-        match self.layout {
-            SessionLayout::Flat => collect_transcripts(&self.path, &mut files)?,
-            SessionLayout::ChildDirectories => {
-                for entry in read_dir(&self.path)? {
-                    let path = entry?.path();
-                    // `is_dir` follows symlinks, so a project directory linked
-                    // into the root is still searched.
-                    if path.is_dir() {
-                        collect_transcripts(&path, &mut files)?;
-                    }
-                }
-            }
-        }
-        files.sort();
-        Ok(files)
-    }
-}
-
-fn collect_transcripts(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in read_dir(directory)? {
-        let path = entry?.path();
-        if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn write_transcript(path: &Path) {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(path, "{}\n").unwrap();
-    }
-
-    #[test]
-    fn missing_root_yields_no_files() {
-        let directory = tempfile::tempdir().unwrap();
-        let root = SessionRoot::flat(directory.path().join("never-created"));
-        assert!(root.discover_files().unwrap().is_empty());
-    }
-
-    #[test]
-    fn flat_layout_takes_only_jsonl_beside_the_root() {
-        let directory = tempfile::tempdir().unwrap();
-        write_transcript(&directory.path().join("session.jsonl"));
-        write_transcript(&directory.path().join("notes.txt"));
-        write_transcript(&directory.path().join("nested/deeper.jsonl"));
-
-        let files = SessionRoot::flat(directory.path())
-            .discover_files()
-            .unwrap();
-        assert_eq!(files, vec![directory.path().join("session.jsonl")]);
-    }
-
-    #[test]
-    fn child_directory_layout_skips_transcripts_in_the_root_itself() {
-        let directory = tempfile::tempdir().unwrap();
-        write_transcript(&directory.path().join("stray.jsonl"));
-        write_transcript(&directory.path().join("project-b/second.jsonl"));
-        write_transcript(&directory.path().join("project-a/first.jsonl"));
-
-        let files = SessionRoot::child_directories(directory.path())
-            .discover_files()
-            .unwrap();
-        assert_eq!(
-            files,
-            vec![
-                directory.path().join("project-a/first.jsonl"),
-                directory.path().join("project-b/second.jsonl"),
-            ],
-            "child directories are searched, the root is not, and results are sorted"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn child_directory_layout_follows_symlinked_project_directories() {
-        use std::os::unix::fs::symlink;
-
-        let directory = tempfile::tempdir().unwrap();
-        let target = directory.path().join("elsewhere");
-        let root = directory.path().join("sessions");
-        write_transcript(&target.join("session.jsonl"));
-        std::fs::create_dir_all(&root).unwrap();
-        symlink(&target, root.join("linked-project")).unwrap();
-
-        let files = SessionRoot::child_directories(&root)
-            .discover_files()
-            .unwrap();
-        assert_eq!(files, vec![root.join("linked-project/session.jsonl")]);
     }
 }

--- a/src/history/provider/launcher.rs
+++ b/src/history/provider/launcher.rs
@@ -1,0 +1,113 @@
+//! Starting an agent on a session the browser selected.
+
+use crate::error::Result;
+use std::path::Path;
+use std::process::Command;
+
+/// What a launcher needs in order to hand a session back to its agent.
+pub struct SessionLaunch<'a> {
+    pub path: &'a Path,
+    /// The directory the session ran in, when it still exists.
+    pub project_path: Option<&'a Path>,
+    /// Extra arguments from `[resume].default_args`, documented as arguments for
+    /// the `claude` CLI. Only Claude's launcher appends them; the others would be
+    /// passing Claude flags to a different program.
+    pub configured_args: &'a [String],
+}
+
+/// Builds the command that resumes a session. Building it can have effects of its
+/// own — Claude copies a transcript into the current project when it has to — so a
+/// launcher returns a command to run rather than running one.
+pub trait SessionLauncher: Sync {
+    fn resume_command(&self, launch: &SessionLaunch) -> Result<Command>;
+
+    /// Resume `launch` as a new session branching from the original.
+    fn fork_command(&self, launch: &SessionLaunch) -> Result<Command>;
+}
+
+/// An agent that takes the transcript path on its command line.
+pub struct PathResumeLauncher {
+    pub program: &'static str,
+    pub resume_flag: &'static str,
+    pub fork_flag: &'static str,
+}
+
+impl SessionLauncher for PathResumeLauncher {
+    fn resume_command(&self, launch: &SessionLaunch) -> Result<Command> {
+        let mut command = Command::new(self.program);
+        command.arg(self.resume_flag).arg(launch.path);
+        if let Some(project_path) = launch.project_path {
+            command.current_dir(project_path);
+        }
+        Ok(command)
+    }
+
+    /// A fork runs where the user is now, not where the original session ran: the
+    /// branch belongs to the current project.
+    fn fork_command(&self, launch: &SessionLaunch) -> Result<Command> {
+        let mut command = Command::new(self.program);
+        command.arg(self.fork_flag).arg(launch.path);
+        Ok(command)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::Source;
+    use std::ffi::OsStr;
+    use std::path::PathBuf;
+
+    fn launch<'a>(
+        path: &'a Path,
+        project_path: &'a Path,
+        configured_args: &'a [String],
+    ) -> SessionLaunch<'a> {
+        SessionLaunch {
+            path,
+            project_path: Some(project_path),
+            configured_args,
+        }
+    }
+
+    fn arguments(command: &Command) -> Vec<&OsStr> {
+        command.get_args().collect()
+    }
+
+    #[test]
+    fn path_resuming_agents_are_invoked_with_the_transcript_path() {
+        let path = PathBuf::from("/tmp/session.jsonl");
+        let project = PathBuf::from("/tmp/project");
+        let claude_args = ["--dangerously-skip-permissions".to_owned()];
+
+        for (source, program, resume_flag) in [
+            (Source::Pi, "pi", "--session"),
+            (Source::Omp, "omp", "--resume"),
+        ] {
+            let launcher = source.provider().launcher();
+            let resume = launcher
+                .resume_command(&launch(&path, &project, &claude_args))
+                .unwrap();
+            assert_eq!(resume.get_program(), OsStr::new(program));
+            assert_eq!(
+                arguments(&resume),
+                vec![OsStr::new(resume_flag), path.as_os_str()],
+                "{program} resume must not inherit Claude's configured arguments"
+            );
+            assert_eq!(resume.get_current_dir(), Some(project.as_path()));
+
+            let fork = launcher
+                .fork_command(&launch(&path, &project, &claude_args))
+                .unwrap();
+            assert_eq!(
+                arguments(&fork),
+                vec![OsStr::new("--fork"), path.as_os_str()]
+            );
+            assert_eq!(
+                fork.get_current_dir(),
+                None,
+                "{program} fork runs in the current directory"
+            );
+        }
+    }
+}

--- a/src/history/provider/load.rs
+++ b/src/history/provider/load.rs
@@ -1,0 +1,276 @@
+//! The load loop shared by every provider that stores sessions under roots.
+
+use super::{SessionRoot, SessionStorage};
+use crate::cli::DebugLevel;
+use crate::debug;
+use crate::error::Result;
+use crate::history::cache::{
+    self, SessionCacheEntry, conversation_from_entry, entry_from_conversation, entry_matches,
+};
+use crate::history::{Conversation, Source, format_short_name_from_path};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Every session `storage` holds, newest first.
+///
+/// Each root carries its own cache, so a session that has not changed since the
+/// last run is rebuilt from cached metadata instead of reparsed.
+pub fn load_sessions(
+    source: Source,
+    storage: &dyn SessionStorage,
+    show_last: bool,
+    debug_level: Option<DebugLevel>,
+) -> Result<Vec<Conversation>> {
+    let mut conversations = Vec::new();
+    for root in storage.roots()? {
+        conversations.extend(load_root(source, storage, &root, show_last, debug_level)?);
+    }
+    conversations.sort_by_key(|conversation| std::cmp::Reverse(conversation.timestamp));
+    for (index, conversation) in conversations.iter_mut().enumerate() {
+        conversation.index = index;
+    }
+    Ok(conversations)
+}
+
+fn load_root(
+    source: Source,
+    storage: &dyn SessionStorage,
+    root: &SessionRoot,
+    show_last: bool,
+    debug_level: Option<DebugLevel>,
+) -> Result<Vec<Conversation>> {
+    let cached = cache::read_session_cache(source, &root.path).unwrap_or_default();
+    let mut refreshed_cache = HashMap::new();
+    let mut conversations = Vec::new();
+
+    for path in root.discover_files()? {
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if exceeds_size_limit(storage, metadata.len(), &path, debug_level) {
+            continue;
+        }
+        let modified = metadata.modified().ok();
+        let cache_key = cache_key_for(root, &path);
+
+        let cached_entry = modified.and_then(|mtime| {
+            cached
+                .get(&cache_key)
+                .filter(|entry| entry_matches(&entry.metadata, metadata.len(), mtime))
+        });
+        let conversation = match cached_entry {
+            Some(entry) => Some(restore_from_cache(source, entry, path.clone(), show_last)),
+            None => parse_session(source, storage, &path, root, modified, debug_level),
+        };
+        let Some(mut conversation) = conversation else {
+            continue;
+        };
+
+        conversation.preview = if show_last {
+            conversation.preview_last.clone()
+        } else {
+            conversation.preview_first.clone()
+        };
+        let project_path = conversation
+            .cwd
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("unknown"));
+        conversation.project_name = Some(format_short_name_from_path(&project_path));
+        conversation.project_path = Some(project_path.clone());
+
+        if let Some(mtime) = modified {
+            refreshed_cache.insert(
+                cache_key,
+                SessionCacheEntry {
+                    metadata: entry_from_conversation(&conversation, metadata.len(), mtime),
+                    session_id: conversation.session_id.clone(),
+                    project_path,
+                },
+            );
+        }
+        conversations.push(conversation);
+    }
+
+    cache::write_session_cache(source, &root.path, refreshed_cache);
+    Ok(conversations)
+}
+
+/// Cache entries are keyed by location within the root, so a root that moves
+/// misses cleanly rather than colliding with its old contents.
+fn cache_key_for(root: &SessionRoot, path: &std::path::Path) -> String {
+    path.strip_prefix(&root.path)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn exceeds_size_limit(
+    storage: &dyn SessionStorage,
+    file_size: u64,
+    path: &std::path::Path,
+    debug_level: Option<DebugLevel>,
+) -> bool {
+    let Some(limit) = storage.max_session_bytes() else {
+        return false;
+    };
+    if file_size <= limit {
+        return false;
+    }
+    debug::warn(
+        debug_level,
+        &format!(
+            "Skipping {}: {file_size} bytes exceeds the {limit} byte session limit",
+            path.display()
+        ),
+    );
+    true
+}
+
+fn restore_from_cache(
+    source: Source,
+    entry: &SessionCacheEntry,
+    path: PathBuf,
+    show_last: bool,
+) -> Conversation {
+    let mut conversation = conversation_from_entry(&entry.metadata, path, show_last);
+    conversation.source = source;
+    conversation.session_id = entry.session_id.clone();
+    conversation.cwd = Some(entry.project_path.clone());
+    conversation.project_path = Some(entry.project_path.clone());
+    conversation.project_name = Some(format_short_name_from_path(&entry.project_path));
+    conversation
+}
+
+/// A transcript another provider owns is not an error: roots can overlap, and a
+/// redirected session directory can hold a sibling agent's files.
+fn parse_session(
+    source: Source,
+    storage: &dyn SessionStorage,
+    path: &std::path::Path,
+    root: &SessionRoot,
+    modified: Option<std::time::SystemTime>,
+    debug_level: Option<DebugLevel>,
+) -> Option<Conversation> {
+    match storage.parse_session(path.to_path_buf(), root, modified, debug_level) {
+        Ok(Some(conversation)) if conversation.source == source => Some(conversation),
+        Ok(_) => None,
+        Err(error) => {
+            debug::warn(
+                debug_level,
+                &format!(
+                    "Failed to parse {} session {}: {error}",
+                    source.list_label(),
+                    path.display()
+                ),
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Records which transcripts the loop offered it, so a test can assert what
+    /// the loop filtered before parsing was ever attempted.
+    struct RecordingStorage {
+        root: SessionRoot,
+        max_session_bytes: Option<u64>,
+        parsed: Mutex<Vec<PathBuf>>,
+    }
+
+    impl RecordingStorage {
+        fn new(root: PathBuf, max_session_bytes: Option<u64>) -> Self {
+            Self {
+                root: SessionRoot::flat(root),
+                max_session_bytes,
+                parsed: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn parsed_file_names(&self) -> Vec<String> {
+            let mut names = self
+                .parsed
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+                .collect::<Vec<_>>();
+            names.sort();
+            names
+        }
+    }
+
+    impl SessionStorage for RecordingStorage {
+        fn cache(&self) -> super::super::SessionCache {
+            super::super::SessionCache {
+                directory: "pi",
+                magic: *b"PIHIST01",
+                schema_version: 1,
+            }
+        }
+
+        fn roots(&self) -> Result<Vec<SessionRoot>> {
+            Ok(vec![self.root.clone()])
+        }
+
+        fn parse_session(
+            &self,
+            path: PathBuf,
+            _root: &SessionRoot,
+            _modified: Option<std::time::SystemTime>,
+            _debug_level: Option<DebugLevel>,
+        ) -> Result<Option<Conversation>> {
+            self.parsed.lock().unwrap().push(path);
+            Ok(None)
+        }
+
+        fn max_session_bytes(&self) -> Option<u64> {
+            self.max_session_bytes
+        }
+    }
+
+    fn write_transcript(directory: &std::path::Path, name: &str, bytes: usize) {
+        std::fs::write(directory.join(name), "x".repeat(bytes)).unwrap();
+    }
+
+    /// Loading writes a cache keyed by the root, which for a temp root lands in
+    /// the real cache tree. Remove it so a test run leaves nothing behind.
+    fn discard_cache_for(root: &std::path::Path) {
+        if let Some(path) = cache::session_cache_path(Source::Pi, root)
+            && let Some(directory) = path.parent()
+        {
+            let _ = std::fs::remove_dir_all(directory);
+        }
+    }
+
+    fn parsed_files_for_limit(max_session_bytes: Option<u64>) -> Vec<String> {
+        let directory = tempfile::tempdir().unwrap();
+        write_transcript(directory.path(), "small.jsonl", 10);
+        write_transcript(directory.path(), "huge.jsonl", 5_000);
+
+        let storage = RecordingStorage::new(directory.path().to_path_buf(), max_session_bytes);
+        load_sessions(Source::Pi, &storage, false, None).unwrap();
+        discard_cache_for(directory.path());
+
+        storage.parsed_file_names()
+    }
+
+    #[test]
+    fn transcripts_over_the_size_limit_are_never_parsed() {
+        assert_eq!(
+            parsed_files_for_limit(Some(1_000)),
+            vec!["small.jsonl".to_string()]
+        );
+    }
+
+    #[test]
+    fn no_size_limit_offers_every_transcript() {
+        assert_eq!(
+            parsed_files_for_limit(None),
+            vec!["huge.jsonl".to_string(), "small.jsonl".to_string()]
+        );
+    }
+}

--- a/src/history/provider/load.rs
+++ b/src/history/provider/load.rs
@@ -5,9 +5,10 @@ use crate::cli::DebugLevel;
 use crate::debug;
 use crate::error::Result;
 use crate::history::cache::{
-    self, SessionCacheEntry, conversation_from_entry, entry_from_conversation, entry_matches,
+    SessionCacheEntry, SessionCacheStore, conversation_from_entry, entry_from_conversation,
+    entry_matches,
 };
-use crate::history::{Conversation, Source, format_short_name_from_path};
+use crate::history::{Conversation, format_short_name_from_path};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -16,14 +17,27 @@ use std::path::PathBuf;
 /// Each root carries its own cache, so a session that has not changed since the
 /// last run is rebuilt from cached metadata instead of reparsed.
 pub fn load_sessions(
-    source: Source,
     storage: &dyn SessionStorage,
+    show_last: bool,
+    debug_level: Option<DebugLevel>,
+) -> Result<Vec<Conversation>> {
+    load_sessions_with_cache(
+        storage,
+        &SessionCacheStore::in_user_cache(storage.cache()),
+        show_last,
+        debug_level,
+    )
+}
+
+fn load_sessions_with_cache(
+    storage: &dyn SessionStorage,
+    cache: &SessionCacheStore,
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
     let mut conversations = Vec::new();
     for root in storage.roots()? {
-        conversations.extend(load_root(source, storage, &root, show_last, debug_level)?);
+        conversations.extend(load_root(storage, cache, &root, show_last, debug_level)?);
     }
     conversations.sort_by_key(|conversation| std::cmp::Reverse(conversation.timestamp));
     for (index, conversation) in conversations.iter_mut().enumerate() {
@@ -33,13 +47,13 @@ pub fn load_sessions(
 }
 
 fn load_root(
-    source: Source,
     storage: &dyn SessionStorage,
+    cache: &SessionCacheStore,
     root: &SessionRoot,
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let cached = cache::read_session_cache(source, &root.path).unwrap_or_default();
+    let cached = cache.read(&root.path);
     let mut refreshed_cache = HashMap::new();
     let mut conversations = Vec::new();
 
@@ -59,8 +73,8 @@ fn load_root(
                 .filter(|entry| entry_matches(&entry.metadata, metadata.len(), mtime))
         });
         let conversation = match cached_entry {
-            Some(entry) => Some(restore_from_cache(source, entry, path.clone(), show_last)),
-            None => parse_session(source, storage, &path, root, modified, debug_level),
+            Some(entry) => Some(restore_from_cache(storage, entry, path.clone(), show_last)),
+            None => parse_session(storage, &path, root, modified, debug_level),
         };
         let Some(mut conversation) = conversation else {
             continue;
@@ -91,7 +105,7 @@ fn load_root(
         conversations.push(conversation);
     }
 
-    cache::write_session_cache(source, &root.path, refreshed_cache);
+    cache.write(&root.path, refreshed_cache);
     Ok(conversations)
 }
 
@@ -127,13 +141,13 @@ fn exceeds_size_limit(
 }
 
 fn restore_from_cache(
-    source: Source,
+    storage: &dyn SessionStorage,
     entry: &SessionCacheEntry,
     path: PathBuf,
     show_last: bool,
 ) -> Conversation {
     let mut conversation = conversation_from_entry(&entry.metadata, path, show_last);
-    conversation.source = source;
+    conversation.source = storage.source();
     conversation.session_id = entry.session_id.clone();
     conversation.cwd = Some(entry.project_path.clone());
     conversation.project_path = Some(entry.project_path.clone());
@@ -144,7 +158,6 @@ fn restore_from_cache(
 /// A transcript another provider owns is not an error: roots can overlap, and a
 /// redirected session directory can hold a sibling agent's files.
 fn parse_session(
-    source: Source,
     storage: &dyn SessionStorage,
     path: &std::path::Path,
     root: &SessionRoot,
@@ -152,14 +165,14 @@ fn parse_session(
     debug_level: Option<DebugLevel>,
 ) -> Option<Conversation> {
     match storage.parse_session(path.to_path_buf(), root, modified, debug_level) {
-        Ok(Some(conversation)) if conversation.source == source => Some(conversation),
+        Ok(Some(conversation)) if conversation.source == storage.source() => Some(conversation),
         Ok(_) => None,
         Err(error) => {
             debug::warn(
                 debug_level,
                 &format!(
                     "Failed to parse {} session {}: {error}",
-                    source.list_label(),
+                    storage.source().list_label(),
                     path.display()
                 ),
             );
@@ -171,6 +184,7 @@ fn parse_session(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::history::Source;
     use std::sync::Mutex;
 
     /// Records which transcripts the loop offered it, so a test can assert what
@@ -204,10 +218,14 @@ mod tests {
     }
 
     impl SessionStorage for RecordingStorage {
+        fn source(&self) -> Source {
+            Source::Pi
+        }
+
         fn cache(&self) -> super::super::SessionCache {
             super::super::SessionCache {
-                directory: "pi",
-                magic: *b"PIHIST01",
+                directory: "recording-storage",
+                magic: *b"RECORD01",
                 schema_version: 1,
             }
         }
@@ -236,24 +254,15 @@ mod tests {
         std::fs::write(directory.join(name), "x".repeat(bytes)).unwrap();
     }
 
-    /// Loading writes a cache keyed by the root, which for a temp root lands in
-    /// the real cache tree. Remove it so a test run leaves nothing behind.
-    fn discard_cache_for(root: &std::path::Path) {
-        if let Some(path) = cache::session_cache_path(Source::Pi, root)
-            && let Some(directory) = path.parent()
-        {
-            let _ = std::fs::remove_dir_all(directory);
-        }
-    }
-
     fn parsed_files_for_limit(max_session_bytes: Option<u64>) -> Vec<String> {
         let directory = tempfile::tempdir().unwrap();
+        let cache_base = tempfile::tempdir().unwrap();
         write_transcript(directory.path(), "small.jsonl", 10);
         write_transcript(directory.path(), "huge.jsonl", 5_000);
 
         let storage = RecordingStorage::new(directory.path().to_path_buf(), max_session_bytes);
-        load_sessions(Source::Pi, &storage, false, None).unwrap();
-        discard_cache_for(directory.path());
+        let cache = SessionCacheStore::under(cache_base.path(), storage.cache());
+        load_sessions_with_cache(&storage, &cache, false, None).unwrap();
 
         storage.parsed_file_names()
     }

--- a/src/history/provider/load.rs
+++ b/src/history/provider/load.rs
@@ -1,5 +1,6 @@
 //! The load loop shared by every provider that stores sessions under roots.
 
+use super::storage::SessionStub;
 use super::{SessionRoot, SessionStorage};
 use crate::cli::DebugLevel;
 use crate::debug;
@@ -57,24 +58,29 @@ fn load_root(
     let mut refreshed_cache = HashMap::new();
     let mut conversations = Vec::new();
 
-    for path in root.discover_files()? {
-        let Ok(metadata) = std::fs::metadata(&path) else {
-            continue;
-        };
-        if exceeds_size_limit(storage, metadata.len(), &path, debug_level) {
+    for stub in storage.discover(root)? {
+        let SessionStub {
+            locator,
+            cache_key,
+            fingerprint,
+        } = stub;
+        if exceeds_size_limit(storage, fingerprint.size, &locator, debug_level) {
             continue;
         }
-        let modified = metadata.modified().ok();
-        let cache_key = cache_key_for(root, &path);
 
-        let cached_entry = modified.and_then(|mtime| {
+        let cached_entry = fingerprint.modified.and_then(|mtime| {
             cached
                 .get(&cache_key)
-                .filter(|entry| entry_matches(&entry.metadata, metadata.len(), mtime))
+                .filter(|entry| entry_matches(&entry.metadata, fingerprint.size, mtime))
         });
         let conversation = match cached_entry {
-            Some(entry) => Some(restore_from_cache(storage, entry, path.clone(), show_last)),
-            None => parse_session(storage, &path, root, modified, debug_level),
+            Some(entry) => Some(restore_from_cache(
+                storage,
+                entry,
+                locator.clone(),
+                show_last,
+            )),
+            None => parse_session(storage, &locator, root, fingerprint.modified, debug_level),
         };
         let Some(mut conversation) = conversation else {
             continue;
@@ -92,11 +98,11 @@ fn load_root(
         conversation.project_name = Some(format_short_name_from_path(&project_path));
         conversation.project_path = Some(project_path.clone());
 
-        if let Some(mtime) = modified {
+        if let Some(mtime) = fingerprint.modified {
             refreshed_cache.insert(
                 cache_key,
                 SessionCacheEntry {
-                    metadata: entry_from_conversation(&conversation, metadata.len(), mtime),
+                    metadata: entry_from_conversation(&conversation, fingerprint.size, mtime),
                     session_id: conversation.session_id.clone(),
                     project_path,
                 },
@@ -109,32 +115,23 @@ fn load_root(
     Ok(conversations)
 }
 
-/// Cache entries are keyed by location within the root, so a root that moves
-/// misses cleanly rather than colliding with its old contents.
-fn cache_key_for(root: &SessionRoot, path: &std::path::Path) -> String {
-    path.strip_prefix(&root.path)
-        .unwrap_or(path)
-        .to_string_lossy()
-        .into_owned()
-}
-
 fn exceeds_size_limit(
     storage: &dyn SessionStorage,
-    file_size: u64,
-    path: &std::path::Path,
+    size: u64,
+    locator: &std::path::Path,
     debug_level: Option<DebugLevel>,
 ) -> bool {
     let Some(limit) = storage.max_session_bytes() else {
         return false;
     };
-    if file_size <= limit {
+    if size <= limit {
         return false;
     }
     debug::warn(
         debug_level,
         &format!(
-            "Skipping {}: {file_size} bytes exceeds the {limit} byte session limit",
-            path.display()
+            "Skipping {}: {size} bytes exceeds the {limit} byte session limit",
+            locator.display()
         ),
     );
     true
@@ -143,10 +140,10 @@ fn exceeds_size_limit(
 fn restore_from_cache(
     storage: &dyn SessionStorage,
     entry: &SessionCacheEntry,
-    path: PathBuf,
+    locator: PathBuf,
     show_last: bool,
 ) -> Conversation {
-    let mut conversation = conversation_from_entry(&entry.metadata, path, show_last);
+    let mut conversation = conversation_from_entry(&entry.metadata, locator, show_last);
     conversation.source = storage.source();
     conversation.session_id = entry.session_id.clone();
     conversation.cwd = Some(entry.project_path.clone());
@@ -155,16 +152,16 @@ fn restore_from_cache(
     conversation
 }
 
-/// A transcript another provider owns is not an error: roots can overlap, and a
+/// A session another provider owns is not an error: roots can overlap, and a
 /// redirected session directory can hold a sibling agent's files.
 fn parse_session(
     storage: &dyn SessionStorage,
-    path: &std::path::Path,
+    locator: &std::path::Path,
     root: &SessionRoot,
     modified: Option<std::time::SystemTime>,
     debug_level: Option<DebugLevel>,
 ) -> Option<Conversation> {
-    match storage.parse_session(path.to_path_buf(), root, modified, debug_level) {
+    match storage.parse_session(locator.to_path_buf(), root, modified, debug_level) {
         Ok(Some(conversation)) if conversation.source == storage.source() => Some(conversation),
         Ok(_) => None,
         Err(error) => {
@@ -173,7 +170,7 @@ fn parse_session(
                 &format!(
                     "Failed to parse {} session {}: {error}",
                     storage.source().list_label(),
-                    path.display()
+                    locator.display()
                 ),
             );
             None
@@ -184,8 +181,10 @@ fn parse_session(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::history::Source;
+    use crate::history::provider::{Fingerprint, walk};
+    use crate::history::{Source, cache};
     use std::sync::Mutex;
+    use std::time::{Duration, UNIX_EPOCH};
 
     /// Records which transcripts the loop offered it, so a test can assert what
     /// the loop filtered before parsing was ever attempted.
@@ -198,7 +197,7 @@ mod tests {
     impl RecordingStorage {
         fn new(root: PathBuf, max_session_bytes: Option<u64>) -> Self {
             Self {
-                root: SessionRoot::flat(root),
+                root: SessionRoot::new(root),
                 max_session_bytes,
                 parsed: Mutex::new(Vec::new()),
             }
@@ -234,19 +233,107 @@ mod tests {
             Ok(vec![self.root.clone()])
         }
 
+        fn discover(&self, root: &SessionRoot) -> Result<Vec<SessionStub>> {
+            Ok(walk::file_stubs(
+                root,
+                walk::jsonl_files_at_depth(&root.path, 0)?,
+            ))
+        }
+
         fn parse_session(
             &self,
-            path: PathBuf,
+            locator: PathBuf,
             _root: &SessionRoot,
             _modified: Option<std::time::SystemTime>,
             _debug_level: Option<DebugLevel>,
         ) -> Result<Option<Conversation>> {
-            self.parsed.lock().unwrap().push(path);
+            self.parsed.lock().unwrap().push(locator);
             Ok(None)
         }
 
         fn max_session_bytes(&self) -> Option<u64> {
             self.max_session_bytes
+        }
+    }
+
+    /// A storage whose locators name no file on disk. What it pins: the load
+    /// loop consumes stubs as given — it never stats, opens, or interprets a
+    /// locator — so a provider can back sessions with something other than
+    /// files and still get listing and caching from the shared loop.
+    struct VirtualStorage {
+        root: SessionRoot,
+        stubs: Vec<SessionStub>,
+        parse_count: Mutex<usize>,
+    }
+
+    impl VirtualStorage {
+        fn new(stubs: Vec<SessionStub>) -> Self {
+            Self {
+                root: SessionRoot::new("container.db"),
+                stubs,
+                parse_count: Mutex::new(0),
+            }
+        }
+
+        fn parse_count(&self) -> usize {
+            *self.parse_count.lock().unwrap()
+        }
+    }
+
+    impl SessionStorage for VirtualStorage {
+        fn source(&self) -> Source {
+            Source::Pi
+        }
+
+        fn cache(&self) -> super::super::SessionCache {
+            super::super::SessionCache {
+                directory: "virtual-storage",
+                magic: *b"VIRTUAL1",
+                schema_version: 1,
+            }
+        }
+
+        fn roots(&self) -> Result<Vec<SessionRoot>> {
+            Ok(vec![self.root.clone()])
+        }
+
+        fn discover(&self, _root: &SessionRoot) -> Result<Vec<SessionStub>> {
+            Ok(self.stubs.clone())
+        }
+
+        fn parse_session(
+            &self,
+            locator: PathBuf,
+            _root: &SessionRoot,
+            _modified: Option<std::time::SystemTime>,
+            _debug_level: Option<DebugLevel>,
+        ) -> Result<Option<Conversation>> {
+            *self.parse_count.lock().unwrap() += 1;
+            let mut conversation = cache::conversation_from_entry(
+                &cache::empty_entry(0, UNIX_EPOCH),
+                PathBuf::new(),
+                false,
+            );
+            conversation.session_id = locator.to_string_lossy().into_owned();
+            conversation.source = Source::Pi;
+            conversation.path = locator;
+            conversation.message_count = 1;
+            Ok(Some(conversation))
+        }
+
+        fn max_session_bytes(&self) -> Option<u64> {
+            None
+        }
+    }
+
+    fn virtual_stub(session_id: &str, size: u64, modified_secs: u64) -> SessionStub {
+        SessionStub {
+            locator: PathBuf::from("container.db").join(format!("{session_id}.jsonl")),
+            cache_key: session_id.to_owned(),
+            fingerprint: Fingerprint {
+                size,
+                modified: Some(UNIX_EPOCH + Duration::from_secs(modified_secs)),
+            },
         }
     }
 
@@ -280,6 +367,51 @@ mod tests {
         assert_eq!(
             parsed_files_for_limit(None),
             vec!["huge.jsonl".to_string(), "small.jsonl".to_string()]
+        );
+    }
+
+    #[test]
+    fn sessions_that_are_not_files_load_and_cache_through_the_shared_loop() {
+        let cache_base = tempfile::tempdir().unwrap();
+        let storage = VirtualStorage::new(vec![
+            virtual_stub("ses_first", 100, 1_000),
+            virtual_stub("ses_second", 200, 2_000),
+        ]);
+        let cache = SessionCacheStore::under(cache_base.path(), storage.cache());
+
+        let cold = load_sessions_with_cache(&storage, &cache, false, None).unwrap();
+        assert_eq!(cold.len(), 2);
+        assert_eq!(storage.parse_count(), 2);
+        assert_eq!(
+            cold.iter()
+                .map(|conversation| conversation.path.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("container.db").join("ses_first.jsonl"),
+                PathBuf::from("container.db").join("ses_second.jsonl"),
+            ],
+            "locators reach the conversations untouched"
+        );
+
+        let warm = load_sessions_with_cache(&storage, &cache, false, None).unwrap();
+        assert_eq!(warm.len(), 2);
+        assert_eq!(
+            storage.parse_count(),
+            2,
+            "unchanged fingerprints must restore from the cache, not reparse"
+        );
+
+        let mut changed = VirtualStorage::new(vec![
+            virtual_stub("ses_first", 100, 1_000),
+            virtual_stub("ses_second", 250, 3_000),
+        ]);
+        changed.parse_count = Mutex::new(storage.parse_count());
+        let after_change = load_sessions_with_cache(&changed, &cache, false, None).unwrap();
+        assert_eq!(after_change.len(), 2);
+        assert_eq!(
+            changed.parse_count(),
+            3,
+            "only the session whose fingerprint changed is reparsed"
         );
     }
 }

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -14,7 +14,7 @@ mod omp;
 mod pi;
 mod storage;
 
-pub use discovery::SessionRoot;
+pub use discovery::{RootOrigin, SessionRoot};
 pub use launcher::{SessionLaunch, SessionLauncher};
 pub use load::load_sessions;
 pub use storage::{SessionCache, SessionStorage};
@@ -119,6 +119,9 @@ pub fn display_names_in_prose() -> String {
 }
 
 impl Source {
+    /// A match rather than a scan of [`PROVIDERS`], so that a new [`Source`]
+    /// variant fails to compile until it is mapped here. That the two lists say
+    /// the same thing is checked by `registry_and_source_lookup_agree`.
     pub fn provider(self) -> &'static dyn SessionProvider {
         match self {
             Self::Claude => &CLAUDE,
@@ -236,6 +239,25 @@ mod tests {
             }),
             "OMP cache identity must not change"
         );
+    }
+
+    /// The load loop stamps, caches and reports under the storage's own source,
+    /// so a storage that named a different one would file its sessions under a
+    /// provider that never collected them.
+    #[test]
+    fn storage_collects_the_sessions_of_the_provider_that_offers_it() {
+        for provider in providers() {
+            let Some(storage) = provider.storage() else {
+                continue;
+            };
+            assert_eq!(
+                storage.source(),
+                provider.source(),
+                "provider {} offers storage for {:?}",
+                provider.labels().name,
+                storage.source()
+            );
+        }
     }
 
     #[test]

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -25,9 +25,26 @@ pub struct SourceLabels {
     pub list: &'static str,
 }
 
+/// On-disk identity of a provider's whole-root session cache.
+///
+/// All three fields are a compatibility contract with caches users already have:
+/// `directory` names the folder under `~/.cache/claude-history`, and `magic` plus
+/// `schema_version` stamp the file so an incompatible one is discarded rather
+/// than misread. Changing any of them silently invalidates existing caches.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SessionCache {
+    pub directory: &'static str,
+    pub magic: [u8; 8],
+    pub schema_version: u32,
+}
+
 pub trait SessionProvider: Sync {
     fn source(&self) -> Source;
     fn labels(&self) -> SourceLabels;
+
+    /// The cache covering every session under one root, or `None` for a provider
+    /// whose transcripts are cached by some other partition.
+    fn session_cache(&self) -> Option<SessionCache>;
 }
 
 static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;
@@ -91,6 +108,46 @@ mod tests {
             [Source::Claude, Source::Pi, Source::Omp].len(),
             "a source is missing from the registry"
         );
+    }
+
+    #[test]
+    fn session_cache_identities_are_pinned() {
+        assert_eq!(Source::Claude.provider().session_cache(), None);
+        assert_eq!(
+            Source::Pi.provider().session_cache(),
+            Some(SessionCache {
+                directory: "pi",
+                magic: *b"PIHIST01",
+                schema_version: 1,
+            }),
+            "changing a cache identity discards every cache users already have"
+        );
+        assert_eq!(
+            Source::Omp.provider().session_cache(),
+            Some(SessionCache {
+                directory: "omp",
+                magic: *b"OMHIST01",
+                schema_version: 1,
+            }),
+            "changing a cache identity discards every cache users already have"
+        );
+    }
+
+    #[test]
+    fn session_caches_do_not_share_a_directory_or_magic() {
+        let caches = providers()
+            .iter()
+            .filter_map(|provider| provider.session_cache())
+            .collect::<Vec<_>>();
+        for (index, cache) in caches.iter().enumerate() {
+            for other in &caches[index + 1..] {
+                assert_ne!(cache.directory, other.directory);
+                assert_ne!(
+                    cache.magic, other.magic,
+                    "shared magic bytes let one source read another's cache"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -1,0 +1,91 @@
+//! Per-provider behavior for the coding agents whose history this browser reads.
+//!
+//! [`Source`] identifies which agent recorded a conversation. Everything that
+//! *differs* between those agents — where sessions live, how their transcripts
+//! are shaped, how to resume or rename one — is reached through the
+//! [`SessionProvider`] returned by [`Source::provider`], so adding an agent means
+//! adding a provider rather than editing matches scattered across the codebase.
+
+mod claude;
+mod omp;
+mod pi;
+
+use super::Source;
+
+/// How a source is named in output. Widths matter: list rows align on `list`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SourceLabels {
+    /// Lowercase identifier used in diagnostics and agent output (`claude`).
+    pub name: &'static str,
+    /// Short label shown in the TUI conversation list (`CC`).
+    pub list: &'static str,
+}
+
+pub trait SessionProvider: Sync {
+    fn source(&self) -> Source;
+    fn labels(&self) -> SourceLabels;
+}
+
+static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;
+static PI: pi::PiProvider = pi::PiProvider;
+static OMP: omp::OmpProvider = omp::OmpProvider;
+
+/// Every supported provider, in the order sources are presented to the user.
+static PROVIDERS: &[&dyn SessionProvider] = &[&CLAUDE, &PI, &OMP];
+
+pub fn providers() -> &'static [&'static dyn SessionProvider] {
+    PROVIDERS
+}
+
+impl Source {
+    pub fn provider(self) -> &'static dyn SessionProvider {
+        match self {
+            Self::Claude => &CLAUDE,
+            Self::Pi => &PI,
+            Self::Omp => &OMP,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_and_source_lookup_agree() {
+        for provider in providers() {
+            assert_eq!(
+                provider.source().provider().labels(),
+                provider.labels(),
+                "{} resolves to a different provider than it registers as",
+                provider.labels().name
+            );
+        }
+    }
+
+    #[test]
+    fn registry_lists_every_source_exactly_once() {
+        let mut sources = providers()
+            .iter()
+            .map(|provider| provider.source())
+            .collect::<Vec<_>>();
+        let registered = sources.len();
+        sources.dedup();
+        assert_eq!(registered, sources.len(), "a source is registered twice");
+        assert_eq!(
+            registered,
+            [Source::Claude, Source::Pi, Source::Omp].len(),
+            "a source is missing from the registry"
+        );
+    }
+
+    #[test]
+    fn labels_are_unique() {
+        for (index, provider) in providers().iter().enumerate() {
+            for other in &providers()[index + 1..] {
+                assert_ne!(provider.labels().name, other.labels().name);
+                assert_ne!(provider.labels().list, other.labels().list);
+            }
+        }
+    }
+}

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -8,10 +8,14 @@
 
 mod claude;
 mod discovery;
+mod load;
 mod omp;
 mod pi;
+mod storage;
 
 pub use discovery::SessionRoot;
+pub use load::load_sessions;
+pub use storage::{SessionCache, SessionStorage};
 
 use super::Source;
 use unicode_width::UnicodeWidthStr;
@@ -25,26 +29,13 @@ pub struct SourceLabels {
     pub list: &'static str,
 }
 
-/// On-disk identity of a provider's whole-root session cache.
-///
-/// All three fields are a compatibility contract with caches users already have:
-/// `directory` names the folder under `~/.cache/claude-history`, and `magic` plus
-/// `schema_version` stamp the file so an incompatible one is discarded rather
-/// than misread. Changing any of them silently invalidates existing caches.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SessionCache {
-    pub directory: &'static str,
-    pub magic: [u8; 8],
-    pub schema_version: u32,
-}
-
 pub trait SessionProvider: Sync {
     fn source(&self) -> Source;
     fn labels(&self) -> SourceLabels;
 
-    /// The cache covering every session under one root, or `None` for a provider
-    /// whose transcripts are cached by some other partition.
-    fn session_cache(&self) -> Option<SessionCache>;
+    /// How this provider finds and reads sessions under its roots, or `None` for
+    /// a provider whose transcripts are organized some other way.
+    fn storage(&self) -> Option<&dyn SessionStorage>;
 }
 
 static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;
@@ -112,9 +103,12 @@ mod tests {
 
     #[test]
     fn session_cache_identities_are_pinned() {
-        assert_eq!(Source::Claude.provider().session_cache(), None);
+        assert!(Source::Claude.provider().storage().is_none());
         assert_eq!(
-            Source::Pi.provider().session_cache(),
+            Source::Pi
+                .provider()
+                .storage()
+                .map(|storage| storage.cache()),
             Some(SessionCache {
                 directory: "pi",
                 magic: *b"PIHIST01",
@@ -123,7 +117,10 @@ mod tests {
             "changing a cache identity discards every cache users already have"
         );
         assert_eq!(
-            Source::Omp.provider().session_cache(),
+            Source::Omp
+                .provider()
+                .storage()
+                .map(|storage| storage.cache()),
             Some(SessionCache {
                 directory: "omp",
                 magic: *b"OMHIST01",
@@ -137,7 +134,7 @@ mod tests {
     fn session_caches_do_not_share_a_directory_or_magic() {
         let caches = providers()
             .iter()
-            .filter_map(|provider| provider.session_cache())
+            .filter_map(|provider| provider.storage().map(|storage| storage.cache()))
             .collect::<Vec<_>>();
         for (index, cache) in caches.iter().enumerate() {
             for other in &caches[index + 1..] {

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -138,7 +138,7 @@ mod tests {
             assert_eq!(
                 provider.source().provider().labels(),
                 provider.labels(),
-                "{} resolves to a different provider than it registers as",
+                "provider {} resolves to a different provider than it registers as",
                 provider.labels().name
             );
         }
@@ -154,13 +154,12 @@ mod tests {
             for (other_name, other) in &registered[index + 1..] {
                 assert_ne!(
                     namespace.project, other.project,
-                    "{name} and {other_name} must not share project namespace {:?}",
-                    namespace.project
+                    "providers {name} and {other_name} must have different project namespaces"
                 );
                 if let (Some(left), Some(right)) = (namespace.conversation, other.conversation) {
                     assert_ne!(
                         left, right,
-                        "{name} and {other_name} must not share conversation namespace {left:?}"
+                        "providers {name} and {other_name} must have different conversation namespaces"
                     );
                 }
             }
@@ -169,28 +168,50 @@ mod tests {
 
     #[test]
     fn provider_names_read_as_prose() {
-        assert_eq!(display_names_in_prose(), "Claude, Pi, or OMP");
+        assert_eq!(
+            display_names_in_prose(),
+            "Claude, Pi, or OMP",
+            "expected prose is stale; a provider was added or renamed"
+        );
     }
 
     #[test]
     fn registry_lists_every_source_exactly_once() {
-        let mut sources = providers()
+        const EVERY_SOURCE: [Source; 3] = [Source::Claude, Source::Pi, Source::Omp];
+
+        let registered = providers()
             .iter()
             .map(|provider| provider.source())
             .collect::<Vec<_>>();
-        let registered = sources.len();
-        sources.dedup();
-        assert_eq!(registered, sources.len(), "a source is registered twice");
+        let distinct = registered
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+
         assert_eq!(
-            registered,
-            [Source::Claude, Source::Pi, Source::Omp].len(),
-            "a source is missing from the registry"
+            registered.len(),
+            distinct.len(),
+            "PROVIDERS must list each source once: {registered:?}"
+        );
+        for source in EVERY_SOURCE {
+            assert!(
+                distinct.contains(&source),
+                "{source:?} has no entry in PROVIDERS"
+            );
+        }
+        assert_eq!(
+            registered.len(),
+            EVERY_SOURCE.len(),
+            "PROVIDERS and EVERY_SOURCE must list the same sources"
         );
     }
 
     #[test]
     fn session_cache_identities_are_pinned() {
-        assert!(Source::Claude.provider().storage().is_none());
+        assert!(
+            Source::Claude.provider().storage().is_none(),
+            "Claude caches per project directory, not per session root"
+        );
         assert_eq!(
             Source::Pi
                 .provider()
@@ -201,7 +222,7 @@ mod tests {
                 magic: *b"PIHIST01",
                 schema_version: 1,
             }),
-            "changing a cache identity discards every cache users already have"
+            "Pi cache identity must not change"
         );
         assert_eq!(
             Source::Omp
@@ -213,7 +234,7 @@ mod tests {
                 magic: *b"OMHIST01",
                 schema_version: 1,
             }),
-            "changing a cache identity discards every cache users already have"
+            "OMP cache identity must not change"
         );
     }
 
@@ -221,14 +242,21 @@ mod tests {
     fn session_caches_do_not_share_a_directory_or_magic() {
         let caches = providers()
             .iter()
-            .filter_map(|provider| provider.storage().map(|storage| storage.cache()))
+            .filter_map(|provider| {
+                provider
+                    .storage()
+                    .map(|storage| (provider.labels().name, storage.cache()))
+            })
             .collect::<Vec<_>>();
-        for (index, cache) in caches.iter().enumerate() {
-            for other in &caches[index + 1..] {
-                assert_ne!(cache.directory, other.directory);
+        for (index, (name, cache)) in caches.iter().enumerate() {
+            for (other_name, other) in &caches[index + 1..] {
+                assert_ne!(
+                    cache.directory, other.directory,
+                    "providers {name} and {other_name} must have different cache directories"
+                );
                 assert_ne!(
                     cache.magic, other.magic,
-                    "shared magic bytes let one source read another's cache"
+                    "providers {name} and {other_name} must have different magic bytes"
                 );
             }
         }
@@ -238,8 +266,22 @@ mod tests {
     fn labels_are_unique() {
         for (index, provider) in providers().iter().enumerate() {
             for other in &providers()[index + 1..] {
-                assert_ne!(provider.labels().name, other.labels().name);
-                assert_ne!(provider.labels().list, other.labels().list);
+                let (left, right) = (provider.labels(), other.labels());
+                assert_ne!(
+                    left.name, right.name,
+                    "two providers must not share the name {:?}",
+                    left.name
+                );
+                assert_ne!(
+                    left.list, right.list,
+                    "providers {} and {} must have different list labels",
+                    left.name, right.name
+                );
+                assert_ne!(
+                    left.display, right.display,
+                    "providers {} and {} must have different display names",
+                    left.name, right.name
+                );
             }
         }
     }

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -8,14 +8,18 @@
 
 mod claude;
 mod discovery;
+mod launcher;
 mod load;
 mod omp;
 mod pi;
 mod storage;
 
 pub use discovery::SessionRoot;
+pub use launcher::{SessionLaunch, SessionLauncher};
 pub use load::load_sessions;
 pub use storage::{SessionCache, SessionStorage};
+
+use launcher::PathResumeLauncher;
 
 use super::Source;
 use super::format::SessionFormat;
@@ -42,6 +46,9 @@ pub trait SessionProvider: Sync {
     /// normalized entries, or `None` for a provider whose files carry no session
     /// header to project from.
     fn format(&self) -> Option<&dyn SessionFormat>;
+
+    /// How this provider hands a session back to its agent, to resume or fork.
+    fn launcher(&self) -> &dyn SessionLauncher;
 }
 
 static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -18,6 +18,7 @@ pub use load::load_sessions;
 pub use storage::{SessionCache, SessionStorage};
 
 use super::Source;
+use super::format::SessionFormat;
 use unicode_width::UnicodeWidthStr;
 
 /// How a source is named in output. Widths matter: list rows align on `list`.
@@ -36,6 +37,11 @@ pub trait SessionProvider: Sync {
     /// How this provider finds and reads sessions under its roots, or `None` for
     /// a provider whose transcripts are organized some other way.
     fn storage(&self) -> Option<&dyn SessionStorage>;
+
+    /// How this provider recognizes one of its transcripts and projects it into
+    /// normalized entries, or `None` for a provider whose files carry no session
+    /// header to project from.
+    fn format(&self) -> Option<&dyn SessionFormat>;
 }
 
 static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -13,11 +13,12 @@ mod load;
 mod omp;
 mod pi;
 mod storage;
+pub(crate) mod walk;
 
 pub use discovery::{RootOrigin, SessionRoot};
 pub use launcher::{SessionLaunch, SessionLauncher};
 pub use load::load_sessions;
-pub use storage::{SessionCache, SessionStorage};
+pub use storage::{Fingerprint, SessionCache, SessionStorage, SessionStub};
 
 use launcher::PathResumeLauncher;
 

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -23,6 +23,8 @@ use launcher::PathResumeLauncher;
 
 use super::Source;
 use super::format::SessionFormat;
+use crate::error::Result;
+use std::path::Path;
 use unicode_width::UnicodeWidthStr;
 
 /// How a source is named in output. Widths matter: list rows align on `list`.
@@ -49,6 +51,17 @@ pub trait SessionProvider: Sync {
 
     /// How this provider hands a session back to its agent, to resume or fork.
     fn launcher(&self) -> &dyn SessionLauncher;
+
+    /// Give the session at `path` a user-chosen title.
+    ///
+    /// Every agent records titles differently — appended records, a rewritten
+    /// header slot — and none of it is shared, so this is a plain method rather
+    /// than another capability object.
+    fn rename_session(&self, path: &Path, title: &str) -> Result<()>;
+
+    /// Remove the session at `path`, along with whatever else the agent stores
+    /// beside it.
+    fn delete_session(&self, path: &Path) -> Result<()>;
 }
 
 static CLAUDE: claude::ClaudeProvider = claude::ClaudeProvider;

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -7,10 +7,14 @@
 //! adding a provider rather than editing matches scattered across the codebase.
 
 mod claude;
+mod discovery;
 mod omp;
 mod pi;
 
+pub use discovery::SessionRoot;
+
 use super::Source;
+use unicode_width::UnicodeWidthStr;
 
 /// How a source is named in output. Widths matter: list rows align on `list`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -35,6 +39,16 @@ static PROVIDERS: &[&dyn SessionProvider] = &[&CLAUDE, &PI, &OMP];
 
 pub fn providers() -> &'static [&'static dyn SessionProvider] {
     PROVIDERS
+}
+
+/// Column width that keeps mixed-source list rows aligned: the widest list
+/// label any registered provider can print.
+pub fn list_label_column_width() -> usize {
+    providers()
+        .iter()
+        .map(|provider| UnicodeWidthStr::width(provider.labels().list))
+        .max()
+        .unwrap_or(0)
 }
 
 impl Source {

--- a/src/history/provider/mod.rs
+++ b/src/history/provider/mod.rs
@@ -34,11 +34,28 @@ pub struct SourceLabels {
     pub name: &'static str,
     /// Short label shown in the TUI conversation list (`CC`).
     pub list: &'static str,
+    /// The agent's name as written in prose (`Claude`).
+    pub display: &'static str,
+}
+
+/// Domain separation strings mixed into the reference digests the agent CLI emits
+/// and resolves, so one agent's references cannot collide with another's.
+///
+/// These are a compatibility contract: changing one silently invalidates every
+/// reference a user has already written down.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RefNamespaces {
+    /// `None` for Claude, whose conversation references predate per-source
+    /// digests and are derived from the project directory and session filename.
+    pub conversation: Option<&'static str>,
+    pub project: &'static str,
 }
 
 pub trait SessionProvider: Sync {
     fn source(&self) -> Source;
     fn labels(&self) -> SourceLabels;
+
+    fn ref_namespaces(&self) -> RefNamespaces;
 
     /// How this provider finds and reads sessions under its roots, or `None` for
     /// a provider whose transcripts are organized some other way.
@@ -85,6 +102,22 @@ pub fn list_label_column_width() -> usize {
         .unwrap_or(0)
 }
 
+/// Every provider named as prose would name them: `"Claude, Pi, or OMP"`. Used by
+/// messages about history that is missing everywhere, which must stay accurate as
+/// providers are added.
+pub fn display_names_in_prose() -> String {
+    let names = providers()
+        .iter()
+        .map(|provider| provider.labels().display)
+        .collect::<Vec<_>>();
+    match names.as_slice() {
+        [] => String::new(),
+        [only] => (*only).to_owned(),
+        [first, last] => format!("{first} or {last}"),
+        [leading @ .., last] => format!("{}, or {last}", leading.join(", ")),
+    }
+}
+
 impl Source {
     pub fn provider(self) -> &'static dyn SessionProvider {
         match self {
@@ -109,6 +142,34 @@ mod tests {
                 provider.labels().name
             );
         }
+    }
+
+    #[test]
+    fn ref_namespaces_are_unique_across_providers() {
+        let registered = providers()
+            .iter()
+            .map(|provider| (provider.labels().name, provider.ref_namespaces()))
+            .collect::<Vec<_>>();
+        for (index, (name, namespace)) in registered.iter().enumerate() {
+            for (other_name, other) in &registered[index + 1..] {
+                assert_ne!(
+                    namespace.project, other.project,
+                    "{name} and {other_name} must not share project namespace {:?}",
+                    namespace.project
+                );
+                if let (Some(left), Some(right)) = (namespace.conversation, other.conversation) {
+                    assert_ne!(
+                        left, right,
+                        "{name} and {other_name} must not share conversation namespace {left:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn provider_names_read_as_prose() {
+        assert_eq!(display_names_in_prose(), "Claude, Pi, or OMP");
     }
 
     #[test]

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -3,6 +3,7 @@
 use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
 use crate::cli::DebugLevel;
 use crate::error::Result;
+use crate::history::format::{SessionFormat, pi_log};
 use crate::history::{Conversation, Source, omp_loader, parser};
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -24,6 +25,10 @@ impl SessionProvider for OmpProvider {
     fn storage(&self) -> Option<&dyn SessionStorage> {
         Some(&OmpStorage)
     }
+
+    fn format(&self) -> Option<&dyn SessionFormat> {
+        Some(&pi_log::OMP_LOG)
+    }
 }
 
 struct OmpStorage;
@@ -41,8 +46,9 @@ impl SessionStorage for OmpStorage {
         Ok(vec![omp_loader::session_root()?])
     }
 
-    /// OMP's own tree holds OMP transcripts, but a redirected session directory
-    /// may hold Pi-format files, which have to be sniffed rather than assumed.
+    /// Everything under OMP's own tree is OMP's, title slot or not. A redirected
+    /// session directory belongs to no one in particular, so its files are left to
+    /// the registry to attribute rather than claimed outright.
     fn parse_session(
         &self,
         path: PathBuf,
@@ -51,7 +57,7 @@ impl SessionStorage for OmpStorage {
         debug_level: Option<DebugLevel>,
     ) -> Result<Option<Conversation>> {
         if root_is_omp_owned(root) {
-            parser::process_omp_conversation_file(path, modified, debug_level)
+            parser::process_session_file(path, &pi_log::OMP_LOG, modified, debug_level)
         } else {
             parser::process_conversation_file(path, modified, debug_level)
         }
@@ -66,4 +72,43 @@ fn root_is_omp_owned(root: &SessionRoot) -> bool {
     root.path
         .components()
         .any(|component| matches!(component.as_os_str().to_str(), Some(".omp" | "omp")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed_source(root: SessionRoot) -> Source {
+        std::fs::create_dir_all(&root.path).unwrap();
+        let path = root.path.join("session.jsonl");
+        std::fs::copy(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/pi/v3-branched.jsonl"),
+            &path,
+        )
+        .unwrap();
+        OmpStorage
+            .parse_session(path, &root, None, None)
+            .unwrap()
+            .unwrap()
+            .source
+    }
+
+    /// A transcript with no OMP title slot cannot say which agent wrote it, so the
+    /// tree holding it decides. Attributing it wrongly would also mislabel every
+    /// assistant turn in the viewer.
+    #[test]
+    fn an_untitled_transcript_belongs_to_the_tree_that_holds_it() {
+        let directory = tempfile::tempdir().unwrap();
+        assert_eq!(
+            parsed_source(SessionRoot::flat(
+                directory.path().join(".omp/agent/sessions")
+            )),
+            Source::Omp
+        );
+        assert_eq!(
+            parsed_source(SessionRoot::flat(directory.path().join("redirected"))),
+            Source::Pi
+        );
+    }
 }

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -2,7 +2,7 @@
 
 use super::{
     PathResumeLauncher, RefNamespaces, RootOrigin, SessionCache, SessionLauncher, SessionProvider,
-    SessionRoot, SessionStorage, SourceLabels,
+    SessionRoot, SessionStorage, SessionStub, SourceLabels, walk,
 };
 use crate::cli::DebugLevel;
 use crate::error::Result;
@@ -84,7 +84,17 @@ impl SessionStorage for OmpStorage {
     }
 
     fn roots(&self) -> Result<Vec<SessionRoot>> {
-        Ok(vec![omp_loader::session_root()?])
+        Ok(vec![omp_loader::session_root()?.root])
+    }
+
+    /// The walk depth belongs to the resolution that produced the root, so it
+    /// is re-resolved here rather than guessed from the path.
+    fn discover(&self, root: &SessionRoot) -> Result<Vec<SessionStub>> {
+        let depth = omp_loader::session_root()?.depth;
+        Ok(walk::file_stubs(
+            root,
+            walk::jsonl_files_at_depth(&root.path, depth)?,
+        ))
     }
 
     /// Everything under OMP's own tree is OMP's, title slot or not. A redirected
@@ -161,11 +171,11 @@ mod tests {
     fn an_untitled_transcript_belongs_to_the_tree_that_holds_it() {
         let directory = tempfile::tempdir().unwrap();
         assert_eq!(
-            parsed_source(SessionRoot::flat(directory.path().join("own-tree")).in_agent_tree()),
+            parsed_source(SessionRoot::new(directory.path().join("own-tree")).in_agent_tree()),
             Source::Omp
         );
         assert_eq!(
-            parsed_source(SessionRoot::flat(directory.path().join("redirected"))),
+            parsed_source(SessionRoot::new(directory.path().join("redirected"))),
             Source::Pi,
             "a directory the user redirected OMP to can hold Pi's transcripts"
         );

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,6 +1,9 @@
 //! OMP sessions, stored under `~/.omp/agent/sessions/`.
 
-use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
+use super::{
+    PathResumeLauncher, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
+    SessionStorage, SourceLabels,
+};
 use crate::cli::DebugLevel;
 use crate::error::Result;
 use crate::history::format::{SessionFormat, pi_log};
@@ -29,7 +32,17 @@ impl SessionProvider for OmpProvider {
     fn format(&self) -> Option<&dyn SessionFormat> {
         Some(&pi_log::OMP_LOG)
     }
+
+    fn launcher(&self) -> &dyn SessionLauncher {
+        &LAUNCHER
+    }
 }
+
+static LAUNCHER: PathResumeLauncher = PathResumeLauncher {
+    program: "omp",
+    resume_flag: "--resume",
+    fork_flag: "--fork",
+};
 
 struct OmpStorage;
 

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -5,10 +5,10 @@ use super::{
     SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
-use crate::error::Result;
-use crate::history::format::{SessionFormat, pi_log};
+use crate::error::{AppError, Result};
+use crate::history::format::{self, SessionFormat, pi_log};
 use crate::history::{Conversation, Source, omp_loader, parser};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 pub struct OmpProvider;
@@ -35,6 +35,26 @@ impl SessionProvider for OmpProvider {
 
     fn launcher(&self) -> &dyn SessionLauncher {
         &LAUNCHER
+    }
+
+    fn rename_session(&self, path: &Path, title: &str) -> Result<()> {
+        pi_log::append_omp_session_rename(path, title)
+    }
+
+    /// OMP keeps a session's tool results in a directory named after the
+    /// transcript, so deleting the transcript alone would orphan it.
+    fn delete_session(&self, path: &Path) -> Result<()> {
+        if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
+            || !format::owns_transcript(Source::Omp, path)
+        {
+            return Err(AppError::SessionNotFound(path.display().to_string()));
+        }
+        std::fs::remove_file(path)?;
+        let artifacts = path.with_extension("");
+        if artifacts.is_dir() {
+            std::fs::remove_dir_all(artifacts)?;
+        }
+        Ok(())
     }
 }
 
@@ -110,6 +130,28 @@ mod tests {
     /// A transcript with no OMP title slot cannot say which agent wrote it, so the
     /// tree holding it decides. Attributing it wrongly would also mislabel every
     /// assistant turn in the viewer.
+    #[test]
+    fn deleting_a_session_takes_its_artifact_directory_with_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let session = directory.path().join("session.jsonl");
+        std::fs::copy(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/omp/v3.jsonl"),
+            &session,
+        )
+        .unwrap();
+        let artifacts = directory.path().join("session");
+        std::fs::create_dir_all(artifacts.join("tool-results")).unwrap();
+        std::fs::write(artifacts.join("tool-results/output.txt"), "result").unwrap();
+
+        OmpProvider.delete_session(&session).unwrap();
+
+        assert!(!session.exists());
+        assert!(
+            !artifacts.exists(),
+            "tool results named after the transcript would be orphaned"
+        );
+    }
+
     #[test]
     fn an_untitled_transcript_belongs_to_the_tree_that_holds_it() {
         let directory = tempfile::tempdir().unwrap();

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,7 +1,7 @@
 //! OMP sessions, stored under `~/.omp/agent/sessions/`.
 
 use super::{
-    PathResumeLauncher, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
+    PathResumeLauncher, RefNamespaces, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
     SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
@@ -22,6 +22,14 @@ impl SessionProvider for OmpProvider {
         SourceLabels {
             name: "omp",
             list: "OMP",
+            display: "OMP",
+        }
+    }
+
+    fn ref_namespaces(&self) -> RefNamespaces {
+        RefNamespaces {
+            conversation: Some("agent-omp-v1"),
+            project: "agent-omp-project-v1",
         }
     }
 

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,11 +1,11 @@
 //! OMP sessions, stored under `~/.omp/agent/sessions/`.
 
 use super::{
-    PathResumeLauncher, RefNamespaces, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
-    SessionStorage, SourceLabels,
+    PathResumeLauncher, RefNamespaces, RootOrigin, SessionCache, SessionLauncher, SessionProvider,
+    SessionRoot, SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::history::format::{self, SessionFormat, pi_log};
 use crate::history::{Conversation, Source, omp_loader, parser};
 use std::path::{Path, PathBuf};
@@ -52,11 +52,7 @@ impl SessionProvider for OmpProvider {
     /// OMP keeps a session's tool results in a directory named after the
     /// transcript, so deleting the transcript alone would orphan it.
     fn delete_session(&self, path: &Path) -> Result<()> {
-        if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-            || !format::owns_transcript(Source::Omp, path)
-        {
-            return Err(AppError::SessionNotFound(path.display().to_string()));
-        }
+        format::require_owned_transcript(Source::Omp, path)?;
         std::fs::remove_file(path)?;
         let artifacts = path.with_extension("");
         if artifacts.is_dir() {
@@ -75,6 +71,10 @@ static LAUNCHER: PathResumeLauncher = PathResumeLauncher {
 struct OmpStorage;
 
 impl SessionStorage for OmpStorage {
+    fn source(&self) -> Source {
+        Source::Omp
+    }
+
     fn cache(&self) -> SessionCache {
         SessionCache {
             directory: "omp",
@@ -97,22 +97,19 @@ impl SessionStorage for OmpStorage {
         modified: Option<SystemTime>,
         debug_level: Option<DebugLevel>,
     ) -> Result<Option<Conversation>> {
-        if root_is_omp_owned(root) {
-            parser::process_session_file(path, &pi_log::OMP_LOG, modified, debug_level)
-        } else {
-            parser::process_conversation_file(path, modified, debug_level)
+        match root.origin() {
+            RootOrigin::AgentTree => {
+                parser::process_session_file(path, &pi_log::OMP_LOG, modified, debug_level)
+            }
+            RootOrigin::Redirected => {
+                parser::process_conversation_file(path, modified, debug_level)
+            }
         }
     }
 
     fn max_session_bytes(&self) -> Option<u64> {
         None
     }
-}
-
-fn root_is_omp_owned(root: &SessionRoot) -> bool {
-    root.path
-        .components()
-        .any(|component| matches!(component.as_os_str().to_str(), Some(".omp" | "omp")))
 }
 
 #[cfg(test)]
@@ -135,9 +132,6 @@ mod tests {
             .source
     }
 
-    /// A transcript with no OMP title slot cannot say which agent wrote it, so the
-    /// tree holding it decides. Attributing it wrongly would also mislabel every
-    /// assistant turn in the viewer.
     #[test]
     fn deleting_a_session_takes_its_artifact_directory_with_it() {
         let directory = tempfile::tempdir().unwrap();
@@ -160,18 +154,20 @@ mod tests {
         );
     }
 
+    /// A transcript with no OMP title slot cannot say which agent wrote it, so the
+    /// tree holding it decides. Attributing it wrongly would also mislabel every
+    /// assistant turn in the viewer.
     #[test]
     fn an_untitled_transcript_belongs_to_the_tree_that_holds_it() {
         let directory = tempfile::tempdir().unwrap();
         assert_eq!(
-            parsed_source(SessionRoot::flat(
-                directory.path().join(".omp/agent/sessions")
-            )),
+            parsed_source(SessionRoot::flat(directory.path().join("own-tree")).in_agent_tree()),
             Source::Omp
         );
         assert_eq!(
             parsed_source(SessionRoot::flat(directory.path().join("redirected"))),
-            Source::Pi
+            Source::Pi,
+            "a directory the user redirected OMP to can hold Pi's transcripts"
         );
     }
 }

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,6 +1,6 @@
 //! OMP sessions, stored under `~/.omp/agent/sessions/`.
 
-use super::{SessionProvider, SourceLabels};
+use super::{SessionCache, SessionProvider, SourceLabels};
 use crate::history::Source;
 
 pub struct OmpProvider;
@@ -15,5 +15,13 @@ impl SessionProvider for OmpProvider {
             name: "omp",
             list: "OMP",
         }
+    }
+
+    fn session_cache(&self) -> Option<SessionCache> {
+        Some(SessionCache {
+            directory: "omp",
+            magic: *b"OMHIST01",
+            schema_version: 1,
+        })
     }
 }

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,7 +1,11 @@
 //! OMP sessions, stored under `~/.omp/agent/sessions/`.
 
-use super::{SessionCache, SessionProvider, SourceLabels};
-use crate::history::Source;
+use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
+use crate::cli::DebugLevel;
+use crate::error::Result;
+use crate::history::{Conversation, Source, omp_loader, parser};
+use std::path::PathBuf;
+use std::time::SystemTime;
 
 pub struct OmpProvider;
 
@@ -17,11 +21,49 @@ impl SessionProvider for OmpProvider {
         }
     }
 
-    fn session_cache(&self) -> Option<SessionCache> {
-        Some(SessionCache {
+    fn storage(&self) -> Option<&dyn SessionStorage> {
+        Some(&OmpStorage)
+    }
+}
+
+struct OmpStorage;
+
+impl SessionStorage for OmpStorage {
+    fn cache(&self) -> SessionCache {
+        SessionCache {
             directory: "omp",
             magic: *b"OMHIST01",
             schema_version: 1,
-        })
+        }
     }
+
+    fn roots(&self) -> Result<Vec<SessionRoot>> {
+        Ok(vec![omp_loader::session_root()?])
+    }
+
+    /// OMP's own tree holds OMP transcripts, but a redirected session directory
+    /// may hold Pi-format files, which have to be sniffed rather than assumed.
+    fn parse_session(
+        &self,
+        path: PathBuf,
+        root: &SessionRoot,
+        modified: Option<SystemTime>,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Option<Conversation>> {
+        if root_is_omp_owned(root) {
+            parser::process_omp_conversation_file(path, modified, debug_level)
+        } else {
+            parser::process_conversation_file(path, modified, debug_level)
+        }
+    }
+
+    fn max_session_bytes(&self) -> Option<u64> {
+        None
+    }
+}
+
+fn root_is_omp_owned(root: &SessionRoot) -> bool {
+    root.path
+        .components()
+        .any(|component| matches!(component.as_os_str().to_str(), Some(".omp" | "omp")))
 }

--- a/src/history/provider/omp.rs
+++ b/src/history/provider/omp.rs
@@ -1,0 +1,19 @@
+//! OMP sessions, stored under `~/.omp/agent/sessions/`.
+
+use super::{SessionProvider, SourceLabels};
+use crate::history::Source;
+
+pub struct OmpProvider;
+
+impl SessionProvider for OmpProvider {
+    fn source(&self) -> Source {
+        Source::Omp
+    }
+
+    fn labels(&self) -> SourceLabels {
+        SourceLabels {
+            name: "omp",
+            list: "OMP",
+        }
+    }
+}

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -1,7 +1,7 @@
 //! Pi coding agent sessions, stored under `~/.pi/agent/sessions/`.
 
 use super::{
-    PathResumeLauncher, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
+    PathResumeLauncher, RefNamespaces, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
     SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
@@ -22,6 +22,14 @@ impl SessionProvider for PiProvider {
         SourceLabels {
             name: "pi",
             list: "Pi",
+            display: "Pi",
+        }
+    }
+
+    fn ref_namespaces(&self) -> RefNamespaces {
+        RefNamespaces {
+            conversation: Some("agent-pi-v1"),
+            project: "agent-pi-project-v1",
         }
     }
 

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -5,10 +5,10 @@ use super::{
     SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
-use crate::error::Result;
-use crate::history::format::{SessionFormat, pi_log};
+use crate::error::{AppError, Result};
+use crate::history::format::{self, SessionFormat, pi_log};
 use crate::history::{Conversation, Source, parser, pi_loader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 pub struct PiProvider;
@@ -35,6 +35,20 @@ impl SessionProvider for PiProvider {
 
     fn launcher(&self) -> &dyn SessionLauncher {
         &LAUNCHER
+    }
+
+    fn rename_session(&self, path: &Path, title: &str) -> Result<()> {
+        pi_log::append_session_rename(path, title)
+    }
+
+    fn delete_session(&self, path: &Path) -> Result<()> {
+        if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
+            || !format::owns_transcript(Source::Pi, path)
+        {
+            return Err(AppError::SessionNotFound(path.display().to_string()));
+        }
+        std::fs::remove_file(path)?;
+        Ok(())
     }
 }
 
@@ -71,5 +85,32 @@ impl SessionStorage for PiStorage {
 
     fn max_session_bytes(&self) -> Option<u64> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_removes_only_the_transcript_pi_owns() {
+        let directory = tempfile::tempdir().unwrap();
+        let session = directory.path().join("session.jsonl");
+        std::fs::copy(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pi/v1.jsonl"),
+            &session,
+        )
+        .unwrap();
+        let sibling = directory.path().join("sibling.txt");
+        std::fs::write(&sibling, "keep").unwrap();
+
+        PiProvider.delete_session(&session).unwrap();
+
+        assert!(!session.exists());
+        assert!(sibling.exists());
+        assert!(
+            PiProvider.delete_session(&sibling).is_err(),
+            "a file Pi does not own must survive a delete aimed at it"
+        );
     }
 }

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -1,7 +1,11 @@
 //! Pi coding agent sessions, stored under `~/.pi/agent/sessions/`.
 
-use super::{SessionCache, SessionProvider, SourceLabels};
-use crate::history::Source;
+use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
+use crate::cli::DebugLevel;
+use crate::error::Result;
+use crate::history::{Conversation, Source, parser, pi_loader};
+use std::path::PathBuf;
+use std::time::SystemTime;
 
 pub struct PiProvider;
 
@@ -17,11 +21,37 @@ impl SessionProvider for PiProvider {
         }
     }
 
-    fn session_cache(&self) -> Option<SessionCache> {
-        Some(SessionCache {
+    fn storage(&self) -> Option<&dyn SessionStorage> {
+        Some(&PiStorage)
+    }
+}
+
+struct PiStorage;
+
+impl SessionStorage for PiStorage {
+    fn cache(&self) -> SessionCache {
+        SessionCache {
             directory: "pi",
             magic: *b"PIHIST01",
             schema_version: 1,
-        })
+        }
+    }
+
+    fn roots(&self) -> Result<Vec<SessionRoot>> {
+        Ok(vec![pi_loader::session_root()?])
+    }
+
+    fn parse_session(
+        &self,
+        path: PathBuf,
+        _root: &SessionRoot,
+        modified: Option<SystemTime>,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Option<Conversation>> {
+        parser::process_conversation_file(path, modified, debug_level)
+    }
+
+    fn max_session_bytes(&self) -> Option<u64> {
+        None
     }
 }

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -2,7 +2,7 @@
 
 use super::{
     PathResumeLauncher, RefNamespaces, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
-    SessionStorage, SourceLabels,
+    SessionStorage, SessionStub, SourceLabels, walk,
 };
 use crate::cli::DebugLevel;
 use crate::error::Result;
@@ -78,7 +78,17 @@ impl SessionStorage for PiStorage {
     }
 
     fn roots(&self) -> Result<Vec<SessionRoot>> {
-        Ok(vec![pi_loader::session_root()?])
+        Ok(vec![pi_loader::session_root()?.root])
+    }
+
+    /// The walk depth belongs to the resolution that produced the root, so it
+    /// is re-resolved here rather than guessed from the path.
+    fn discover(&self, root: &SessionRoot) -> Result<Vec<SessionStub>> {
+        let depth = pi_loader::session_root()?.depth;
+        Ok(walk::file_stubs(
+            root,
+            walk::jsonl_files_at_depth(&root.path, depth)?,
+        ))
     }
 
     fn parse_session(

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -1,6 +1,9 @@
 //! Pi coding agent sessions, stored under `~/.pi/agent/sessions/`.
 
-use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
+use super::{
+    PathResumeLauncher, SessionCache, SessionLauncher, SessionProvider, SessionRoot,
+    SessionStorage, SourceLabels,
+};
 use crate::cli::DebugLevel;
 use crate::error::Result;
 use crate::history::format::{SessionFormat, pi_log};
@@ -29,7 +32,17 @@ impl SessionProvider for PiProvider {
     fn format(&self) -> Option<&dyn SessionFormat> {
         Some(&pi_log::PI_LOG)
     }
+
+    fn launcher(&self) -> &dyn SessionLauncher {
+        &LAUNCHER
+    }
 }
+
+static LAUNCHER: PathResumeLauncher = PathResumeLauncher {
+    program: "pi",
+    resume_flag: "--session",
+    fork_flag: "--fork",
+};
 
 struct PiStorage;
 

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -3,6 +3,7 @@
 use super::{SessionCache, SessionProvider, SessionRoot, SessionStorage, SourceLabels};
 use crate::cli::DebugLevel;
 use crate::error::Result;
+use crate::history::format::{SessionFormat, pi_log};
 use crate::history::{Conversation, Source, parser, pi_loader};
 use std::path::PathBuf;
 use std::time::SystemTime;
@@ -23,6 +24,10 @@ impl SessionProvider for PiProvider {
 
     fn storage(&self) -> Option<&dyn SessionStorage> {
         Some(&PiStorage)
+    }
+
+    fn format(&self) -> Option<&dyn SessionFormat> {
+        Some(&pi_log::PI_LOG)
     }
 }
 
@@ -48,7 +53,7 @@ impl SessionStorage for PiStorage {
         modified: Option<SystemTime>,
         debug_level: Option<DebugLevel>,
     ) -> Result<Option<Conversation>> {
-        parser::process_conversation_file(path, modified, debug_level)
+        parser::process_session_file(path, &pi_log::PI_LOG, modified, debug_level)
     }
 
     fn max_session_bytes(&self) -> Option<u64> {

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -1,0 +1,19 @@
+//! Pi coding agent sessions, stored under `~/.pi/agent/sessions/`.
+
+use super::{SessionProvider, SourceLabels};
+use crate::history::Source;
+
+pub struct PiProvider;
+
+impl SessionProvider for PiProvider {
+    fn source(&self) -> Source {
+        Source::Pi
+    }
+
+    fn labels(&self) -> SourceLabels {
+        SourceLabels {
+            name: "pi",
+            list: "Pi",
+        }
+    }
+}

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -1,6 +1,6 @@
 //! Pi coding agent sessions, stored under `~/.pi/agent/sessions/`.
 
-use super::{SessionProvider, SourceLabels};
+use super::{SessionCache, SessionProvider, SourceLabels};
 use crate::history::Source;
 
 pub struct PiProvider;
@@ -15,5 +15,13 @@ impl SessionProvider for PiProvider {
             name: "pi",
             list: "Pi",
         }
+    }
+
+    fn session_cache(&self) -> Option<SessionCache> {
+        Some(SessionCache {
+            directory: "pi",
+            magic: *b"PIHIST01",
+            schema_version: 1,
+        })
     }
 }

--- a/src/history/provider/pi.rs
+++ b/src/history/provider/pi.rs
@@ -5,7 +5,7 @@ use super::{
     SessionStorage, SourceLabels,
 };
 use crate::cli::DebugLevel;
-use crate::error::{AppError, Result};
+use crate::error::Result;
 use crate::history::format::{self, SessionFormat, pi_log};
 use crate::history::{Conversation, Source, parser, pi_loader};
 use std::path::{Path, PathBuf};
@@ -50,11 +50,7 @@ impl SessionProvider for PiProvider {
     }
 
     fn delete_session(&self, path: &Path) -> Result<()> {
-        if path.extension().and_then(|extension| extension.to_str()) != Some("jsonl")
-            || !format::owns_transcript(Source::Pi, path)
-        {
-            return Err(AppError::SessionNotFound(path.display().to_string()));
-        }
+        format::require_owned_transcript(Source::Pi, path)?;
         std::fs::remove_file(path)?;
         Ok(())
     }
@@ -69,6 +65,10 @@ static LAUNCHER: PathResumeLauncher = PathResumeLauncher {
 struct PiStorage;
 
 impl SessionStorage for PiStorage {
+    fn source(&self) -> Source {
+        Source::Pi
+    }
+
     fn cache(&self) -> SessionCache {
         SessionCache {
             directory: "pi",

--- a/src/history/provider/storage.rs
+++ b/src/history/provider/storage.rs
@@ -1,0 +1,55 @@
+//! Providers that keep whole session transcripts under one or more roots.
+
+use super::SessionRoot;
+use crate::cli::DebugLevel;
+use crate::error::Result;
+use crate::history::Conversation;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+/// On-disk identity of a provider's whole-root session cache.
+///
+/// All three fields are a compatibility contract with caches users already have:
+/// `directory` names the folder under `~/.cache/claude-history`, and `magic` plus
+/// `schema_version` stamp the file so an incompatible one is discarded rather
+/// than misread. Changing any of them silently invalidates existing caches.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SessionCache {
+    pub directory: &'static str,
+    pub magic: [u8; 8],
+    pub schema_version: u32,
+}
+
+/// How a provider finds, bounds and parses the sessions under its roots.
+///
+/// Claude is deliberately absent: its transcripts are partitioned by project
+/// directory and loaded through machinery that predates and outgrows this shape,
+/// so it reports no storage rather than pretending to fit.
+pub trait SessionStorage: Sync {
+    fn cache(&self) -> SessionCache;
+
+    /// Every directory this provider stores sessions under, in the order they
+    /// should be searched.
+    fn roots(&self) -> Result<Vec<SessionRoot>>;
+
+    /// Parse one transcript into a conversation, or `None` if the file holds
+    /// nothing this provider recognizes.
+    ///
+    /// `root` is supplied because the user can redirect a provider's session
+    /// directory outside the agent's own tree, where transcripts may be written
+    /// in a sibling agent's format.
+    fn parse_session(
+        &self,
+        path: PathBuf,
+        root: &SessionRoot,
+        modified: Option<SystemTime>,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Option<Conversation>>;
+
+    /// Largest transcript worth parsing, or `None` to accept any size.
+    ///
+    /// A cap trades completeness for a bounded worst case: a single rollout can
+    /// run to hundreds of megabytes, and its parsed text is held in memory and
+    /// written to the cache for the lifetime of the process.
+    fn max_session_bytes(&self) -> Option<u64>;
+}

--- a/src/history/provider/storage.rs
+++ b/src/history/provider/storage.rs
@@ -20,6 +20,38 @@ pub struct SessionCache {
     pub schema_version: u32,
 }
 
+/// What discovery reports about one session before it is parsed.
+///
+/// The load loop consumes stubs as given: it never stats, opens, or interprets
+/// a locator itself, which is what lets a provider back a session with
+/// something other than a file.
+#[derive(Clone, Debug)]
+pub struct SessionStub {
+    /// Where the session lives, in whatever encoding the provider's own
+    /// format, launcher, rename and delete understand. A file path for
+    /// file-backed providers. Its final component names the session and feeds
+    /// the agent CLI's reference digests, so it must be stable and meaningful.
+    pub locator: PathBuf,
+    /// Cache entry key, stable while the session stays under this root.
+    /// File providers use the locator relative to the root.
+    pub cache_key: String,
+    pub fingerprint: Fingerprint,
+}
+
+/// Change detector: a cached session is reused while its fingerprint is
+/// unchanged. Deliberately the `(size, mtime)` pair the cache already stores,
+/// so caches written before this type existed stay valid.
+///
+/// The fields need not come from a filesystem — a database-backed provider can
+/// derive them from content (total payload bytes, newest row timestamp) — but
+/// `size` also feeds [`SessionStorage::max_session_bytes`], and a session with
+/// no `modified` is parsed on every load rather than cached.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Fingerprint {
+    pub size: u64,
+    pub modified: Option<SystemTime>,
+}
+
 /// How a provider finds, bounds and parses the sessions under its roots.
 ///
 /// Claude is deliberately absent: its transcripts are partitioned by project
@@ -34,11 +66,11 @@ pub trait SessionStorage: Sync {
 
     fn cache(&self) -> SessionCache;
 
-    /// Every directory this provider stores sessions under, in the order they
+    /// Every root this provider stores sessions under, in the order they
     /// should be searched.
     fn roots(&self) -> Result<Vec<SessionRoot>>;
 
-    /// Parse one transcript into a conversation, or `None` if the file holds
+    /// Parse one session into a conversation, or `None` if the locator holds
     /// nothing this provider recognizes.
     ///
     /// `root` is supplied because the user can redirect a provider's session
@@ -46,16 +78,24 @@ pub trait SessionStorage: Sync {
     /// in a sibling agent's format.
     fn parse_session(
         &self,
-        path: PathBuf,
+        locator: PathBuf,
         root: &SessionRoot,
         modified: Option<SystemTime>,
         debug_level: Option<DebugLevel>,
     ) -> Result<Option<Conversation>>;
 
-    /// Largest transcript worth parsing, or `None` to accept any size.
+    /// Largest session worth parsing, or `None` to accept any size.
     ///
     /// A cap trades completeness for a bounded worst case: a single rollout can
     /// run to hundreds of megabytes, and its parsed text is held in memory and
     /// written to the cache for the lifetime of the process.
     fn max_session_bytes(&self) -> Option<u64>;
+
+    /// Every session under `root`, as stubs the load loop consumes without
+    /// touching the sessions themselves.
+    ///
+    /// There is deliberately no default: how sessions are arranged inside a
+    /// root is the provider's own knowledge. File-backed providers compose the
+    /// helpers in [`walk`](super::walk).
+    fn discover(&self, root: &SessionRoot) -> Result<Vec<SessionStub>>;
 }

--- a/src/history/provider/storage.rs
+++ b/src/history/provider/storage.rs
@@ -3,7 +3,7 @@
 use super::SessionRoot;
 use crate::cli::DebugLevel;
 use crate::error::Result;
-use crate::history::Conversation;
+use crate::history::{Conversation, Source};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -26,6 +26,12 @@ pub struct SessionCache {
 /// directory and loaded through machinery that predates and outgrows this shape,
 /// so it reports no storage rather than pretending to fit.
 pub trait SessionStorage: Sync {
+    /// Whose sessions these are. A redirected root can hold a sibling agent's
+    /// transcripts, so the load loop keeps only what this source claims — and
+    /// stamping, caching and diagnostics all follow from here rather than from a
+    /// second argument that could disagree.
+    fn source(&self) -> Source;
+
     fn cache(&self) -> SessionCache;
 
     /// Every directory this provider stores sessions under, in the order they

--- a/src/history/provider/walk.rs
+++ b/src/history/provider/walk.rs
@@ -1,0 +1,199 @@
+//! File-tree helpers for providers whose sessions are transcript files.
+//!
+//! The core never walks a directory itself — each file-backed provider states
+//! its own tree shape by composing these from its
+//! [`discover`](super::SessionStorage::discover). A new file-based agent is
+//! these calls plus a format.
+
+use super::{Fingerprint, SessionRoot, SessionStub};
+use crate::error::Result;
+use std::fs::read_dir;
+use std::path::{Path, PathBuf};
+
+/// A resolved session root whose transcripts are plain files `depth` directory
+/// levels below it: 0 beside the root itself, 1 in a directory per project,
+/// 3 in Codex's `YYYY/MM/DD` tree.
+///
+/// The pairing lives with the code that resolved the root; the core only ever
+/// sees the [`SessionRoot`] inside.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FileRoot {
+    pub root: SessionRoot,
+    pub depth: usize,
+}
+
+/// The `.jsonl` files exactly `depth` directory levels below `directory`,
+/// sorted so successive runs agree.
+///
+/// Fixed depth rather than recursion, so a symlink cycle inside the tree
+/// cannot make the walk unbounded; `is_dir` follows symlinks, so a project
+/// directory linked into the tree is still searched. A directory that does
+/// not exist yields no files rather than an error: an agent the user has not
+/// installed is an absence, not a failure.
+pub fn jsonl_files_at_depth(directory: &Path, depth: usize) -> Result<Vec<PathBuf>> {
+    if !directory.exists() {
+        return Ok(Vec::new());
+    }
+    let mut parents = vec![directory.to_path_buf()];
+    for _ in 0..depth {
+        let mut children = Vec::new();
+        for parent in &parents {
+            children.extend(subdirectories(parent)?);
+        }
+        parents = children;
+    }
+    let mut files = Vec::new();
+    for parent in &parents {
+        collect_jsonl_files(parent, &mut files)?;
+    }
+    files.sort();
+    Ok(files)
+}
+
+/// Stat each file into a [`SessionStub`], keyed by its path relative to the
+/// root. A file that cannot be stat — vanished between enumeration and here —
+/// is skipped rather than failing the whole root.
+pub fn file_stubs(root: &SessionRoot, files: Vec<PathBuf>) -> Vec<SessionStub> {
+    files
+        .into_iter()
+        .filter_map(|path| {
+            let metadata = std::fs::metadata(&path).ok()?;
+            // Keys are relative to the root, so a root that moves misses
+            // cleanly rather than colliding with its old contents.
+            let cache_key = path
+                .strip_prefix(&root.path)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            Some(SessionStub {
+                fingerprint: Fingerprint {
+                    size: metadata.len(),
+                    modified: metadata.modified().ok(),
+                },
+                locator: path,
+                cache_key,
+            })
+        })
+        .collect()
+}
+
+/// The `.jsonl` files directly inside `directory`.
+pub fn collect_jsonl_files(directory: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in read_dir(directory)? {
+        let path = entry?.path();
+        if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+pub fn subdirectories(parent: &Path) -> Result<Vec<PathBuf>> {
+    let mut directories = Vec::new();
+    for entry in read_dir(parent)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            directories.push(path);
+        }
+    }
+    Ok(directories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_transcript(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "{}\n").unwrap();
+    }
+
+    #[test]
+    fn a_missing_directory_yields_no_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let files = jsonl_files_at_depth(&directory.path().join("never-created"), 0).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn depth_zero_takes_only_jsonl_beside_the_root() {
+        let directory = tempfile::tempdir().unwrap();
+        write_transcript(&directory.path().join("session.jsonl"));
+        write_transcript(&directory.path().join("notes.txt"));
+        write_transcript(&directory.path().join("nested/deeper.jsonl"));
+
+        let files = jsonl_files_at_depth(directory.path(), 0).unwrap();
+        assert_eq!(files, vec![directory.path().join("session.jsonl")]);
+    }
+
+    #[test]
+    fn depth_one_skips_transcripts_in_the_root_itself() {
+        let directory = tempfile::tempdir().unwrap();
+        write_transcript(&directory.path().join("stray.jsonl"));
+        write_transcript(&directory.path().join("project-b/second.jsonl"));
+        write_transcript(&directory.path().join("project-a/first.jsonl"));
+
+        let files = jsonl_files_at_depth(directory.path(), 1).unwrap();
+        assert_eq!(
+            files,
+            vec![
+                directory.path().join("project-a/first.jsonl"),
+                directory.path().join("project-b/second.jsonl"),
+            ],
+            "child directories are searched, the root is not, and results are sorted"
+        );
+    }
+
+    #[test]
+    fn depth_three_takes_only_jsonl_exactly_three_levels_down() {
+        let directory = tempfile::tempdir().unwrap();
+        let listed = directory.path().join("2026/08/19/session.jsonl");
+        write_transcript(&listed);
+        write_transcript(&directory.path().join("2026/08/too-shallow.jsonl"));
+        write_transcript(&directory.path().join("2026/08/19/deeper/too-deep.jsonl"));
+        write_transcript(&directory.path().join("2026/08/19/notes.txt"));
+
+        let files = jsonl_files_at_depth(directory.path(), 3).unwrap();
+        assert_eq!(files, vec![listed]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn depth_one_follows_symlinked_project_directories() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("elsewhere");
+        let root = directory.path().join("sessions");
+        write_transcript(&target.join("session.jsonl"));
+        std::fs::create_dir_all(&root).unwrap();
+        symlink(&target, root.join("linked-project")).unwrap();
+
+        let files = jsonl_files_at_depth(&root, 1).unwrap();
+        assert_eq!(files, vec![root.join("linked-project/session.jsonl")]);
+    }
+
+    #[test]
+    fn file_stubs_key_by_location_within_the_root_and_skip_vanished_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let present = directory.path().join("project").join("session.jsonl");
+        write_transcript(&present);
+
+        let root = SessionRoot::new(directory.path());
+        let stubs = file_stubs(
+            &root,
+            vec![present.clone(), directory.path().join("vanished.jsonl")],
+        );
+
+        assert_eq!(stubs.len(), 1, "a file that cannot be stat is not a stub");
+        assert_eq!(stubs[0].locator, present);
+        assert_eq!(
+            stubs[0].cache_key,
+            PathBuf::from("project")
+                .join("session.jsonl")
+                .to_string_lossy()
+        );
+        assert_eq!(stubs[0].fingerprint.size, 3);
+        assert!(stubs[0].fingerprint.modified.is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,67 @@ fn run() -> Result<()> {
     Ok(())
 }
 
+fn tui_search_mode(mode: TuiSearchMode) -> ListSearchMode {
+    match mode {
+        TuiSearchMode::Lexical => ListSearchMode::Lexical,
+        TuiSearchMode::Semantic => ListSearchMode::Semantic,
+    }
+}
+
+fn resume_with_agent(
+    source: history::Source,
+    selected_path: &Path,
+    project_path: Option<&PathBuf>,
+    default_args: &[String],
+    fork_session: bool,
+) -> Result<()> {
+    let launch = history::provider::SessionLaunch {
+        path: selected_path,
+        project_path: project_path.map(PathBuf::as_path),
+        configured_args: default_args,
+    };
+    let launcher = source.provider().launcher();
+    let command = if fork_session {
+        launcher.fork_command(&launch)?
+    } else {
+        launcher.resume_command(&launch)?
+    };
+    run_claude_command(command)
+}
+
+fn format_debug_age(age: chrono::Duration) -> String {
+    let hours = age.num_hours();
+    if hours < 24 {
+        format!("{}h", hours)
+    } else {
+        format!("{}d", hours / 24)
+    }
+}
+
+#[cfg(unix)]
+fn run_claude_command(mut command: Command) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    let err = command.exec();
+    Err(AppError::ClaudeExecutionError(err.to_string()))
+}
+
+#[cfg(not(unix))]
+fn run_claude_command(mut command: Command) -> Result<()> {
+    let status = command
+        .status()
+        .map_err(|e| AppError::ClaudeExecutionError(e.to_string()))?;
+
+    if !status.success() {
+        return Err(AppError::ClaudeExecutionError(format!(
+            "claude CLI exited with status {}",
+            status
+        )));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod agent_command_tests {
     use super::*;
@@ -564,45 +625,6 @@ mod agent_command_tests {
     use crate::agent::test_support::{assistant_jsonl_line as assistant, user_jsonl_line as user};
     use crate::search::mode::SearchMode;
     use cli::{AgentOutlineArgs, AgentOutputFlags, AgentReadArgs};
-
-    #[test]
-    fn pi_resume_and_fork_commands_use_native_paths_without_claude_defaults() {
-        let path = PathBuf::from("/tmp/pi sessions/session.jsonl");
-        let cwd = PathBuf::from("/tmp/project");
-        let resume = build_pi_resume_command(&path, Some(&cwd), false);
-        assert_eq!(
-            resume.get_args().collect::<Vec<_>>(),
-            vec![std::ffi::OsStr::new("--session"), path.as_os_str()]
-        );
-        assert_eq!(resume.get_current_dir(), Some(cwd.as_path()));
-
-        let fork = build_pi_resume_command(&path, Some(&cwd), true);
-        assert_eq!(
-            fork.get_args().collect::<Vec<_>>(),
-            vec![std::ffi::OsStr::new("--fork"), path.as_os_str()]
-        );
-        assert_eq!(fork.get_current_dir(), None);
-    }
-
-    #[test]
-    fn omp_resume_and_fork_commands_use_native_paths() {
-        let path = PathBuf::from("/tmp/omp sessions/session.jsonl");
-        let cwd = PathBuf::from("/tmp/project");
-        let resume = build_omp_resume_command(&path, Some(&cwd), false);
-        assert_eq!(resume.get_program(), std::ffi::OsStr::new("omp"));
-        assert_eq!(
-            resume.get_args().collect::<Vec<_>>(),
-            vec![std::ffi::OsStr::new("--resume"), path.as_os_str()]
-        );
-        assert_eq!(resume.get_current_dir(), Some(cwd.as_path()));
-
-        let fork = build_omp_resume_command(&path, Some(&cwd), true);
-        assert_eq!(
-            fork.get_args().collect::<Vec<_>>(),
-            vec![std::ffi::OsStr::new("--fork"), path.as_os_str()]
-        );
-        assert_eq!(fork.get_current_dir(), None);
-    }
 
     fn key(project: &str, filename: &str) -> AgentConversationKey {
         AgentConversationKey::new(
@@ -1726,309 +1748,4 @@ mod agent_command_tests {
 
         assert!(err.to_string().contains("exceeds transcript length"));
     }
-
-    #[test]
-    fn resume_action_uses_cwd_when_it_maps_to_selected_project_dir() {
-        let cwd = tempfile::tempdir().unwrap();
-        let stale_project = tempfile::tempdir().unwrap();
-        let stale_project_path = stale_project.path().to_path_buf();
-        let selected_path = history::get_claude_projects_dir(cwd.path())
-            .unwrap()
-            .join("12345678-1234-4234-9234-123456789abc.jsonl");
-
-        let action = resolve_claude_resume_action(
-            &selected_path,
-            Some(&stale_project_path),
-            cwd.path(),
-            false,
-        )
-        .unwrap();
-
-        assert_eq!(
-            action,
-            ClaudeResumeAction::Run {
-                current_dir: cwd.path().to_path_buf()
-            }
-        );
-    }
-
-    #[test]
-    fn resume_action_uses_project_path_when_it_maps_to_selected_project_dir() {
-        let cwd = tempfile::tempdir().unwrap();
-        let project = tempfile::tempdir().unwrap();
-        let project_path = project.path().to_path_buf();
-        let selected_path = history::get_claude_projects_dir(project.path())
-            .unwrap()
-            .join("12345678-1234-4234-9234-123456789abc.jsonl");
-
-        let action =
-            resolve_claude_resume_action(&selected_path, Some(&project_path), cwd.path(), false)
-                .unwrap();
-
-        assert_eq!(
-            action,
-            ClaudeResumeAction::Run {
-                current_dir: project.path().to_path_buf()
-            }
-        );
-    }
-
-    #[test]
-    fn resume_action_copies_selected_transcript_when_project_path_maps_elsewhere() {
-        let cwd = tempfile::tempdir().unwrap();
-        let selected_project = tempfile::tempdir().unwrap();
-        let stale_project = tempfile::tempdir().unwrap();
-        let stale_project_path = stale_project.path().to_path_buf();
-        let selected_path = history::get_claude_projects_dir(selected_project.path())
-            .unwrap()
-            .join("12345678-1234-4234-9234-123456789abc.jsonl");
-        let cwd_projects_dir = history::get_claude_projects_dir(cwd.path()).unwrap();
-
-        let action = resolve_claude_resume_action(
-            &selected_path,
-            Some(&stale_project_path),
-            cwd.path(),
-            false,
-        )
-        .unwrap();
-
-        assert_eq!(
-            action,
-            ClaudeResumeAction::CopyToCurrent { cwd_projects_dir }
-        );
-    }
-}
-
-fn tui_search_mode(mode: TuiSearchMode) -> ListSearchMode {
-    match mode {
-        TuiSearchMode::Lexical => ListSearchMode::Lexical,
-        TuiSearchMode::Semantic => ListSearchMode::Semantic,
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-enum ClaudeResumeAction {
-    Run { current_dir: PathBuf },
-    CopyToCurrent { cwd_projects_dir: PathBuf },
-}
-
-fn resolve_claude_resume_action(
-    selected_path: &Path,
-    project_path: Option<&PathBuf>,
-    cwd: &Path,
-    fork_session: bool,
-) -> Result<ClaudeResumeAction> {
-    let conv_projects_dir = selected_path.parent().ok_or_else(|| {
-        AppError::ClaudeExecutionError(
-            "Cannot determine conversation's project directory".to_string(),
-        )
-    })?;
-    let cwd_projects_dir = history::get_claude_projects_dir(cwd)?;
-    let project_dir = project_path.filter(|p| p.exists() && p.is_dir());
-
-    if project_dir.is_none() || (fork_session && cwd_projects_dir != conv_projects_dir) {
-        return Ok(ClaudeResumeAction::CopyToCurrent { cwd_projects_dir });
-    }
-
-    if cwd_projects_dir == conv_projects_dir {
-        return Ok(ClaudeResumeAction::Run {
-            current_dir: cwd.to_path_buf(),
-        });
-    }
-
-    let project_dir = project_dir.unwrap();
-    let project_projects_dir = history::get_claude_projects_dir(project_dir)?;
-    if project_projects_dir == conv_projects_dir {
-        Ok(ClaudeResumeAction::Run {
-            current_dir: project_dir.clone(),
-        })
-    } else {
-        Ok(ClaudeResumeAction::CopyToCurrent { cwd_projects_dir })
-    }
-}
-
-fn resume_with_agent(
-    source: history::Source,
-    selected_path: &Path,
-    project_path: Option<&PathBuf>,
-    default_args: &[String],
-    fork_session: bool,
-) -> Result<()> {
-    match source {
-        history::Source::Claude => {
-            resume_with_claude(selected_path, project_path, default_args, fork_session)
-        }
-        history::Source::Pi => run_claude_command(build_pi_resume_command(
-            selected_path,
-            project_path,
-            fork_session,
-        )),
-        history::Source::Omp => run_claude_command(build_omp_resume_command(
-            selected_path,
-            project_path,
-            fork_session,
-        )),
-    }
-}
-
-fn build_pi_resume_command(
-    selected_path: &Path,
-    project_path: Option<&PathBuf>,
-    fork_session: bool,
-) -> Command {
-    let mut command = Command::new("pi");
-    command.arg(if fork_session { "--fork" } else { "--session" });
-    command.arg(selected_path);
-    if !fork_session && let Some(project_path) = project_path {
-        command.current_dir(project_path);
-    }
-    command
-}
-
-fn build_omp_resume_command(
-    selected_path: &Path,
-    project_path: Option<&PathBuf>,
-    fork_session: bool,
-) -> Command {
-    let mut command = Command::new("omp");
-    command.arg(if fork_session { "--fork" } else { "--resume" });
-    command.arg(selected_path);
-    if !fork_session && let Some(project_path) = project_path {
-        command.current_dir(project_path);
-    }
-    command
-}
-
-fn resume_with_claude(
-    selected_path: &Path,
-    project_path: Option<&PathBuf>,
-    default_args: &[String],
-    fork_session: bool,
-) -> Result<()> {
-    let conversation_id = selected_path
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .ok_or_else(|| {
-            AppError::ClaudeExecutionError("Conversation filename is not valid Unicode".to_string())
-        })?
-        .to_owned();
-
-    let cwd = std::env::current_dir().map_err(|e| {
-        AppError::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Failed to get current directory: {}", e),
-        ))
-    })?;
-
-    let conv_projects_dir = selected_path.parent().ok_or_else(|| {
-        AppError::ClaudeExecutionError(
-            "Cannot determine conversation's project directory".to_string(),
-        )
-    })?;
-
-    match resolve_claude_resume_action(selected_path, project_path, &cwd, fork_session)? {
-        ClaudeResumeAction::CopyToCurrent { cwd_projects_dir } => {
-            std::fs::create_dir_all(&cwd_projects_dir).map_err(AppError::Io)?;
-            copy_session_files(
-                selected_path,
-                &conversation_id,
-                conv_projects_dir,
-                &cwd_projects_dir,
-            )?;
-
-            let mut command = Command::new("claude");
-            command.args(["--resume", &conversation_id]);
-            command.args(default_args);
-            command.current_dir(&cwd);
-            run_claude_command(command)
-        }
-        ClaudeResumeAction::Run { current_dir } => {
-            let mut command = Command::new("claude");
-            command.args(["--resume", &conversation_id]);
-            if fork_session {
-                command.arg("--fork-session");
-            }
-            command.args(default_args);
-            command.current_dir(current_dir);
-
-            run_claude_command(command)
-        }
-    }
-}
-
-/// Copy session files from one project directory to another for cross-project forking.
-///
-/// Copies:
-/// 1. The .jsonl transcript file
-/// 2. The session subdirectory (tool-results/, subagents/) if it exists
-/// 3. The file-history directory for undo support if it exists
-fn copy_session_files(
-    jsonl_path: &Path,
-    session_id: &str,
-    source_projects_dir: &Path,
-    target_projects_dir: &Path,
-) -> Result<()> {
-    // 1. Copy the .jsonl file
-    let target_jsonl = target_projects_dir.join(jsonl_path.file_name().unwrap());
-    std::fs::copy(jsonl_path, &target_jsonl).map_err(AppError::Io)?;
-
-    // 2. Copy the session subdirectory (tool-results/, subagents/)
-    let session_dir = source_projects_dir.join(session_id);
-    if session_dir.is_dir() {
-        let target_session_dir = target_projects_dir.join(session_id);
-        copy_dir_recursive(&session_dir, &target_session_dir)?;
-    }
-
-    // Note: file-history (~/.claude/file-history/<uuid>/) is global, not per-project.
-    // Claude Code finds it by session ID, so no copy needed.
-
-    Ok(())
-}
-
-fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
-    std::fs::create_dir_all(dst).map_err(AppError::Io)?;
-    for entry in std::fs::read_dir(src).map_err(AppError::Io)? {
-        let entry = entry.map_err(AppError::Io)?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            std::fs::copy(&src_path, &dst_path).map_err(AppError::Io)?;
-        }
-    }
-    Ok(())
-}
-
-fn format_debug_age(age: chrono::Duration) -> String {
-    let hours = age.num_hours();
-    if hours < 24 {
-        format!("{}h", hours)
-    } else {
-        format!("{}d", hours / 24)
-    }
-}
-
-#[cfg(unix)]
-fn run_claude_command(mut command: Command) -> Result<()> {
-    use std::os::unix::process::CommandExt;
-
-    let err = command.exec();
-    Err(AppError::ClaudeExecutionError(err.to_string()))
-}
-
-#[cfg(not(unix))]
-fn run_claude_command(mut command: Command) -> Result<()> {
-    let status = command
-        .status()
-        .map_err(|e| AppError::ClaudeExecutionError(e.to_string()))?;
-
-    if !status.success() {
-        return Err(AppError::ClaudeExecutionError(format!(
-            "claude CLI exited with status {}",
-            status
-        )));
-    }
-
-    Ok(())
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -318,6 +318,13 @@ impl App {
             selected = Some(0);
         }
 
+        // The registry parse above already attributed the file; a file it did
+        // not claim is read as a raw Claude transcript, as everywhere else.
+        let source = conversations
+            .first()
+            .map(|conversation| conversation.source)
+            .unwrap_or(crate::history::Source::Claude);
+
         Self::from_parts(AppParts {
             conversations_snapshot: Self::conversation_snapshot(&conversations),
             semantic_conversations_snapshot: Self::semantic_snapshot(&conversations),
@@ -328,6 +335,7 @@ impl App {
             loading_state: LoadingState::Ready,
             app_mode: AppMode::View(ViewState::initial(
                 path,
+                source,
                 tool_display,
                 show_thinking,
                 false,

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -246,8 +246,9 @@ impl App {
     }
 
     pub(super) fn perform_export(&mut self, option: usize, to_clipboard: bool) {
-        let (path, options) = match &self.app_mode {
+        let (source, path, options) = match &self.app_mode {
             AppMode::View(state) => (
+                state.conversation_source,
                 state.conversation_path.clone(),
                 crate::tui::export::ExportOptions {
                     show_tools: state.tool_display.is_visible(),
@@ -263,9 +264,9 @@ impl App {
         };
 
         let result = if to_clipboard {
-            crate::tui::export::export_to_clipboard(&path, format, options)
+            crate::tui::export::export_to_clipboard(source, &path, format, options)
         } else {
-            crate::tui::export::export_to_file(&path, format, options)
+            crate::tui::export::export_to_file(source, &path, format, options)
         };
 
         self.status_message = Some((result.message, std::time::Instant::now()));

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -209,9 +209,11 @@ impl App {
         let source = self.conversations[idx].source;
         let rename = match source {
             crate::history::Source::Claude => crate::history::append_session_rename(&path, &title),
-            crate::history::Source::Pi => crate::history::pi::append_session_rename(&path, &title),
+            crate::history::Source::Pi => {
+                crate::history::format::pi_log::append_session_rename(&path, &title)
+            }
             crate::history::Source::Omp => {
-                crate::history::pi::append_omp_session_rename(&path, &title)
+                crate::history::format::pi_log::append_omp_session_rename(&path, &title)
             }
         };
         match rename

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -207,16 +207,9 @@ impl App {
         let path = self.conversations[idx].path.clone();
 
         let source = self.conversations[idx].source;
-        let rename = match source {
-            crate::history::Source::Claude => crate::history::append_session_rename(&path, &title),
-            crate::history::Source::Pi => {
-                crate::history::format::pi_log::append_session_rename(&path, &title)
-            }
-            crate::history::Source::Omp => {
-                crate::history::format::pi_log::append_omp_session_rename(&path, &title)
-            }
-        };
-        match rename
+        match source
+            .provider()
+            .rename_session(&path, &title)
             .and_then(|_| crate::history::process_conversation_file(path.clone(), None, None))
         {
             Ok(Some(mut conv)) => {

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -50,6 +50,9 @@ pub enum AppMode {
 pub struct ViewState {
     /// Path to the conversation file (stable identity)
     pub conversation_path: PathBuf,
+    /// Which agent recorded the conversation; re-parses and exports route
+    /// through this source's own format rather than sniffing the path.
+    pub conversation_source: crate::history::Source,
     /// Parsed renderable entries for the currently open view.
     pub parsed_entries: Option<Arc<Vec<RenderableEntry>>>,
     /// Current scroll position (line offset)
@@ -120,6 +123,7 @@ pub enum ListSearchMode {
 impl ViewState {
     pub(super) fn initial(
         conversation_path: PathBuf,
+        conversation_source: crate::history::Source,
         tool_display: ToolDisplayMode,
         show_thinking: bool,
         show_timing: bool,
@@ -127,6 +131,7 @@ impl ViewState {
     ) -> Self {
         Self {
             conversation_path,
+            conversation_source,
             parsed_entries: None,
             scroll_offset: 0,
             rendered_lines: Vec::new(),

--- a/src/tui/app/view_state.rs
+++ b/src/tui/app/view_state.rs
@@ -16,6 +16,7 @@ impl App {
             return;
         };
         let path = self.conversations[conv_idx].path.clone();
+        let source = self.conversations[conv_idx].source;
 
         let options = RenderOptions {
             tool_display: self.tool_display,
@@ -25,7 +26,7 @@ impl App {
             expanded_tool_outputs: BTreeSet::new(),
         };
 
-        match parse_conversation_file(&path) {
+        match parse_conversation_file(source, &path) {
             Ok(entries) => {
                 let entries = Arc::new(entries);
                 let rendered = render_parsed_conversation(&entries, &options);
@@ -37,6 +38,7 @@ impl App {
                 };
                 self.app_mode = AppMode::View(ViewState {
                     conversation_path: path,
+                    conversation_source: source,
                     parsed_entries: Some(entries),
                     scroll_offset: 0,
                     rendered_lines: rendered.lines,
@@ -238,7 +240,10 @@ impl App {
 
             let entries = match state.parsed_entries.clone() {
                 Some(entries) => entries,
-                None => match parse_conversation_file(&state.conversation_path) {
+                None => match parse_conversation_file(
+                    state.conversation_source,
+                    &state.conversation_path,
+                ) {
                     Ok(entries) => {
                         let entries = Arc::new(entries);
                         state.parsed_entries = Some(entries.clone());
@@ -509,10 +514,14 @@ impl App {
             Self::sync_focus_to_scroll(state, viewport_height);
         }
 
-        let (path, entry_index) = if let AppMode::View(ref state) = self.app_mode {
+        let (source, path, entry_index) = if let AppMode::View(ref state) = self.app_mode {
             if let Some(idx) = state.focused_message {
                 if let Some(msg) = state.message_ranges.get(idx) {
-                    (state.conversation_path.clone(), msg.entry_index)
+                    (
+                        state.conversation_source,
+                        state.conversation_path.clone(),
+                        msg.entry_index,
+                    )
                 } else {
                     return;
                 }
@@ -532,7 +541,7 @@ impl App {
             return;
         };
 
-        match crate::tui::export::extract_message_text(&path, entry_index, options) {
+        match crate::tui::export::extract_message_text(source, &path, entry_index, options) {
             Ok(text) if text.is_empty() => {
                 self.status_message = Some((
                     "No text content in this message".to_string(),

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -66,6 +66,7 @@ pub struct ExportOptions {
 
 /// Export conversation to file
 pub fn export_to_file(
+    source: crate::history::Source,
     source_path: &Path,
     format: ExportFormat,
     options: ExportOptions,
@@ -74,7 +75,7 @@ pub fn export_to_file(
     let ext = format.extension();
     let filename = format!("conversation-{}.{}", timestamp, ext);
 
-    let content = match generate_content(source_path, format, options) {
+    let content = match generate_content(source, source_path, format, options) {
         Ok(c) => c,
         Err(e) => {
             return ExportResult {
@@ -221,11 +222,12 @@ fn copy_via_command(cmd: &str, args: &[&str], text: &str) -> Result<Result<(), S
 
 /// Copy conversation to clipboard
 pub fn export_to_clipboard(
+    source: crate::history::Source,
     source_path: &Path,
     format: ExportFormat,
     options: ExportOptions,
 ) -> ExportResult {
-    let content = match generate_content(source_path, format, options) {
+    let content = match generate_content(source, source_path, format, options) {
         Ok(c) => c,
         Err(e) => {
             return ExportResult {
@@ -248,11 +250,12 @@ pub fn export_to_clipboard(
 /// Extract the text content of a single message by its entry index in the JSONL file.
 /// Returns the message text suitable for clipboard copying.
 pub fn extract_message_text(
+    source: crate::history::Source,
     source_path: &Path,
     entry_index: usize,
     options: ExportOptions,
 ) -> Result<String, String> {
-    let entries = crate::history::normalized_log_entries(source_path)
+    let entries = crate::history::normalized_log_entries(source, source_path)
         .map_err(|e| format!("Failed to read: {e}"))?;
     entries
         .into_iter()
@@ -353,20 +356,30 @@ fn format_entry_for_clipboard(entry: &LogEntry, options: ExportOptions) -> Strin
 
 /// Generate content in the specified format
 fn generate_content(
+    source: crate::history::Source,
     source_path: &Path,
     format: ExportFormat,
     options: ExportOptions,
 ) -> std::io::Result<String> {
     match format {
         ExportFormat::Jsonl => fs::read_to_string(source_path),
-        ExportFormat::Plain => generate_plain(source_path, options),
-        ExportFormat::Markdown => generate_markdown(source_path, options),
-        ExportFormat::Ledger => generate_ledger(source_path, options),
+        ExportFormat::Plain => generate_plain(source, source_path, options),
+        ExportFormat::Markdown => generate_markdown(source, source_path, options),
+        ExportFormat::Ledger => generate_ledger(source, source_path, options),
     }
 }
 
-fn generate_plain_or_markdown_content(
+/// The entries of the conversation at `path`, read through `source`'s format.
+fn export_entries(
+    source: crate::history::Source,
     path: &Path,
+) -> std::io::Result<Vec<(usize, LogEntry)>> {
+    crate::history::normalized_log_entries(source, path)
+        .map_err(|error| std::io::Error::other(error.to_string()))
+}
+
+fn generate_plain_or_markdown_content(
+    entries: Vec<(usize, LogEntry)>,
     options: ExportOptions,
     mut handle_user_text: impl FnMut(&mut String, &str, &str),
     mut handle_user_tool_result: impl FnMut(&mut String, &str, &str),
@@ -374,8 +387,6 @@ fn generate_plain_or_markdown_content(
     mut handle_assistant_tool_use: impl FnMut(&mut String, &str, &str, &serde_json::Value),
     mut handle_assistant_thinking: impl FnMut(&mut String, &str, &str),
 ) -> std::io::Result<String> {
-    let entries = crate::history::normalized_log_entries(path)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
     let mut output = String::new();
 
     for (_, entry) in entries {
@@ -444,9 +455,13 @@ fn generate_plain_or_markdown_content(
 }
 
 /// Generate plain text format (simple "Speaker: message" lines)
-fn generate_plain(path: &Path, options: ExportOptions) -> std::io::Result<String> {
+fn generate_plain(
+    source: crate::history::Source,
+    path: &Path,
+    options: ExportOptions,
+) -> std::io::Result<String> {
     generate_plain_or_markdown_content(
-        path,
+        export_entries(source, path)?,
         options,
         |output, prefix, text| {
             output.push_str(&format!("{}You: {}\n\n", prefix, text));
@@ -468,9 +483,13 @@ fn generate_plain(path: &Path, options: ExportOptions) -> std::io::Result<String
 }
 
 /// Generate markdown format (with ## headers for speakers)
-fn generate_markdown(path: &Path, options: ExportOptions) -> std::io::Result<String> {
+fn generate_markdown(
+    source: crate::history::Source,
+    path: &Path,
+    options: ExportOptions,
+) -> std::io::Result<String> {
     generate_plain_or_markdown_content(
-        path,
+        export_entries(source, path)?,
         options,
         |output, prefix, text| {
             output.push_str(&format!("## {}You\n\n{}\n\n", prefix, text));
@@ -497,9 +516,12 @@ fn generate_markdown(path: &Path, options: ExportOptions) -> std::io::Result<Str
 const LEDGER_WIDTH: usize = 90;
 
 /// Generate ledger-style format (formatted like the TUI viewer)
-fn generate_ledger(path: &Path, options: ExportOptions) -> std::io::Result<String> {
-    let entries = crate::history::normalized_log_entries(path)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
+fn generate_ledger(
+    source: crate::history::Source,
+    path: &Path,
+    options: ExportOptions,
+) -> std::io::Result<String> {
+    let entries = export_entries(source, path)?;
     let mut output = String::new();
 
     const NAME_WIDTH: usize = 9;
@@ -922,9 +944,9 @@ mod tests {
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/pi/v3-branched.jsonl");
         let options = ExportOptions::default();
 
-        let plain = generate_plain(&path, options).unwrap();
-        let markdown = generate_markdown(&path, options).unwrap();
-        let ledger = generate_ledger(&path, options).unwrap();
+        let plain = generate_plain(crate::history::Source::Pi, &path, options).unwrap();
+        let markdown = generate_markdown(crate::history::Source::Pi, &path, options).unwrap();
+        let ledger = generate_ledger(crate::history::Source::Pi, &path, options).unwrap();
 
         assert!(plain.contains("Pi: root answer"));
         assert!(markdown.contains("## Pi\n\nroot answer"));
@@ -968,6 +990,7 @@ mod tests {
         std::fs::write(&tmppath, format!("{}\n", entry)).unwrap();
 
         let result = generate_ledger(
+            crate::history::Source::Claude,
             &tmppath,
             ExportOptions {
                 show_tools: false,

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -260,19 +260,7 @@ pub fn run_with_loader(
                     let source = app
                         .get_selected_source()
                         .unwrap_or(crate::history::Source::Claude);
-                    let result = match source {
-                        crate::history::Source::Claude => {
-                            let uuid = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                            crate::history::delete_session_by_uuid(uuid).map(|_| ())
-                        }
-                        crate::history::Source::Pi => {
-                            crate::history::pi_loader::delete_session(path)
-                        }
-                        crate::history::Source::Omp => {
-                            crate::history::omp_loader::delete_session(path)
-                        }
-                    };
-                    match result {
+                    match source.provider().delete_session(path) {
                         Ok(()) => {
                             app.remove_selected_from_list();
                             app.exit_view_mode();

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2920,6 +2920,54 @@ mod tests {
         terminal_contents(&terminal)
     }
 
+    /// Mixed-source rows align on a label column sized from the registry. Pinning
+    /// the rendered text keeps a new provider from silently reflowing every row,
+    /// and keeps the column from drifting back to a hardcoded width.
+    #[test]
+    fn mixed_source_rows_align_on_the_source_label() {
+        let conversations = [
+            (crate::history::Source::Claude, "alpha"),
+            (crate::history::Source::Pi, "beta"),
+            (crate::history::Source::Omp, "gamma"),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (source, project))| {
+            let mut conversation = test_conversation();
+            conversation.source = source;
+            conversation.index = index;
+            conversation.project_name = Some(project.to_string());
+            conversation.custom_title = None;
+            conversation.summary = None;
+            conversation
+        })
+        .collect::<Vec<_>>();
+        let app = App::new(
+            conversations,
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            vec![],
+        );
+        let backend = TestBackend::new(120, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| render_list(frame, &app, frame.area()))
+            .unwrap();
+
+        // Each conversation renders as a header line, a preview line, and a rule.
+        const LINES_PER_CONVERSATION: u16 = 3;
+        for (position, expected) in ["CC  · alpha", "Pi  · beta", "OMP · gamma"]
+            .iter()
+            .enumerate()
+        {
+            let line = position as u16 * LINES_PER_CONVERSATION;
+            let text = row_text(&terminal, line);
+            assert!(text.contains(expected), "line {line}: {text:?}");
+        }
+    }
+
     #[test]
     fn list_truncates_long_project_names_on_narrow_rows() {
         let app = app_with_project_name("claude-history/drop-semantic-feature-gate");

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1530,7 +1530,11 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 .as_ref()
                 .map(|name| {
                     if app.has_multiple_sources() {
-                        format!("{:<3} · {name}", conv.source.list_label())
+                        format!(
+                            "{:<width$} · {name}",
+                            conv.source.list_label(),
+                            width = crate::history::provider::list_label_column_width()
+                        )
                     } else {
                         name.to_string()
                     }

--- a/src/tui/viewer/mod.rs
+++ b/src/tui/viewer/mod.rs
@@ -135,10 +135,29 @@ pub struct RenderableEntry {
     entry: LogEntry,
 }
 
-pub fn parse_conversation_file(file_path: &Path) -> std::io::Result<Vec<RenderableEntry>> {
-    let normalized = crate::history::normalized_log_entries(file_path)
+/// A conversation the list already attributed to a source: only that
+/// provider's format reads the file.
+pub fn parse_conversation_file(
+    source: crate::history::Source,
+    file_path: &Path,
+) -> std::io::Result<Vec<RenderableEntry>> {
+    let normalized = crate::history::normalized_log_entries(source, file_path)
         .map_err(|error| std::io::Error::other(error.to_string()))?;
-    Ok(normalized
+    Ok(renderable_entries(normalized))
+}
+
+/// A bare file the user handed us (`--render`, a direct path argument), read
+/// by whichever registered format recognizes it.
+pub fn parse_unattributed_conversation_file(
+    file_path: &Path,
+) -> std::io::Result<Vec<RenderableEntry>> {
+    let normalized = crate::history::sniffed_log_entries(file_path)
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    Ok(renderable_entries(normalized))
+}
+
+fn renderable_entries(normalized: Vec<(usize, LogEntry)>) -> Vec<RenderableEntry> {
+    normalized
         .into_iter()
         .map(|(_, entry)| entry)
         .enumerate()
@@ -146,7 +165,7 @@ pub fn parse_conversation_file(file_path: &Path) -> std::io::Result<Vec<Renderab
             (!matches!(entry, LogEntry::FileHistorySnapshot { .. }))
                 .then_some(RenderableEntry { entry_index, entry })
         })
-        .collect())
+        .collect()
 }
 
 pub fn render_parsed_conversation(
@@ -366,12 +385,13 @@ fn postprocess_blank_lines(lines: &mut Vec<RenderedLine>, messages: &mut Vec<Mes
     messages.retain(|m| m.start_line < m.end_line);
 }
 
-/// Render a conversation file to lines for display in the TUI viewer
+/// Render a bare conversation file to lines — the `--render` path, where the
+/// file arrives with no source attached.
 pub fn render_conversation(
     file_path: &Path,
     options: &RenderOptions,
 ) -> std::io::Result<RenderedConversation> {
-    let entries = parse_conversation_file(file_path)?;
+    let entries = parse_unattributed_conversation_file(file_path)?;
     Ok(render_parsed_conversation(&entries, options))
 }
 

--- a/src/tui/viewer/tests.rs
+++ b/src/tui/viewer/tests.rs
@@ -613,7 +613,7 @@ fn parse_conversation_file_preserves_entry_indices() {
     )
     .unwrap();
 
-    let entries = parse_conversation_file(&path).unwrap();
+    let entries = parse_unattributed_conversation_file(&path).unwrap();
 
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].entry_index, 0);

--- a/tests/agent_cli.rs
+++ b/tests/agent_cli.rs
@@ -12,6 +12,9 @@ fn run(config: &Path, args: &[&str]) -> Output {
             "PI_CODING_AGENT_SESSION_DIR",
             config.join("empty-agent-sessions"),
         )
+        // The spawned binary would otherwise write session caches for this
+        // test's throwaway roots into the user's real cache directory.
+        .env("CLAUDE_HISTORY_CACHE_DIR", config.join("cache"))
         .args(args)
         .output()
         .expect("run claude-history")
@@ -21,6 +24,7 @@ fn run_pi(config: &Path, sessions: &Path, args: &[&str]) -> Output {
     Command::new(binary())
         .env("CLAUDE_CONFIG_DIR", config)
         .env("PI_CODING_AGENT_SESSION_DIR", sessions)
+        .env("CLAUDE_HISTORY_CACHE_DIR", config.join("cache"))
         .args(args)
         .output()
         .expect("run claude-history with Pi sessions")


### PR DESCRIPTION
First of three stacked PRs toward #42: this one, then Codex and Kimi Code support, then OpenCode.

There are no new providers in this PR: it is the restructuring the other two build on, giving the existing Claude, Pi, and OMP integrations one provider interface, so that a new agent plugs in as one module. Apart from the behavior changes listed below, output is unchanged.

I saw in #42 that you have an incomplete branch adding OpenCode support. I'm not sure what your plan was, but the third PR in this stack implements OpenCode, including its SQLite-backed sessions, with almost no change to shared code. I'd be happy to incorporate feedback on direction and approach.

### Motivation

Adding a provider today means finding every place Pi and OMP are special-cased — roughly 12 files know each provider by name:

- per-source `match` arms in resume, rename, and delete
- `load_pi_conversations` / `load_omp_conversations`, ~70 lines duplicated verbatim
- four cache read/write functions
- two near-identical 45-line agent key scans
- a hardcoded label-column width in the TUI

### Approach

`Source` stays the identity enum: a new variant refuses to compile until every integration point handles it, which keeps the compiler as the checklist for adding a provider. Behavior moves behind a `SessionProvider` trait reached through `Source::provider()`:

- `storage()` — roots, discovery, session cache, and one shared load loop replacing both duplicated bodies. `None` for Claude, which partitions by project directory and streams batches.
- `format()` — transcript recognition and parsing. Pi and OMP share one implementation, differing only in which source an untitled transcript is attributed to.
- `launcher()` — resume and fork commands. Pi and OMP share a path-based launcher; Claude keeps its copy-and-resume logic, moved out of `main.rs`.
- `rename_session` / `delete_session` and per-source agent ref namespaces.
- The TUI's list-label column width is computed from the registry instead of a hardcoded `{:<3}`.

The storage contract deliberately does not assume sessions are files. Providers report each session as a (locator, cache key, fingerprint) stub; the shared load loop never stats, opens, or interprets a locator, and viewer, export, and agent reads route through the owning source's format rather than sniffing paths across formats. File-backed providers compose shared directory walkers from their own modules, so an agent that stores sessions some other way, e.g. one database holding every session, fits the same interface without core changes.

`PROVIDERS.md` (new) writes the interface down: the registry contract, then how each provider meets it. It ends with the steps for adding a provider.

### Behavior changes

- OMP no longer claims an untitled Pi transcript just because `omp` appears in its path (e.g. under a home directory named `omp`).
- Deleting a session whose transcript can't be read now reports the read failure with its path instead of "session not found".
- Parse-error line numbers no longer drift one line early after a message is filtered out of the preview.
- `CLAUDE_HISTORY_CACHE_DIR` relocates the session cache, and test runs no longer write cache directories for throwaway temp roots into the real user cache.

### Review notes

This is a large PR; I could not find a way to make it much smaller. The registry is only useful once every special-cased seam moves behind it, and much of the diff is existing code moving rather than new code. The median commit is ~350 changed lines, and all but three commits are under 700. The largest, the storage-contract rework, is ~1000.

One refactor step per commit, each builds and tests green. Every commit is meant to be output-preserving and can be reviewed against that claim, except the four carrying the behavior changes above:

- [the JSON round-trip removal](https://github.com/raine/claude-history/commit/026a2f7be533c2772c54fa6302f19f0cfc249066)
- [the root-origin commit](https://github.com/raine/claude-history/commit/1fee0c368e7713b7c24a418d93f3a02ede8ed3ea)
- [the `CLAUDE_HISTORY_CACHE_DIR` commit](https://github.com/raine/claude-history/commit/29337aad0b85161274b9dedf3310c7649d9933db)
- [the storage-contract commit](https://github.com/raine/claude-history/commit/5e63f5db222aa22fc493b49281ce080cf6fae40e), which also extends the read-failure reporting above to paths without a `.jsonl` extension: ownership is established by parsing alone

### Regression testing

- `conversation_ref()` digests and `project_id()` for Claude, Pi, and OMP are pinned by [a test](https://github.com/raine/claude-history/commit/52400c87223833da55fca241b1da6e5c9e0e78c5) whose expected values were read off a worktree at `main` — emitted refs are a compatibility contract.
- The on-disk cache keeps its exact filename shape and bincode layout, pinned by [a round-trip test](https://github.com/raine/claude-history/commit/55809bb4b0eb5405bda546156d26fb274459d6f8). Manually verified cache interop both directions: caches written by `main` read back on this branch and vice versa, matching cold runs.
- Rendered mixed-source list rows are pinned, including the registry-derived column width.
- Manual diff, `main` vs this branch, both built from source and run over identical frozen inputs (153 real Claude transcripts, Pi and OMP fixtures including an overlapping shared root): byte-identical output for broad search, Pi- and OMP-targeted searches, and `delete-empty --all`.
- Fixed one existing test that had always failed on Windows (`pi_cache_roots_are_isolated_from_claude_and_each_other` asserted a literal `/` path separator).

Rebased on v0.1.73. `just check` (fmt, clippy, build, test) is green on Windows except one test: 843 pass, and the one failure (`update::tests::test_platform_suffix_current`) fails identically on `main`.

