### PR TITLE
feat(tui): view sidecar subagent transcripts from a session

### DIFF
--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -19,6 +19,7 @@ pub mod path;
 pub mod pi;
 pub mod pi_loader;
 mod rename;
+pub mod subagents;
 
 use crate::error::{AppError, Result};
 use chrono::{DateTime, Local};
@@ -35,6 +36,7 @@ pub(crate) use parser::{
 };
 pub use path::{convert_path_to_project_dir_name, format_short_name_from_path, is_same_project};
 pub use rename::append_session_rename;
+pub use subagents::{SubagentEntry, discover_subagents};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Source {

--- a/src/history/subagents.rs
+++ b/src/history/subagents.rs
@@ -113,7 +113,7 @@ pub fn discover_subagents(session_path: &Path) -> Vec<SubagentEntry> {
         ));
     }
 
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|(mtime, _)| *mtime);
     entries.into_iter().map(|(_, e)| e).collect()
 }
 

--- a/src/history/subagents.rs
+++ b/src/history/subagents.rs
@@ -16,6 +16,7 @@
 //! conversation list. This module enumerates them on demand for a given
 //! session so the TUI can offer a picker.
 
+use rayon::prelude::*;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -73,48 +74,64 @@ pub fn discover_subagents(session_path: &Path) -> Vec<SubagentEntry> {
         return Vec::new();
     };
 
-    let mut entries: Vec<(SystemTime, SubagentEntry)> = Vec::new();
-    for dir_entry in read_dir.flatten() {
-        let path = dir_entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        if !stem.starts_with("agent-") {
-            continue;
-        }
+    // Collect candidate paths first, then read meta files in parallel via
+    // rayon to keep the main TUI thread responsive.
+    let candidates: Vec<PathBuf> = read_dir
+        .flatten()
+        .filter(|entry| {
+            let path = entry.path();
+            path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+                && path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|stem| stem.starts_with("agent-"))
+        })
+        .map(|entry| entry.path())
+        .collect();
 
-        let meta = std::fs::read_to_string(path.with_extension("meta.json"))
-            .ok()
-            .and_then(|s| serde_json::from_str::<SubagentMeta>(&s).ok())
-            .unwrap_or_default();
+    let mut entries: Vec<(SystemTime, PathBuf, SubagentEntry)> = candidates
+        .par_iter()
+        .filter_map(|path| {
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                return None;
+            };
 
-        let agent_type = if meta.agent_type.is_empty() {
-            stem.to_string()
-        } else {
-            meta.agent_type
-        };
+            let meta = std::fs::read_to_string(path.with_extension("meta.json"))
+                .ok()
+                .and_then(|s| serde_json::from_str::<SubagentMeta>(&s).ok())
+                .unwrap_or_default();
 
-        let mtime = dir_entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .unwrap_or(SystemTime::UNIX_EPOCH);
+            let agent_type = if meta.agent_type.is_empty() {
+                stem.to_string()
+            } else {
+                meta.agent_type
+            };
 
-        entries.push((
-            mtime,
-            SubagentEntry {
-                path,
-                agent_type,
-                description: meta.description,
-                tool_use_id: meta.tool_use_id,
-            },
-        ));
-    }
+            let mtime = std::fs::metadata(path)
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
 
-    entries.sort_by_key(|(mtime, _)| *mtime);
-    entries.into_iter().map(|(_, e)| e).collect()
+            Some((
+                mtime,
+                path.clone(),
+                SubagentEntry {
+                    path: path.clone(),
+                    agent_type,
+                    description: meta.description,
+                    tool_use_id: meta.tool_use_id,
+                },
+            ))
+        })
+        .collect();
+
+    // Sort by mtime, then by path for a deterministic order when mtimes tie
+    // (common on filesystems with second-level granularity).
+    entries.sort_by(|(a_mtime, a_path, _), (b_mtime, b_path, _)| {
+        a_mtime
+            .cmp(b_mtime)
+            .then_with(|| a_path.cmp(b_path))
+    });
+    entries.into_iter().map(|(_, _, e)| e).collect()
 }
 
 #[cfg(test)]

--- a/src/history/subagents.rs
+++ b/src/history/subagents.rs
@@ -1,0 +1,197 @@
+//! Discovery of subagent transcripts stored as sidecar files.
+//!
+//! Some Claude Code setups (notably openclaw) do not embed subagent messages
+//! inline in the parent transcript. Instead each subagent gets its own JSONL
+//! transcript stored under a per-session directory:
+//!
+//! ```text
+//! <projects>/<project>/<session-id>.jsonl        # parent session
+//! <projects>/<project>/<session-id>/subagents/
+//!     agent-<id>.jsonl                            # subagent transcript
+//!     agent-<id>.meta.json                        # { agentType, description, toolUseId }
+//! ```
+//!
+//! The main discovery pass deliberately skips `agent-*.jsonl` files and never
+//! recurses into these directories, so subagents are invisible in the normal
+//! conversation list. This module enumerates them on demand for a given
+//! session so the TUI can offer a picker.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// A subagent transcript discovered next to a session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubagentEntry {
+    /// Path to the subagent's `agent-<id>.jsonl` transcript.
+    pub path: PathBuf,
+    /// Agent type from the meta sidecar (e.g. `Explore`), or the file stem
+    /// when no meta is present.
+    pub agent_type: String,
+    /// Human description of the subagent's task from the meta sidecar.
+    pub description: String,
+    /// The parent `tool_use` id that spawned this subagent, if recorded.
+    pub tool_use_id: String,
+}
+
+impl SubagentEntry {
+    /// One-line label for display in a picker, e.g. `Explore — do the thing`.
+    pub fn label(&self) -> String {
+        if self.description.is_empty() {
+            self.agent_type.clone()
+        } else {
+            format!("{} — {}", self.agent_type, self.description)
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SubagentMeta {
+    #[serde(default, rename = "agentType")]
+    agent_type: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default, rename = "toolUseId")]
+    tool_use_id: String,
+}
+
+/// The `subagents/` directory that would hold sidecar transcripts for a
+/// session whose transcript file is `session_path`.
+fn subagents_dir(session_path: &Path) -> PathBuf {
+    // `<...>/<session-id>.jsonl` -> `<...>/<session-id>` -> `<...>/<session-id>/subagents`
+    session_path.with_extension("").join("subagents")
+}
+
+/// Discover subagent transcripts stored alongside `session_path`.
+///
+/// Returns entries ordered by file modification time (spawn order). Returns an
+/// empty vec when the session has no `subagents/` directory — the common case
+/// for standard inline-sidechain transcripts.
+pub fn discover_subagents(session_path: &Path) -> Vec<SubagentEntry> {
+    let dir = subagents_dir(session_path);
+    let Ok(read_dir) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut entries: Vec<(SystemTime, SubagentEntry)> = Vec::new();
+    for dir_entry in read_dir.flatten() {
+        let path = dir_entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if !stem.starts_with("agent-") {
+            continue;
+        }
+
+        let meta = std::fs::read_to_string(path.with_extension("meta.json"))
+            .ok()
+            .and_then(|s| serde_json::from_str::<SubagentMeta>(&s).ok())
+            .unwrap_or_default();
+
+        let agent_type = if meta.agent_type.is_empty() {
+            stem.to_string()
+        } else {
+            meta.agent_type
+        };
+
+        let mtime = dir_entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        entries.push((
+            mtime,
+            SubagentEntry {
+                path,
+                agent_type,
+                description: meta.description,
+                tool_use_id: meta.tool_use_id,
+            },
+        ));
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().map(|(_, e)| e).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn returns_empty_when_no_subagents_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session = tmp.path().join("proj").join("sess-1.jsonl");
+        write(&session, "{}\n");
+        assert!(discover_subagents(&session).is_empty());
+    }
+
+    #[test]
+    fn discovers_entries_with_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("proj");
+        let session = proj.join("sess-1.jsonl");
+        write(&session, "{}\n");
+
+        let subdir = proj.join("sess-1").join("subagents");
+        write(&subdir.join("agent-aaa.jsonl"), "{}\n");
+        write(
+            &subdir.join("agent-aaa.meta.json"),
+            r#"{"agentType":"Explore","description":"look around","toolUseId":"call_1"}"#,
+        );
+
+        let found = discover_subagents(&session);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].agent_type, "Explore");
+        assert_eq!(found[0].description, "look around");
+        assert_eq!(found[0].tool_use_id, "call_1");
+        assert_eq!(found[0].label(), "Explore — look around");
+        assert!(found[0].path.ends_with("agent-aaa.jsonl"));
+    }
+
+    #[test]
+    fn falls_back_to_stem_when_meta_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("proj");
+        let session = proj.join("sess-1.jsonl");
+        write(&session, "{}\n");
+
+        let subdir = proj.join("sess-1").join("subagents");
+        write(&subdir.join("agent-bbb.jsonl"), "{}\n");
+
+        let found = discover_subagents(&session);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].agent_type, "agent-bbb");
+        assert_eq!(found[0].description, "");
+        assert_eq!(found[0].label(), "agent-bbb");
+    }
+
+    #[test]
+    fn ignores_non_agent_and_non_jsonl_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("proj");
+        let session = proj.join("sess-1.jsonl");
+        write(&session, "{}\n");
+
+        let subdir = proj.join("sess-1").join("subagents");
+        write(&subdir.join("agent-aaa.jsonl"), "{}\n");
+        write(&subdir.join("agent-aaa.meta.json"), "{}");
+        write(&subdir.join("notes.txt"), "ignore me");
+        write(&subdir.join("other.jsonl"), "{}\n");
+
+        let found = discover_subagents(&session);
+        assert_eq!(found.len(), 1);
+        assert!(found[0].path.ends_with("agent-aaa.jsonl"));
+    }
+}

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -73,6 +73,67 @@ impl App {
         }
     }
 
+    /// Open the subagent picker for the currently viewed session, if it has
+    /// sidecar `agent-*.jsonl` transcripts. No-op (with a status hint) when
+    /// not in view mode or the session has no subagents.
+    pub(super) fn open_subagent_picker(&mut self) {
+        let path = match &self.app_mode {
+            AppMode::View(state) => state.conversation_path.clone(),
+            _ => return,
+        };
+        let entries = crate::history::discover_subagents(&path);
+        if entries.is_empty() {
+            self.status_message = Some((
+                "No subagents for this session".to_string(),
+                std::time::Instant::now(),
+            ));
+            return;
+        }
+        self.dialog_mode = DialogMode::SubagentPicker {
+            entries,
+            selected: 0,
+        };
+    }
+
+    pub(super) fn handle_subagent_picker_key(&mut self, code: KeyCode) -> Option<Action> {
+        match code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let DialogMode::SubagentPicker { selected, .. } = &mut self.dialog_mode {
+                    *selected = selected.saturating_sub(1);
+                }
+                None
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if let DialogMode::SubagentPicker { entries, selected } = &mut self.dialog_mode {
+                    *selected = (*selected + 1).min(entries.len().saturating_sub(1));
+                }
+                None
+            }
+            KeyCode::Enter => {
+                let path = match &self.dialog_mode {
+                    DialogMode::SubagentPicker { entries, selected } => {
+                        entries.get(*selected).map(|e| e.path.clone())
+                    }
+                    _ => None,
+                };
+                self.dialog_mode = DialogMode::None;
+                if let Some(path) = path {
+                    let content_width = match &self.app_mode {
+                        AppMode::View(state) => state.content_width,
+                        _ => return None,
+                    };
+                    self.open_conversation_path(path, content_width);
+                }
+                None
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.dialog_mode = DialogMode::None;
+                None
+            }
+            _ => None,
+        }
+    }
+
     pub(super) fn handle_help_key(
         &mut self,
         code: KeyCode,

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -116,13 +116,17 @@ impl App {
                     }
                     _ => None,
                 };
+                // Capture content_width before closing the dialog, so we don't
+                // read app_mode state after mutating dialog_mode.
+                let content_width = match &self.app_mode {
+                    AppMode::View(state) => Some(state.content_width),
+                    _ => None,
+                };
                 self.dialog_mode = DialogMode::None;
-                if let Some(path) = path {
-                    let content_width = match &self.app_mode {
-                        AppMode::View(state) => state.content_width,
-                        _ => return None,
-                    };
-                    self.open_conversation_path(path, content_width);
+                if let Some(path) = path
+                    && let Some(width) = content_width
+                {
+                    self.open_conversation_path(path, width);
                 }
                 None
             }

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -132,6 +132,7 @@ impl App {
                 return None;
             }
             DialogMode::Rename { .. } => return self.handle_rename_key(code, modifiers),
+            DialogMode::SubagentPicker { .. } => return self.handle_subagent_picker_key(code),
             DialogMode::None => {}
         }
 
@@ -356,6 +357,10 @@ impl App {
             }
             KeyCode::Char('e') => {
                 self.dialog_mode = DialogMode::ExportMenu { selected: 0 };
+                None
+            }
+            KeyCode::Char('s') => {
+                self.open_subagent_picker();
                 None
             }
             KeyCode::Char('y') => {

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -205,11 +205,9 @@ impl App {
                     self.clear_view_search();
                     return None;
                 }
-                if self.single_file_mode {
-                    return Some(Action::Quit);
-                }
                 // Drilled into a subagent: Esc returns to the parent session
-                // rather than the conversation list.
+                // rather than the conversation list. Checked before
+                // single_file_mode so the feature works in single-file view.
                 if let AppMode::View(ref state) = self.app_mode
                     && let Some(parent) = state.parent_path.clone()
                 {
@@ -217,10 +215,22 @@ impl App {
                     self.open_conversation_path(parent, width);
                     return None;
                 }
+                if self.single_file_mode {
+                    return Some(Action::Quit);
+                }
                 self.app_mode = AppMode::List;
                 None
             }
             KeyCode::Char('q') => {
+                // Match Esc: return to the parent session when drilling into a
+                // subagent, so `q` and Esc behave consistently.
+                if let AppMode::View(ref state) = self.app_mode
+                    && let Some(parent) = state.parent_path.clone()
+                {
+                    let width = state.content_width;
+                    self.open_conversation_path(parent, width);
+                    return None;
+                }
                 if self.single_file_mode {
                     return Some(Action::Quit);
                 }

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -208,6 +208,15 @@ impl App {
                 if self.single_file_mode {
                     return Some(Action::Quit);
                 }
+                // Drilled into a subagent: Esc returns to the parent session
+                // rather than the conversation list.
+                if let AppMode::View(ref state) = self.app_mode
+                    && let Some(parent) = state.parent_path.clone()
+                {
+                    let width = state.content_width;
+                    self.open_conversation_path(parent, width);
+                    return None;
+                }
                 self.app_mode = AppMode::List;
                 None
             }

--- a/src/tui/app/interaction_tests.rs
+++ b/src/tui/app/interaction_tests.rs
@@ -435,3 +435,97 @@ fn submit_empty_rename_clears_searchable_title() {
     assert_eq!(app.conversations[0].custom_title, None);
     assert!(search::search(&app.conversations, &app.searchable, "old", Local::now()).is_empty());
 }
+
+fn write_subagent(dir: &std::path::Path, id: &str, meta: Option<&str>) -> PathBuf {
+    let subdir = dir.join("subagents");
+    std::fs::create_dir_all(&subdir).unwrap();
+    let agent = subdir.join(format!("agent-{id}.jsonl"));
+    write_named_conversation(&agent, "subagent body");
+    if let Some(meta) = meta {
+        std::fs::write(subdir.join(format!("agent-{id}.meta.json")), meta).unwrap();
+    }
+    agent
+}
+
+#[test]
+fn subagent_picker_opens_selected_subagent() {
+    let dir = tempfile::tempdir().unwrap();
+    let proj = dir.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    let session = proj.join("sess-1.jsonl");
+    write_named_conversation(&session, "parent body");
+    let agent = write_subagent(
+        &proj.join("sess-1"),
+        "aaa",
+        Some(r#"{"agentType":"Explore","description":"look","toolUseId":"call_1"}"#),
+    );
+
+    let mut app = app_with_conversation(session, None);
+    app.selected = Some(0);
+    app.enter_view_mode(80);
+
+    // `s` opens the picker with the one discovered subagent.
+    app.handle_key(KeyCode::Char('s'), KeyModifiers::empty(), 20);
+    match &app.dialog_mode {
+        DialogMode::SubagentPicker { entries, selected } => {
+            assert_eq!(entries.len(), 1);
+            assert_eq!(*selected, 0);
+            assert_eq!(entries[0].agent_type, "Explore");
+        }
+        other => panic!("expected SubagentPicker, got {other:?}"),
+    }
+
+    // Enter opens that subagent transcript in the viewer.
+    app.handle_key(KeyCode::Enter, KeyModifiers::empty(), 20);
+    assert_eq!(app.dialog_mode, DialogMode::None);
+    match app.app_mode() {
+        AppMode::View(state) => assert_eq!(state.conversation_path, agent),
+        other => panic!("expected view mode, got {other:?}"),
+    }
+}
+
+#[test]
+fn subagent_picker_noop_without_subagents() {
+    let dir = tempfile::tempdir().unwrap();
+    let session = dir.path().join("sess-2.jsonl");
+    write_named_conversation(&session, "parent body");
+
+    let mut app = app_with_conversation(session.clone(), None);
+    app.selected = Some(0);
+    app.enter_view_mode(80);
+
+    app.handle_key(KeyCode::Char('s'), KeyModifiers::empty(), 20);
+
+    // No dialog opens; a status hint is shown and we stay on the parent.
+    assert_eq!(app.dialog_mode, DialogMode::None);
+    assert!(app.status_message().is_some());
+    match app.app_mode() {
+        AppMode::View(state) => assert_eq!(state.conversation_path, session),
+        other => panic!("expected view mode, got {other:?}"),
+    }
+}
+
+#[test]
+fn subagent_picker_escape_closes_without_opening() {
+    let dir = tempfile::tempdir().unwrap();
+    let proj = dir.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    let session = proj.join("sess-3.jsonl");
+    write_named_conversation(&session, "parent body");
+    write_subagent(&proj.join("sess-3"), "bbb", None);
+
+    let mut app = app_with_conversation(session.clone(), None);
+    app.selected = Some(0);
+    app.enter_view_mode(80);
+
+    app.handle_key(KeyCode::Char('s'), KeyModifiers::empty(), 20);
+    assert!(matches!(app.dialog_mode, DialogMode::SubagentPicker { .. }));
+
+    app.handle_key(KeyCode::Esc, KeyModifiers::empty(), 20);
+    assert_eq!(app.dialog_mode, DialogMode::None);
+    // Still viewing the parent, unchanged.
+    match app.app_mode() {
+        AppMode::View(state) => assert_eq!(state.conversation_path, session),
+        other => panic!("expected view mode, got {other:?}"),
+    }
+}

--- a/src/tui/app/interaction_tests.rs
+++ b/src/tui/app/interaction_tests.rs
@@ -529,3 +529,43 @@ fn subagent_picker_escape_closes_without_opening() {
         other => panic!("expected view mode, got {other:?}"),
     }
 }
+
+#[test]
+fn esc_from_subagent_returns_to_parent_session() {
+    let dir = tempfile::tempdir().unwrap();
+    let proj = dir.path().join("proj");
+    std::fs::create_dir_all(&proj).unwrap();
+    let session = proj.join("sess-4.jsonl");
+    write_named_conversation(&session, "parent body");
+    let agent = write_subagent(
+        &proj.join("sess-4"),
+        "ccc",
+        Some(r#"{"agentType":"Explore","description":"look","toolUseId":"call_1"}"#),
+    );
+
+    let mut app = app_with_conversation(session.clone(), None);
+    app.selected = Some(0);
+    app.enter_view_mode(80);
+
+    // Drill into the subagent.
+    app.handle_key(KeyCode::Char('s'), KeyModifiers::empty(), 20);
+    app.handle_key(KeyCode::Enter, KeyModifiers::empty(), 20);
+    match app.app_mode() {
+        AppMode::View(state) => {
+            assert_eq!(state.conversation_path, agent);
+            assert_eq!(state.parent_path.as_deref(), Some(session.as_path()));
+        }
+        other => panic!("expected view mode, got {other:?}"),
+    }
+
+    // Esc returns to the parent session, not the conversation list.
+    app.handle_key(KeyCode::Esc, KeyModifiers::empty(), 20);
+    assert!(matches!(app.app_mode(), AppMode::View(_)));
+    match app.app_mode() {
+        AppMode::View(state) => {
+            assert_eq!(state.conversation_path, session);
+            assert!(state.parent_path.is_none(), "parent itself has no parent");
+        }
+        other => panic!("expected view mode, got {other:?}"),
+    }
+}

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -55,6 +55,9 @@ pub enum AppMode {
 pub struct ViewState {
     /// Path to the conversation file (stable identity)
     pub conversation_path: PathBuf,
+    /// Session we came from when drilling into a subagent, so `Esc` returns to
+    /// the parent session rather than the conversation list.
+    pub parent_path: Option<PathBuf>,
     /// Parsed renderable entries for the currently open view.
     pub parsed_entries: Option<Arc<Vec<RenderableEntry>>>,
     /// Current scroll position (line offset)
@@ -132,6 +135,7 @@ impl ViewState {
     ) -> Self {
         Self {
             conversation_path,
+            parent_path: None,
             parsed_entries: None,
             scroll_offset: 0,
             rendered_lines: Vec::new(),

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -33,6 +33,11 @@ pub enum DialogMode {
     SemanticDebug,
     /// Rename the selected conversation
     Rename { input: String, cursor: usize },
+    /// Pick a subagent transcript to open (sidecar `agent-*.jsonl` files)
+    SubagentPicker {
+        entries: Vec<crate::history::SubagentEntry>,
+        selected: usize,
+    },
 }
 
 /// Main application mode

--- a/src/tui/app/view_state.rs
+++ b/src/tui/app/view_state.rs
@@ -23,6 +23,23 @@ impl App {
     pub fn open_conversation_path(&mut self, path: std::path::PathBuf, content_width: usize) {
         use crate::tui::viewer::{parse_conversation_file, render_parsed_conversation};
 
+        // When drilling from a subagent back into another subagent, keep the
+        // original parent so Esc still returns to the top-level session. When
+        // returning to the parent itself (path == current parent), the parent
+        // is a top-level session with no parent of its own.
+        let parent_path = match &self.app_mode {
+            AppMode::View(state) => {
+                if state.conversation_path == path {
+                    state.parent_path.clone()
+                } else if state.parent_path.as_deref() == Some(path.as_path()) {
+                    None
+                } else {
+                    Some(state.conversation_path.clone())
+                }
+            }
+            _ => None,
+        };
+
         let options = RenderOptions {
             tool_display: self.tool_display,
             show_thinking: self.show_thinking,
@@ -43,6 +60,7 @@ impl App {
                 };
                 self.app_mode = AppMode::View(ViewState {
                     conversation_path: path,
+                    parent_path,
                     parsed_entries: Some(entries),
                     scroll_offset: 0,
                     rendered_lines: rendered.lines,

--- a/src/tui/app/view_state.rs
+++ b/src/tui/app/view_state.rs
@@ -27,17 +27,30 @@ impl App {
         // original parent so Esc still returns to the top-level session. When
         // returning to the parent itself (path == current parent), the parent
         // is a top-level session with no parent of its own.
-        let parent_path = match &self.app_mode {
+        let (parent_path, restore) = match &self.app_mode {
             AppMode::View(state) => {
                 if state.conversation_path == path {
-                    state.parent_path.clone()
+                    (state.parent_path.clone(), None)
                 } else if state.parent_path.as_deref() == Some(path.as_path()) {
-                    None
+                    // Returning to the parent session: preserve the scroll
+                    // position, search state, and expanded tool outputs so the
+                    // user resumes where they left off rather than from the top.
+                    let saved = ViewStateSnapshot {
+                        scroll_offset: state.scroll_offset,
+                        search_mode: state.search_mode.clone(),
+                        search_query: state.search_query.clone(),
+                        search_matches: state.search_matches.clone(),
+                        current_match: state.current_match,
+                        expanded_tool_outputs: state.expanded_tool_outputs.clone(),
+                        message_nav_active: state.message_nav_active,
+                        focused_message: state.focused_message,
+                    };
+                    (None, Some(saved))
                 } else {
-                    Some(state.conversation_path.clone())
+                    (Some(state.parent_path.clone().unwrap_or_else(|| state.conversation_path.clone())), None)
                 }
             }
-            _ => None,
+            _ => (None, None),
         };
 
         let options = RenderOptions {
@@ -58,7 +71,7 @@ impl App {
                 } else {
                     Some(0)
                 };
-                self.app_mode = AppMode::View(ViewState {
+                let mut new_state = ViewState {
                     conversation_path: path,
                     parent_path,
                     parsed_entries: Some(entries),
@@ -78,7 +91,11 @@ impl App {
                     message_nav_active: false,
                     expanded_tool_outputs: BTreeSet::new(),
                     hovered_tool_output: None,
-                });
+                };
+                if let Some(snap) = restore {
+                    snap.restore(&mut new_state);
+                }
+                self.app_mode = AppMode::View(new_state);
             }
             Err(e) => {
                 self.status_message =
@@ -600,6 +617,36 @@ impl App {
 struct ScrollAnchor {
     entry_index: usize,
     relative_row: isize,
+}
+
+/// Snapshot of the ephemeral view state captured before switching to a
+/// subagent, restored when Esc returns to the parent session so the user
+/// resumes at the same scroll position and search state.
+struct ViewStateSnapshot {
+    scroll_offset: usize,
+    search_mode: ViewSearchMode,
+    search_query: String,
+    search_matches: Vec<usize>,
+    current_match: usize,
+    expanded_tool_outputs: BTreeSet<ToolOutputId>,
+    message_nav_active: bool,
+    focused_message: Option<usize>,
+}
+
+impl ViewStateSnapshot {
+    fn restore(self, state: &mut ViewState) {
+        // Clamp scroll_offset to the new total in case the re-rendered
+        // content is shorter than before.
+        let max_scroll = state.total_lines.saturating_sub(state.scroll_offset.max(1));
+        state.scroll_offset = self.scroll_offset.min(max_scroll);
+        state.search_mode = self.search_mode;
+        state.search_query = self.search_query;
+        state.search_matches = self.search_matches;
+        state.current_match = self.current_match;
+        state.expanded_tool_outputs = self.expanded_tool_outputs;
+        state.message_nav_active = self.message_nav_active;
+        state.focused_message = self.focused_message;
+    }
 }
 
 fn capture_anchor(

--- a/src/tui/app/view_state.rs
+++ b/src/tui/app/view_state.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 
 impl App {
     pub fn enter_view_mode(&mut self, content_width: usize) {
-        use crate::tui::viewer::{parse_conversation_file, render_parsed_conversation};
-
         let Some(selected) = self.selected else {
             return;
         };
@@ -16,6 +14,14 @@ impl App {
             return;
         };
         let path = self.conversations[conv_idx].path.clone();
+        self.open_conversation_path(path, content_width);
+    }
+
+    /// Parse and open an arbitrary conversation transcript by path, switching
+    /// into view mode. Used both by list selection (`enter_view_mode`) and by
+    /// the subagent picker to open sidecar `agent-*.jsonl` files.
+    pub fn open_conversation_path(&mut self, path: std::path::PathBuf, content_width: usize) {
+        use crate::tui::viewer::{parse_conversation_file, render_parsed_conversation};
 
         let options = RenderOptions {
             tool_display: self.tool_display,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1166,6 +1166,27 @@ fn centered_modal_area(area: Rect, preferred_width: u16, preferred_height: u16) 
     }
 }
 
+/// Render the shared modal chrome (Clear → background → bordered block) and
+/// return the inner area for content. Centralizes the overlay styling used by
+/// the export menu, yank menu, and subagent picker.
+fn render_modal_chrome(frame: &mut Frame, title: String, width: u16, height: u16) -> Rect {
+    let area = frame.area();
+    let menu_area = centered_modal_area(area, width, height);
+
+    frame.render_widget(Clear, menu_area);
+    let background = Block::default().style(Style::default().bg(rgb(th().overlay_bg)));
+    frame.render_widget(background, menu_area);
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(rgb(th().accent)));
+    let inner = block.inner(menu_area);
+    frame.render_widget(block, menu_area);
+    inner
+}
+
 fn render_confirm_dialog(frame: &mut Frame, area: Rect) {
     let prompt = Line::from(vec![
         Span::raw(" "),
@@ -1241,28 +1262,8 @@ fn render_export_menu(frame: &mut Frame, selected: usize, is_yank: bool) {
         "[4] JSONL (raw)",
     ];
 
-    let area = frame.area();
-    let menu_width = 35;
     let menu_height = options.len() as u16 + 4; // options + title + border + cancel hint
-
-    let menu_area = centered_modal_area(area, menu_width, menu_height);
-
-    // Clear the area behind the modal first
-    frame.render_widget(Clear, menu_area);
-
-    // Render background
-    let background = Block::default().style(Style::default().bg(rgb(th().overlay_bg)));
-    frame.render_widget(background, menu_area);
-
-    // Render border
-    let block = Block::default()
-        .title(format!(" {} ", title))
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(rgb(th().accent)));
-
-    let inner = block.inner(menu_area);
-    frame.render_widget(block, menu_area);
+    let inner = render_modal_chrome(frame, format!(" {} ", title), 35, menu_height);
 
     // Render options
     let mut lines = Vec::new();
@@ -1294,41 +1295,28 @@ fn render_subagent_picker(
     entries: &[crate::history::SubagentEntry],
     selected: usize,
 ) {
-    let area = frame.area();
     let title = format!(" Subagents ({}) ", entries.len());
 
-    let max_label = entries
+    // Precompute labels once to avoid double allocation (width + render).
+    let labels: Vec<String> = entries.iter().map(|e| e.label()).collect();
+
+    // Use display width (not char count) so CJK/emoji labels size the menu
+    // correctly — a CJK char occupies 2 columns but counts as 1 char.
+    let max_label_width = labels
         .iter()
-        .map(|e| e.label().chars().count())
+        .map(|l| UnicodeWidthStr::width(l.as_str()))
         .max()
         .unwrap_or(0);
-    let menu_width = (max_label as u16)
+    let menu_width = (max_label_width as u16)
         .saturating_add(6)
-        .clamp(30, area.width.saturating_sub(4).max(30));
+        .clamp(30, frame.area().width.saturating_sub(4).max(30));
 
     // Leave room for border (2) + blank line (1) + hint line (1).
-    let max_rows = area.height.saturating_sub(6).max(1) as usize;
+    let max_rows = frame.area().height.saturating_sub(6).max(1) as usize;
     let visible = entries.len().min(max_rows).max(1);
     let menu_height = (visible as u16) + 4;
 
-    let menu_area = centered_modal_area(area, menu_width, menu_height);
-
-    // Clear the area behind the modal first
-    frame.render_widget(Clear, menu_area);
-
-    // Render background
-    let background = Block::default().style(Style::default().bg(rgb(th().overlay_bg)));
-    frame.render_widget(background, menu_area);
-
-    // Render border
-    let block = Block::default()
-        .title(title)
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(rgb(th().accent)));
-
-    let inner = block.inner(menu_area);
-    frame.render_widget(block, menu_area);
+    let inner = render_modal_chrome(frame, title, menu_width, menu_height);
 
     if inner.is_empty() {
         return;
@@ -1343,7 +1331,7 @@ fn render_subagent_picker(
     let end = (start + visible).min(entries.len());
 
     let mut lines = Vec::new();
-    for (offset, entry) in entries[start..end].iter().enumerate() {
+    for (offset, label) in labels[start..end].iter().enumerate() {
         let idx = start + offset;
         let style = if idx == selected {
             Style::default().fg(rgb(th().accent)).bold()
@@ -1352,7 +1340,7 @@ fn render_subagent_picker(
         };
         let prefix = if idx == selected { "▶ " } else { "  " };
         // Paragraph clips (does not wrap) so an overlong label stays on one row.
-        lines.push(Line::styled(format!("{}{}", prefix, entry.label()), style));
+        lines.push(Line::styled(format!("{}{}", prefix, label), style));
     }
     lines.push(Line::from(""));
     lines.push(Line::styled(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -505,6 +505,9 @@ fn render_view_mode(frame: &mut Frame, app: &App, state: &ViewState) {
         }
         DialogMode::SemanticDebug => render_semantic_debug_popup(frame, app),
         DialogMode::Rename { input, cursor } => render_rename_dialog(frame, input, *cursor),
+        DialogMode::SubagentPicker { entries, selected } => {
+            render_subagent_picker(frame, entries, *selected)
+        }
         DialogMode::None => {}
     }
 }
@@ -1284,6 +1287,81 @@ fn render_export_menu(frame: &mut Frame, selected: usize, is_yank: bool) {
     frame.render_widget(menu_content, inner);
 }
 
+fn render_subagent_picker(
+    frame: &mut Frame,
+    entries: &[crate::history::SubagentEntry],
+    selected: usize,
+) {
+    let area = frame.area();
+    let title = format!(" Subagents ({}) ", entries.len());
+
+    let max_label = entries
+        .iter()
+        .map(|e| e.label().chars().count())
+        .max()
+        .unwrap_or(0);
+    let menu_width = (max_label as u16)
+        .saturating_add(6)
+        .clamp(30, area.width.saturating_sub(4).max(30));
+
+    // Leave room for border (2) + blank line (1) + hint line (1).
+    let max_rows = area.height.saturating_sub(6).max(1) as usize;
+    let visible = entries.len().min(max_rows).max(1);
+    let menu_height = (visible as u16) + 4;
+
+    let menu_area = centered_modal_area(area, menu_width, menu_height);
+
+    // Clear the area behind the modal first
+    frame.render_widget(Clear, menu_area);
+
+    // Render background
+    let background = Block::default().style(Style::default().bg(rgb(th().overlay_bg)));
+    frame.render_widget(background, menu_area);
+
+    // Render border
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(rgb(th().accent)));
+
+    let inner = block.inner(menu_area);
+    frame.render_widget(block, menu_area);
+
+    if inner.is_empty() {
+        return;
+    }
+
+    // Scroll window so the selected entry stays visible.
+    let start = if selected >= visible {
+        selected + 1 - visible
+    } else {
+        0
+    };
+    let end = (start + visible).min(entries.len());
+
+    let mut lines = Vec::new();
+    for (offset, entry) in entries[start..end].iter().enumerate() {
+        let idx = start + offset;
+        let style = if idx == selected {
+            Style::default().fg(rgb(th().accent)).bold()
+        } else {
+            Style::default().fg(rgb(th().text_primary))
+        };
+        let prefix = if idx == selected { "▶ " } else { "  " };
+        // Paragraph clips (does not wrap) so an overlong label stays on one row.
+        lines.push(Line::styled(format!("{}{}", prefix, entry.label()), style));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::styled(
+        "  [↑/↓] Move  [Enter] Open  [Esc] Cancel",
+        Style::default().fg(rgb(th().text_muted)),
+    ));
+
+    let menu_content = Paragraph::new(lines);
+    frame.render_widget(menu_content, inner);
+}
+
 fn render_help_overlay(
     frame: &mut Frame,
     is_view_mode: bool,
@@ -1313,6 +1391,7 @@ fn render_help_overlay(
             ("t".into(), "Cycle tools: off/trunc/full"),
             ("T".into(), "Toggle thinking"),
             ("i".into(), "Toggle timing"),
+            ("s".into(), "View subagents"),
             ("e".into(), "Export to file"),
             ("y".into(), "Copy to clipboard / message"),
             ("p".into(), "Show file path"),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -862,6 +862,8 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
             Span::styled("help  ", label_style),
             Span::styled("/", key_style),
             Span::styled("search  ", label_style),
+            Span::styled("s", key_style),
+            Span::styled("ubagents  ", label_style),
             Span::styled("e", key_style),
             Span::styled("xport  ", label_style),
             Span::styled("y", key_style),


### PR DESCRIPTION
## Summary

Adds a subagent picker to the conversation viewer: press `s` while viewing a session to list its subagents and open the selected one in the same viewer.

**Motivation:** Some Claude Code setups (notably [openclaw](https://github.com/jd-opensource/openclaw)) do not embed subagent messages inline as sidechains. Each subagent gets its own transcript stored next to the parent session:

\`\`\`text
<projects>/<project>/<session-id>.jsonl        # parent session
<projects>/<project>/<session-id>/subagents/
    agent-<id>.jsonl                            # subagent transcript
    agent-<id>.meta.json                        # { agentType, description, toolUseId }
\`\`\`

The discovery pass deliberately skips `agent-*.jsonl` and never recurses into `subagents/`, so these subagents are invisible in the conversation list. `claude-history <file>` already renders an `agent-*.jsonl` file perfectly (it is a standard transcript), but there was no way to reach one from its parent session in the TUI.

## UX

- View mode: `s` → lists the session's subagents (`agentType — description` from the meta sidecar), sorted by mtime (spawn order).
- `↑/↓` or `j/k` to move, `Enter` opens the selected subagent transcript in the viewer (same navigation, search, tool/thinking toggles as any conversation), `Esc`/`q` cancels.
- Sessions without a `subagents/` directory show a status hint and no overlay.
- Help overlay lists `s` alongside the other view-mode keys.
- List mode is intentionally untouched: a bare letter would collide with the search query, and subagents are most naturally reached from the session that spawned them.

## Files

- \`src/history/subagents.rs\` (new) — \`discover_subagents(session_path)\` scans \`<session-stem>/subagents/agent-*.jsonl\`, reads the sibling \`.meta.json\` (\`agentType\`/\`description\`/\`toolUseId\`), falls back to the file stem when meta is missing, and sorts by mtime.
- \`src/history/mod.rs\` — module declaration + re-export.
- \`src/tui/app/types.rs\` — \`DialogMode::SubagentPicker { entries, selected }\`.
- \`src/tui/app/view_state.rs\` — refactor: extract \`open_conversation_path(path, width)\` from \`enter_view_mode\` so the picker opens a subagent the same way list selection opens a conversation.
- \`src/tui/app/dialog_state.rs\` — \`open_subagent_picker()\` + \`handle_subagent_picker_key()\` (mirrors the existing \`handle_menu_key\` pattern).
- \`src/tui/app/input_controller.rs\` — route the new dialog; bind \`s\` in view mode.
- \`src/tui/ui.rs\` — \`render_subagent_picker\` (centered modal, \`▶\` on selected, scrolls when the list overflows the terminal) + help-overlay entry.
- \`src/tui/app/interaction_tests.rs\` — tests for open/cancel/no-op.

## Test plan

- [x] \`cargo fmt --all -- --check\`, \`cargo clippy --all-targets\`, \`cargo build\` clean. No new clippy warnings from this change.
- [x] \`cargo test\` — 820 passed; the single failure (\`tui::semantic_worker::tests::empty_prewarm_search_builds_cache_without_idle_short_circuit\`) is pre-existing and environmental (it tries to fetch \`onnx/model.onnx\`); confirmed it fails identically on unmodified \`main\`.
- [x] Unit tests for \`discover_subagents\`: with meta, meta-missing fallback, non-`agent-*` / non-jsonl files ignored, empty when no \`subagents/\` dir.
- [x] Interaction tests: picker opens and the selected subagent renders in view mode; \`Esc\` closes without changing the viewed conversation; \`s\` on a session with no subagents is a no-op with a status hint.
- [x] Manual smoke test against real openclaw sessions under \`CLAUDE_CONFIG_DIR\`: \`s\` on a session with 8 sidecar subagents lists them with correct types/descriptions; opening one renders its full conversation.

## Notes

- Standard inline sidechains (\`isSidechain\` entries inside the parent transcript) are unchanged — they continue to render inline (gated by \`--show-thinking\`/\`T\`). This PR only adds a path to the sidecar-file layout.
- No new dependencies. Reuses the existing conversation parser and viewer, so subagent transcripts get markdown rendering, tool-result toggles, search, etc. for free.
- \`tool_use_id\` from the meta sidecar is parsed and stored on \`SubagentEntry\` but not yet surfaced in the UI; it's available if a future change wants to jump from the parent's \`Task\`/\`Agent\` tool call to the matching subagent.