### PR TITLE
semantic: fit chunks inside the model's 512-token window

### DIFF
--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -6,7 +6,7 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-pub const DEFAULT_CHUNK_TARGET_CHARS: usize = 2_400;
+pub const DEFAULT_CHUNK_TARGET_CHARS: usize = 1_600;
 pub const DEFAULT_CHUNK_OVERLAP_CHARS: usize = 300;
 pub const DEFAULT_CHUNK_CONTEXT_TURNS: usize = 1;
 pub const DEFAULT_EMBEDDING_BATCH_SIZE: usize = 32;


### PR DESCRIPTION
One constant: `DEFAULT_CHUNK_TARGET_CHARS` 2,400 → 1,600.

## The defect

BGE-small reads 512 tokens per passage. Claude Code transcripts tokenise at about 0.28 tokens per character (measured with the model's own tokenizer over 15,350 chunks from 1,540 conversations on one machine), because file paths, identifiers, JSON and code split into short tokens. A 2,400-character chunk therefore encodes to roughly 666 tokens. fastembed truncates the encoding at 512 before the model runs, so the last ~550 characters of a full-size chunk reach no vector. Only the 300-character overlap into the next chunk covers any of it.

Over that corpus:

| target | chunks | chunks truncated | chunk text reaching the model |
|---|---|---|---|
| 2,400 (current) | 15,350 | 7,793 (50.8%) | 84.4% |
| 1,600 | 24,293 | 3,590 (14.8%) | 97.1% |
| 1,200 | 33,697 | 814 (2.4%) | 99.7% |

Text in the dropped tail is unreachable by semantic search unless the same words also fall in the overlap.

## Retrieval effect

Chunk size also changes what one vector describes. At 2,400 a prompt is pooled with about 2,000 characters of neighbouring turns into a single CLS vector, which lowers its cosine to a query about that prompt. Measured on 36 real user prompts as queries against the chunks of 24 conversations (fastembed 5.13, batch 32):

| target | top-1 correct (of 36) | MRR | paired top-1 vs 2,400 |
|---|---|---|---|
| 2,400 | 24 | 0.750 | — |
| 1,600 | 29 | 0.863 | +7 / −2 |
| 1,200 | 32 | 0.918 | +8 / −0 |

n = 36, so single-query differences are noise; the direction is consistent across targets.

## Cost

- Chunk count +58%, embedding cache file from 25.9 MB to an estimated 41 MB (bytes per entry held constant).
- One full re-embed for existing installs: `cache_matches_config` compares `chunk_target_chars`, so the next semantic search or `--generate-semantic-cache` starts from an empty cache and shows the existing progress bar. On an M2 Pro CPU the corpus above took an estimated 21 minutes at 2,400 and 26 minutes at 1,600 (rate measured on a 24-conversation subset, extrapolated).
- Steady-state embedding of new sessions runs at the same per-chunk cost; more chunks, each shorter, so slightly more total work per conversation.

## Why 1,600 and not 1,200 or a longer-window model

1,200 removes almost all truncation but doubles the chunk count and cache. 1,600 is where truncation falls to a code-heavy residue before the count doubles. A longer-window model (GTE-base at 1,024 tokens, 768-d) was measured on the same queries: 25 of 36 top-1, 3.9× slower per passage, 4.4× the download, and identical ranking to the same model at 512 tokens, so reading the tail through a bigger model returned nothing here.

## Checks

`cargo fmt --check` exit 0; `cargo clippy --all --locked` 23 warnings, the same as main; `cargo test --all --locked` 815 + 11 + 1 passed, 0 failed; `cargo build --all --locked` exit 0.
