### PR TITLE
annotations: notes attached to a conversation, read from any tool, searched with it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.18",
  "toml",
+ "toml_edit",
  "unicode-width",
 ]
 
@@ -3283,10 +3284,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3299,19 +3300,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "winnow",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4026,6 +4049,15 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ tempfile = "3"
 indicatif = "0.17"
 fastembed = { version = "5.13", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries-rustls-tls"] }
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["load-dynamic"], optional = true }
+toml_edit = "0.25.13"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,106 @@ Claude resume default arguments apply only to Claude sessions.
 
 ### Delete empty transcripts
 
+### Annotations
+
+An annotation is text attached to a conversation from outside it: a note you
+write, or a summary a tool generates. Annotations live in their own files and
+never change a transcript, and they are searched alongside conversation content.
+
+```sh
+claude-history annotate --text "decided against the cache rewrite here"
+claude-history annotate ch_1234abcd5678 --line 412 --kind recap --text "..."
+claude-history annotate ch_1234abcd5678 --line 3 --line 7..9 --text "..."
+claude-history annotate ch_1234abcd5678 --session --text "..."
+claude-history annotate ch_1234abcd5678 --delete an_18d1c251bbf7eec8
+```
+
+A conversation is named by a `ch_` ref from search output or by a transcript
+path. With none named, the session id Claude Code exports and the working
+directory's project folder compose into the running session's transcript. With
+no `--line`, the annotation attaches to the last line marked
+`promptSource: "typed"`, which is the last prompt a person typed; `--session`
+attaches it to the conversation as a whole and conflicts with `--line`.
+`--kind` is a free label the writer chooses, defaulting to `note`, which is what
+the viewer writes for an annotation a person types; `--delete` names the `id`
+reported when the annotation was written.
+
+Search reports an annotation hit with `source=annotation`, so text you attached
+is never mistaken for something said in the conversation.
+
+Annotations are read from every registered annotator and merged. Writes go to
+exactly one of them:
+
+```sh
+claude-history annotators list
+claude-history annotators add chsum --command "chsum annotations" --name "Chsum"
+claude-history annotators write-to chsum
+claude-history annotators remove chsum
+```
+
+`file` is built in: one JSONL sidecar per conversation under
+`~/.local/share/claude-history/annotations`, and the annotator writes go to
+while no other is named. Notes written under an earlier configuration keep being
+read, so changing where writes go moves nothing on disk.
+
+An external annotator is a command invoked as `<command> read|write|delete`,
+with one JSON object on stdin and one on stdout:
+
+```
+read    {"conversations": ["/path/session.jsonl"]}
+     -> {"annotations": [{"conversation": "/path/session.jsonl", "id": "an_1",
+                          "targets": [3, "7..9"], "kind": "recap", "text": "...",
+                          "created": "2026-09-06T09:15:00+10:00",
+                          "modified": "2026-09-08T11:42:00+10:00",
+                          "origin": {"path": "/path/subagents/agent-1.jsonl",
+                                     "lines": "412..430"}}]}
+write   {"conversation": "...", "targets": [...], "kind": "...", "text": "...",
+         "created": "...", "modified": "...", "replaces": "an_1"}
+     -> {"id": "an_2"}
+delete  {"conversation": "...", "id": "an_2"}
+     -> {"deleted": true}
+```
+
+A read carries every conversation in scope, so the command runs once per query
+rather than once per conversation. `origin` is optional: it names a file the note
+summarises when that file is not the conversation itself, such as a subagent's
+transcript, and the viewer prints it in the note's trailer and includes it when
+the note is yanked. `created` and `modified` are RFC 3339 stamps, both optional:
+the viewer prints the creation time in the trailer as `created 4 days ago`, in
+the same relative form the list uses -- "3 hours ago", "yesterday", "4 days ago"
+-- and the edit time beside it as `edited yesterday` where the two render
+differently. An edit through the viewer carries `created`
+forward from the note it replaces and moves `modified` to the time of the edit.
+A note carrying neither renders without times.
+
+`replaces` names the annotation a write supersedes, present on an edit and on a
+move and absent on a new note. An annotator acting on it updates that record and
+returns its id, which keeps the id and the note's history intact. An annotator
+ignoring it stores a new record and returns a new id, and claude-history removes
+the superseded one, which is the behaviour before the field existed. The
+built-in `file` annotator takes the second path: its records are one line each,
+keyed by id, so a superseded line is removed rather than rewritten. The annotator mints the id on write, and a
+later delete names it. A non-zero exit drops that annotator from the merge and
+the rest still render.
+
+Those commands write `~/.config/claude-history/config.toml`, which can also be
+edited by hand:
+
+```toml
+[annotations]
+write_to = "chsum"
+
+[annotators.file]
+root = "~/.local/share/claude-history/annotations"
+
+[annotators.chsum]
+command = "chsum annotations"
+name = "Chsum"
+```
+
+`name` is the label the viewer prints beside each note, truncated to nine
+characters; with it absent the key is used with its first letter capitalised.
+
 Use `delete-empty` to find transcript files that have no Claude messages, such as
 sessions that only contain slash commands like `/status` or `/plugin`.
 
@@ -214,7 +314,7 @@ JSONL files and their matching session artifact directories.
 | `t`            | Cycle tools: summary/truncated/full                |
 | `T`            | Toggle thinking                                    |
 | `e`            | Export conversation to file                        |
-| `y`            | Copy to clipboard (message if selected, else menu) |
+| `y`            | Copy to clipboard (message or note if selected)    |
 | `p`            | Show file path                                     |
 | `Y`            | Copy file path to clipboard                        |
 | `I`            | Copy session ID to clipboard                       |
@@ -400,6 +500,8 @@ Usage: claude-history [OPTIONS] [FILE]
 Commands:
   agent         Run agent-oriented search and transcript commands
   delete-empty  Delete transcript files with no Claude messages
+  annotate      Attach an annotation to a conversation, or remove one
+  annotators    Register the tools annotations are read from and written to
   update        Update claude-history to the latest version
 
 Arguments:

--- a/skills/claude-history/SKILL.md
+++ b/skills/claude-history/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: claude-history
-description: Find, browse, read, or quote prior Claude Code conversations with the claude-history CLI.
+description: Find, browse, read, quote, or annotate prior Claude Code conversations with the claude-history CLI.
 ---
 
 # claude-history
 
-Use this skill to find, browse, read, or quote prior Claude Code conversations
-with `claude-history`.
+Use this skill to find, browse, read, quote, or annotate prior Claude Code
+conversations with `claude-history`.
 
 ## Safety
 
@@ -115,6 +115,29 @@ claude-history agent read ch_1234abcd5678:m8 --match "historical correction" --c
 Sliced output numbers content lines. A `>` marks a matching line, and `...`
 marks omitted lines between match windows. Both options require one
 single-message ref.
+
+## Annotations
+
+An annotation is text attached to a conversation from outside it. Annotation
+files sit beside the transcripts and never change them, and search returns their
+text alongside conversation content.
+
+```sh
+claude-history annotate --text "decided against the cache rewrite here"
+claude-history annotate ch_1234abcd5678 --line 412 --kind recap --text "..."
+claude-history annotate ch_1234abcd5678 --session --text "..."
+claude-history annotate ch_1234abcd5678 --delete an_18d1c251bbf7eec8
+```
+
+With no conversation named, `CLAUDE_CODE_SESSION_ID` and the working directory's
+project folder compose into the running session's transcript. With no `--line`,
+the annotation attaches to the last line marked `promptSource: "typed"`, which is
+the last prompt a person typed. `--session` attaches it to the conversation as a
+whole and conflicts with `--line`. `--kind` is a free label defaulting to `note`.
+`--delete` names the `id` reported when the annotation was written.
+
+A search hit carrying `source=annotation` came from an annotation, not from
+something said in the conversation.
 
 Failures exit nonzero and write one typed compact line to stderr:
 

--- a/src/agent/retrieval.rs
+++ b/src/agent/retrieval.rs
@@ -17,6 +17,9 @@ pub enum AgentHitSource {
     Dialogue,
     Tool,
     Thinking,
+    /// Text a producer attached to the conversation. Named separately so a hit
+    /// on an annotation does not read as something said in the conversation.
+    Annotation,
 }
 
 pub type AgentHitRenderOptions = ContentVisibility;
@@ -578,6 +581,7 @@ fn source_rank(source: AgentHitSource) -> u8 {
         AgentHitSource::Dialogue => 0,
         AgentHitSource::Tool => 1,
         AgentHitSource::Thinking => 2,
+        AgentHitSource::Annotation => 3,
     }
 }
 

--- a/src/agent/search.rs
+++ b/src/agent/search.rs
@@ -495,6 +495,7 @@ pub fn run_global_lexical_search(
         ranked_indices,
         load_transcript,
         |_, _| {},
+        &HashMap::new(),
     )
 }
 
@@ -505,6 +506,7 @@ pub fn run_global_lexical_search_reporting(
     ranked_indices: &[usize],
     load_transcript: impl Fn(&AgentConversationKey) -> Result<AgentTranscript>,
     mut report_error: impl FnMut(&AgentConversationKey, &AppError),
+    annotations: &HashMap<usize, crate::annotations::ConversationAnnotations>,
 ) -> Result<AgentSearchOutput> {
     let mode = effective_agent_mode(
         &request.query,
@@ -531,6 +533,14 @@ pub fn run_global_lexical_search_reporting(
         let Some(resolved) = resolved_by_path.get(&conversation.path) else {
             continue;
         };
+        if let Some(found) = annotations.get(&index) {
+            hits.extend(annotation_hits(
+                &request.query,
+                conversation,
+                resolved,
+                found,
+            ));
+        }
         let transcript = match load_transcript(&resolved.key) {
             Ok(transcript) => transcript,
             Err(error) => {
@@ -768,6 +778,62 @@ fn retrieval_output_hit(
     }
 }
 
+/// Hits built from annotation text rather than from transcript content.
+///
+/// The lexical path extracts evidence from the loaded transcript, and annotation
+/// text is not in the transcript, so a conversation shortlisted on an annotation
+/// yields no transcript hit and is dropped. These hits carry the annotation text
+/// as their own evidence.
+///
+/// `focus_range` is `MessageRange::single(1)`: annotation targets are line
+/// numbers and this field is ordinal space, so a target placed here would reach
+/// `agent read` as a message range that need not exist.
+fn annotation_hits(
+    query: &str,
+    conversation: &Conversation,
+    resolved: &ResolvedConversation,
+    annotations: &crate::annotations::ConversationAnnotations,
+) -> Vec<AgentOutputHit> {
+    let needle = crate::text_match::normalize_for_search(query);
+    let terms = needle.split_whitespace().collect::<Vec<_>>();
+    if terms.is_empty() {
+        return Vec::new();
+    }
+    let range = MessageRange::single(1);
+    annotations
+        .session
+        .iter()
+        .chain(annotations.positioned.iter())
+        .filter_map(|annotation| {
+            let haystack = crate::text_match::normalize_for_search(&annotation.text);
+            let matched = terms.iter().filter(|term| haystack.contains(*term)).count();
+            if matched == 0 {
+                return None;
+            }
+            // Every term present scores 1.0; a partial match scores its share,
+            // so an annotation covering the whole query outranks one covering
+            // half of it.
+            let score = matched as f64 / terms.len() as f64;
+            Some(AgentOutputHit {
+                conversation_ref: resolved.reference.canonical(),
+                project_id: resolved.key.project_id(),
+                conversation_uuid: resolved.reference.uuid(),
+                session: resolved.key.session_filename.clone(),
+                anchors: Vec::new(),
+                title: title_for_conversation(conversation),
+                score,
+                evidence_score: score,
+                source: AgentHitKind::Lexical,
+                evidence_source: AgentHitSource::Annotation,
+                render_options: AgentHitRenderOptions::default(),
+                preview: format_evidence_preview(&annotation.text),
+                focus_range: range,
+                read_range: range,
+            })
+        })
+        .collect()
+}
+
 fn anchors_for_range(
     transcript: &AgentTranscript,
     resolved: &ResolvedConversation,
@@ -867,6 +933,7 @@ fn semantic_evidence_source(source: SemanticChunkSource) -> AgentHitSource {
         SemanticChunkSource::AgentThinking | SemanticChunkSource::AgentSubagentThinking => {
             AgentHitSource::Thinking
         }
+        SemanticChunkSource::Annotation => AgentHitSource::Annotation,
     }
 }
 
@@ -959,8 +1026,7 @@ fn build_conversation_groups(
         }
     }
     for group in &mut by_ref {
-        sort_group_hits(&mut group.hits);
-        group.hits.truncate(hits_per_conversation);
+        truncate_group_hits(&mut group.hits, hits_per_conversation);
         group.score = group
             .hits
             .first()
@@ -994,8 +1060,48 @@ fn push_group_hit(
         return;
     }
     group.hits.push(hit);
-    sort_group_hits(&mut group.hits);
-    group.hits.truncate(hits_per_conversation);
+    truncate_group_hits(&mut group.hits, hits_per_conversation);
+}
+
+/// Trim one conversation's hits to the cap, giving annotation evidence a share
+/// of the slots proportional to its share of the hits.
+///
+/// An annotation hit scores the share of query terms its text carries, so at
+/// most 1.0, while a transcript hit scores higher. Ranked together, every note
+/// from a conversation whose transcript also matches falls below the cap and
+/// the conversation reports no annotation evidence at all.
+fn truncate_group_hits(hits: &mut Vec<AgentOutputHit>, cap: usize) {
+    sort_group_hits(hits);
+    if hits.len() <= cap || cap == 0 {
+        hits.truncate(cap);
+        return;
+    }
+    let annotation_count = hits
+        .iter()
+        .filter(|hit| hit.evidence_source == AgentHitSource::Annotation)
+        .count();
+    if annotation_count == 0 {
+        hits.truncate(cap);
+        return;
+    }
+
+    // Proportional, and at least one: a conversation carrying a matching note
+    // reports it, and one carrying thirty does not fill the group with them.
+    let reserved = ((cap * annotation_count) / hits.len()).clamp(1, cap);
+    let mut annotations = Vec::new();
+    let mut others = Vec::new();
+    for hit in hits.drain(..) {
+        if hit.evidence_source == AgentHitSource::Annotation {
+            if annotations.len() < reserved {
+                annotations.push(hit);
+            }
+        } else if others.len() < cap - reserved {
+            others.push(hit);
+        }
+    }
+    hits.extend(annotations);
+    hits.extend(others);
+    sort_group_hits(hits);
 }
 
 fn same_evidence_identity(existing: &AgentOutputHit, candidate: &AgentOutputHit) -> bool {
@@ -1039,6 +1145,7 @@ fn evidence_source_rank(source: AgentHitSource) -> u8 {
         AgentHitSource::Dialogue => 0,
         AgentHitSource::Tool => 1,
         AgentHitSource::Thinking => 2,
+        AgentHitSource::Annotation => 3,
     }
 }
 
@@ -1228,6 +1335,7 @@ fn output_source_atom(hit: &AgentOutputHit) -> &'static str {
         AgentHitSource::Dialogue => hit_source_atom(hit.source),
         AgentHitSource::Tool => "tool",
         AgentHitSource::Thinking => "thinking",
+        AgentHitSource::Annotation => "annotation",
     }
 }
 
@@ -1304,6 +1412,158 @@ mod tests {
             reference: key.conversation_ref(),
             key,
         }
+    }
+
+    fn annotations_of(
+        entries: &[(&str, &str, Vec<usize>)],
+    ) -> crate::annotations::ConversationAnnotations {
+        crate::annotations::ConversationAnnotations::from_flat(
+            entries
+                .iter()
+                .map(|(id, text, targets)| crate::annotations::Annotation {
+                    id: (*id).to_string(),
+                    targets: targets
+                        .iter()
+                        .map(|line| crate::annotations::TargetSpan::single(*line))
+                        .collect(),
+                    kind: "note".to_string(),
+                    text: (*text).to_string(),
+                    annotator: String::new(),
+                    origin: None,
+                    created: None,
+                    modified: None,
+                })
+                .collect(),
+        )
+    }
+
+    /// One hit at `score` from `source`, enough for the trimming rules.
+    fn hit_from(source: AgentHitSource, score: f64) -> AgentOutputHit {
+        AgentOutputHit {
+            conversation_ref: "ch_1".to_string(),
+            project_id: "pr_1".to_string(),
+            conversation_uuid: "uuid".to_string(),
+            session: "session.jsonl".to_string(),
+            anchors: Vec::new(),
+            title: String::new(),
+            score,
+            evidence_score: score,
+            source: AgentHitKind::Lexical,
+            evidence_source: source,
+            render_options: AgentHitRenderOptions::default(),
+            preview: String::new(),
+            focus_range: MessageRange::single(1),
+            read_range: MessageRange::single(1),
+        }
+    }
+
+    fn annotation_count(hits: &[AgentOutputHit]) -> usize {
+        hits.iter()
+            .filter(|hit| hit.evidence_source == AgentHitSource::Annotation)
+            .count()
+    }
+
+    #[test]
+    fn a_matching_note_keeps_a_slot_against_higher_scoring_transcript_hits() {
+        let mut hits = vec![
+            hit_from(AgentHitSource::Dialogue, 4.0),
+            hit_from(AgentHitSource::Dialogue, 4.0),
+            hit_from(AgentHitSource::Dialogue, 4.0),
+            hit_from(AgentHitSource::Dialogue, 4.0),
+            hit_from(AgentHitSource::Annotation, 1.0),
+        ];
+
+        truncate_group_hits(&mut hits, 2);
+
+        // An annotation scores at most 1.0 and a transcript hit scores higher,
+        // so ranking alone drops every note from a conversation its transcript
+        // also matches.
+        assert_eq!(hits.len(), 2);
+        assert_eq!(annotation_count(&hits), 1);
+    }
+
+    #[test]
+    fn notes_take_slots_in_proportion_to_their_share_of_the_hits() {
+        let mut hits = (0..8)
+            .map(|_| hit_from(AgentHitSource::Annotation, 1.0))
+            .chain((0..2).map(|_| hit_from(AgentHitSource::Dialogue, 4.0)))
+            .collect::<Vec<_>>();
+
+        truncate_group_hits(&mut hits, 5);
+
+        // Eight of ten hits are notes, so four of five slots are theirs and the
+        // transcript keeps one.
+        assert_eq!(hits.len(), 5);
+        assert_eq!(annotation_count(&hits), 4);
+    }
+
+    #[test]
+    fn a_group_without_notes_trims_by_score_alone() {
+        let mut hits = vec![
+            hit_from(AgentHitSource::Dialogue, 4.0),
+            hit_from(AgentHitSource::Dialogue, 3.0),
+            hit_from(AgentHitSource::Dialogue, 2.0),
+        ];
+
+        truncate_group_hits(&mut hits, 2);
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(annotation_count(&hits), 0);
+    }
+
+    #[test]
+    fn annotation_hits_carry_their_own_evidence_and_source() {
+        let conversation = conversation("/p/a.jsonl", "title");
+        let resolved = resolved("/p/a.jsonl");
+        let annotations = annotations_of(&[
+            ("a", "the cache invalidation approach changed", vec![12]),
+            ("b", "unrelated note about deployments", vec![]),
+        ]);
+
+        let hits = annotation_hits("cache invalidation", &conversation, &resolved, &annotations);
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].evidence_source, AgentHitSource::Annotation);
+        assert!(hits[0].preview.contains("cache invalidation"));
+        // Line targets are not ordinals, so the focus stays at the session
+        // rather than naming messages that need not exist.
+        assert_eq!(hits[0].focus_range, MessageRange::single(1));
+        assert_eq!(hits[0].score, 1.0);
+    }
+
+    #[test]
+    fn annotation_hits_score_by_share_of_query_terms_present() {
+        let conversation = conversation("/p/a.jsonl", "title");
+        let resolved = resolved("/p/a.jsonl");
+        let annotations = annotations_of(&[
+            ("full", "retry backoff behaviour", vec![1]),
+            ("half", "retry only, no mention of the other term", vec![2]),
+        ]);
+
+        let hits = annotation_hits("retry backoff", &conversation, &resolved, &annotations);
+
+        assert_eq!(hits.len(), 2);
+        let full = hits
+            .iter()
+            .find(|hit| hit.preview.contains("behaviour"))
+            .unwrap();
+        let half = hits
+            .iter()
+            .find(|hit| hit.preview.contains("no mention"))
+            .unwrap();
+        assert_eq!(full.score, 1.0);
+        assert_eq!(half.score, 0.5);
+    }
+
+    #[test]
+    fn annotation_hits_are_empty_when_nothing_matches() {
+        let conversation = conversation("/p/a.jsonl", "title");
+        let resolved = resolved("/p/a.jsonl");
+        let annotations = annotations_of(&[("a", "something else entirely", vec![1])]);
+
+        let hits = annotation_hits("cache invalidation", &conversation, &resolved, &annotations);
+
+        assert!(hits.is_empty());
     }
 
     fn request(query: &str, mode: Option<SearchMode>) -> AgentWithinRequest {

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -416,7 +416,7 @@ impl AgentService {
     }
 }
 
-fn discover_agent_keys(
+pub(crate) fn discover_agent_keys(
     project_filter: Option<&str>,
 ) -> Result<(Vec<agent::refs::AgentConversationKey>, Vec<AgentWarning>)> {
     let root = history::get_claude_projects_root().map_err(structured_agent_error)?;

--- a/src/agent/service.rs
+++ b/src/agent/service.rs
@@ -153,6 +153,9 @@ impl AgentService {
 
     fn run_search(&self, args: &cli::AgentSearchArgs) -> Result<String> {
         let config = config::load_config()?;
+        // Built before the per-section moves below: those partially move
+        // `config` and end any borrow of it as a whole.
+        let annotators = crate::annotations::AnnotatorSet::from_config(&config);
         let search_config = config.search.unwrap_or_default();
         let agent_config = config.agent.unwrap_or_default();
         // Resolved before loading so an inverted range fails without paying for
@@ -177,6 +180,12 @@ impl AgentService {
             scope,
             current_project_dir_name.as_deref(),
         )?;
+        // After scoping, so a --local query reads annotations for one project
+        // rather than for every conversation on the machine, and before the
+        // corpus is chunked, because the chunker is rebuilt from these
+        // conversations and the query arrives after the load.
+        let annotations =
+            crate::annotations::enrich_scoped(&mut conversations, &scoped, &annotators)?;
         let request = agent::search::AgentSearchRequest {
             query: args.query.clone(),
             top: configured_usize(args.top, DEFAULT_SEARCH_TOP, agent_config.top),
@@ -236,6 +245,7 @@ impl AgentService {
                             ),
                         ));
                     },
+                    &annotations,
                 )?;
                 apply_configured_render_policy(&mut output, &agent_config);
                 return Ok(agent::search::format_agent_output_with_warnings(
@@ -244,8 +254,14 @@ impl AgentService {
                 ));
             }
             SearchMode::Semantic => {
-                let (mut output, mut warnings) =
-                    run_agent_semantic_search(self, &request, &conversations, &keys, &scoped)?;
+                let (mut output, mut warnings) = run_agent_semantic_search(
+                    self,
+                    &request,
+                    &conversations,
+                    &keys,
+                    &scoped,
+                    &annotations,
+                )?;
                 apply_configured_render_policy(&mut output, &agent_config);
                 warnings.splice(0..0, base_warnings);
                 return Ok(agent::search::format_agent_output_with_warnings(
@@ -280,9 +296,10 @@ impl AgentService {
                             ),
                         ));
                     },
+                    &annotations,
                 )?;
                 let inputs = agent_inputs_for_indices(&conversations, &keys, &scoped)?;
-                match run_agent_semantic_hits(&args.query, &inputs) {
+                match run_agent_semantic_hits(&args.query, &inputs, &annotations) {
                     Ok((semantic, semantic_warnings)) => {
                         warnings.borrow_mut().extend(semantic_warnings);
                         let mut output = agent::search::run_global_hybrid_search(
@@ -315,6 +332,7 @@ impl AgentService {
                                     ),
                                 ));
                             },
+                            &annotations,
                         )?;
                         let mut output = lexical;
                         output.mode = SearchMode::Hybrid;
@@ -805,9 +823,10 @@ fn run_agent_semantic_search(
     conversations: &[history::Conversation],
     keys: &[agent::refs::AgentConversationKey],
     indices: &[usize],
+    annotations: &std::collections::HashMap<usize, crate::annotations::ConversationAnnotations>,
 ) -> Result<(agent::search::AgentSearchOutput, Vec<AgentWarning>)> {
     let inputs = agent_inputs_for_indices(conversations, keys, indices)?;
-    let (semantic, warnings) = run_agent_semantic_hits(&request.query, &inputs)?;
+    let (semantic, warnings) = run_agent_semantic_hits(&request.query, &inputs, annotations)?;
     let mut output = agent::search::run_global_semantic_search(request, &inputs, &semantic);
     attach_input_transcript_metadata(service, &mut output, &inputs);
     Ok((output, warnings))
@@ -837,6 +856,7 @@ fn attach_input_transcript_metadata(
 fn run_agent_semantic_hits(
     query: &str,
     inputs: &[agent::search::AgentConversationInput<'_>],
+    annotations: &std::collections::HashMap<usize, crate::annotations::ConversationAnnotations>,
 ) -> Result<(Vec<semantic::types::SemanticHit>, Vec<AgentWarning>)> {
     let mut candidates = Vec::with_capacity(inputs.len().saturating_mul(2));
     for input in inputs {
@@ -857,6 +877,15 @@ fn run_agent_semantic_hits(
                 index: input.original_index,
                 source: semantic::types::SemanticChunkSource::AgentRoute,
                 conversation: std::sync::Arc::new(route),
+            });
+        }
+        if let Some(found) = annotations.get(&input.original_index)
+            && let Some(annotated) = annotation_semantic_conversation(input.conversation, found)
+        {
+            candidates.push(semantic::index::SemanticIndexCandidate {
+                index: input.original_index,
+                source: semantic::types::SemanticChunkSource::Annotation,
+                conversation: std::sync::Arc::new(annotated),
             });
         }
     }
@@ -895,6 +924,44 @@ pub(crate) fn agent_route_semantic_conversation(
                 .copied()
                 .unwrap_or_else(|| agent::refs::MessageRange::single(1)),
         ],
+    ))
+}
+
+/// A candidate carrying only annotation text, tagged
+/// `SemanticChunkSource::Annotation`.
+///
+/// Built as its own candidate rather than appended to the conversation's
+/// semantic turns, because a source applies per conversation and the chunker
+/// concatenates consecutive turns: appended annotations would be absorbed into
+/// dialogue chunks and never carry the annotation source.
+///
+/// Every turn takes `MessageRange::single(1)`. The range is ordinal space and
+/// annotation targets are line space; a target placed here would reach
+/// `agent read` as `m{start}..m{end}` and name messages that need not exist.
+/// The hit identifies the conversation, and the annotation's own text names its
+/// lines.
+pub(crate) fn annotation_semantic_conversation(
+    conversation: &history::Conversation,
+    annotations: &crate::annotations::ConversationAnnotations,
+) -> Option<history::Conversation> {
+    let turns = annotations
+        .texts()
+        .filter(|text| !text.trim().is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if turns.is_empty() {
+        return None;
+    }
+    let file_name = conversation
+        .path
+        .file_name()
+        .map(|name| format!("{}.annotations-semantic", name.to_string_lossy()))?;
+    let ranges = vec![agent::refs::MessageRange::single(1); turns.len()];
+    Some(stripped_semantic_conversation(
+        conversation,
+        conversation.path.with_file_name(file_name),
+        turns,
+        ranges,
     ))
 }
 
@@ -1646,6 +1713,85 @@ mod tests {
                 .ends_with("session.jsonl.agent-route-semantic")
         );
         assert!(!route.semantic_turns[0].contains("should not be copied"));
+    }
+
+    #[test]
+    fn the_annotation_candidate_carries_one_turn_per_note() {
+        let conversation = crate::semantic::test_fixtures::SemanticConversationFixture::new(
+            "/tmp/session.jsonl",
+            ["dialogue that should not be copied into the candidate"],
+        )
+        .build();
+        let annotations = crate::annotations::ConversationAnnotations::from_flat(vec![
+            crate::annotations::Annotation {
+                id: "a".to_string(),
+                targets: vec![crate::annotations::TargetSpan::single(4)],
+                kind: "recap".to_string(),
+                text: "cache rewrite reverted".to_string(),
+                annotator: "chsum".to_string(),
+                origin: None,
+                created: None,
+                modified: None,
+            },
+            crate::annotations::Annotation {
+                id: "b".to_string(),
+                targets: Vec::new(),
+                kind: "note".to_string(),
+                text: "decided against it here".to_string(),
+                annotator: "chsum".to_string(),
+                origin: None,
+                created: None,
+                modified: None,
+            },
+        ]);
+
+        let candidate = annotation_semantic_conversation(&conversation, &annotations).unwrap();
+
+        // One turn per note, so the chunker groups them independently and a hit
+        // names one note rather than a run of them.
+        assert_eq!(candidate.semantic_turns.len(), 2);
+        assert!(
+            candidate
+                .semantic_turns
+                .contains(&"cache rewrite reverted".to_string())
+        );
+        assert!(
+            !candidate.semantic_turns[0].contains("should not be copied"),
+            "{:?}",
+            candidate.semantic_turns
+        );
+        // Every range is ordinal m1: annotation targets are line space, and a
+        // line placed here would reach `agent read` as a message that need not
+        // exist.
+        assert!(
+            candidate
+                .semantic_turn_ranges
+                .iter()
+                .all(|range| *range == agent::refs::MessageRange::single(1))
+        );
+        assert!(
+            candidate
+                .path
+                .to_string_lossy()
+                .ends_with("session.jsonl.annotations-semantic")
+        );
+    }
+
+    #[test]
+    fn a_conversation_without_notes_builds_no_annotation_candidate() {
+        let conversation = crate::semantic::test_fixtures::SemanticConversationFixture::new(
+            "/tmp/session.jsonl",
+            ["dialogue"],
+        )
+        .build();
+
+        let candidate = annotation_semantic_conversation(
+            &conversation,
+            &crate::annotations::ConversationAnnotations::default(),
+        );
+
+        // An empty candidate would embed and cache a conversation with no text.
+        assert!(candidate.is_none());
     }
 
     #[test]

--- a/src/annotations/command.rs
+++ b/src/annotations/command.rs
@@ -1,0 +1,270 @@
+//! The `claude-history annotate` command.
+
+use super::{Annotation, TargetSpan};
+use crate::cli::AnnotateArgs;
+use crate::error::{AppError, Result};
+
+/// Parse one `--line` value: `7` names a single line, `7..9` a run of them.
+fn parse_line_argument(value: &str) -> Result<TargetSpan> {
+    let Some((start, end)) = value.split_once("..") else {
+        return value
+            .trim()
+            .parse::<usize>()
+            .map(TargetSpan::single)
+            .map_err(|_| {
+                AppError::ConfigError(format!("--line {value} is not a line number or a range"))
+            });
+    };
+    let start = start
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| AppError::ConfigError(format!("--line {value} has a non-numeric start")))?;
+    let end = end
+        .trim()
+        .parse::<usize>()
+        .map_err(|_| AppError::ConfigError(format!("--line {value} has a non-numeric end")))?;
+    if end < start {
+        return Err(AppError::ConfigError(format!(
+            "--line {value} ends before it starts"
+        )));
+    }
+    Ok(TargetSpan { start, end })
+}
+
+/// An identifier for an annotation the caller did not name.
+///
+/// The clock supplies the leading half and a counter the trailing half: two
+/// writes inside one clock tick read the same nanosecond, and an id repeated
+/// there would address the earlier annotation on a later delete.
+pub fn generated_id() -> String {
+    static SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or_default();
+    let sequence = SEQUENCE.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("an_{now:x}_{sequence:x}")
+}
+
+/// The transcript the running session writes to.
+///
+/// Claude Code exports the session id, and the project directory follows from
+/// the working directory, so the two compose into a path without a search. An
+/// unset id or a missing file leaves the command without a target, and the
+/// error names which of the two is absent.
+fn live_session_transcript() -> Result<std::path::PathBuf> {
+    let session = std::env::var("CLAUDE_CODE_SESSION_ID").unwrap_or_default();
+    if session.is_empty() {
+        return Err(AppError::ConfigError(
+            "no conversation named and CLAUDE_CODE_SESSION_ID is unset; name a ch_ ref or a transcript path"
+                .to_string(),
+        ));
+    }
+    let working = std::env::current_dir().map_err(|error| {
+        AppError::ConfigError(format!("working directory does not resolve: {error}"))
+    })?;
+    let path = crate::history::get_claude_projects_dir(&working)?.join(format!("{session}.jsonl"));
+    if !path.is_file() {
+        return Err(AppError::ConfigError(format!(
+            "session {session} has no transcript at {}",
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+/// The line carrying the last prompt a person typed into the transcript.
+///
+/// Claude Code marks a typed prompt with `promptSource: "typed"`. A `!` shell
+/// invocation, its output, and a tool result carry no such mark, so the mark
+/// separates what the person said from what the session recorded around it. A
+/// transcript holding no typed prompt yields no line and the annotation covers
+/// the conversation as a whole.
+fn latest_typed_prompt_line(path: &std::path::Path) -> Result<Option<usize>> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(path).map_err(|error| {
+        AppError::ConfigError(format!("{} does not open: {error}", path.display()))
+    })?;
+    let mut latest = None;
+    for (index, line) in std::io::BufReader::new(file).lines().enumerate() {
+        let Ok(line) = line else { continue };
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let is_user = record.get("type").and_then(serde_json::Value::as_str) == Some("user");
+        let is_typed = record
+            .get("promptSource")
+            .and_then(serde_json::Value::as_str)
+            == Some("typed");
+        if is_user && is_typed {
+            latest = Some(index + 1);
+        }
+    }
+    Ok(latest)
+}
+
+pub fn run_annotate(args: AnnotateArgs) -> Result<String> {
+    let annotators = super::AnnotatorSet::from_current_config();
+    // A transcript path is accepted alongside a ch_ ref. The viewer and a tool
+    // watching the file already hold a path; without this arm each one runs a
+    // search that returns the reference the path already names. Anything else
+    // goes through the shared agent resolver, so annotate accepts the same
+    // reference forms as read and outline.
+    let (conversation, label) = match args.reference.as_deref() {
+        Some(reference) if std::path::Path::new(reference).is_file() => {
+            (std::path::PathBuf::from(reference), reference.to_string())
+        }
+        Some(reference) => {
+            let (keys, _) = crate::agent::service::discover_agent_keys(None)?;
+            let resolved =
+                crate::agent::service::resolve_agent_conversation_arg(reference, Some(&keys))?;
+            let label = resolved.reference.canonical();
+            (resolved.key.path.clone(), label)
+        }
+        None => {
+            let path = live_session_transcript()?;
+            (path, "this session".to_string())
+        }
+    };
+
+    if let Some(id) = args.delete {
+        // The annotation is addressed by id rather than by position, because a
+        // store is rewritten whenever anything is removed from it and every
+        // position after the removal would shift. The annotator holding it is
+        // found by reading, so a delete reaches the store the id came from.
+        let annotations = annotators.read_one(&conversation);
+        let holder = annotations
+            .session
+            .iter()
+            .chain(annotations.positioned.iter())
+            .find(|annotation| annotation.id == id)
+            .map(|annotation| annotation.annotator.clone())
+            .unwrap_or_default();
+        if annotators.delete(&conversation, &id, &holder)? {
+            return Ok(format!("removed {id}\n"));
+        }
+        return Err(AppError::ConfigError(format!(
+            "no annotation with id {id} on {label}"
+        )));
+    }
+
+    let Some(text) = args.text else {
+        return Err(AppError::ConfigError(
+            "--text is required when not deleting".to_string(),
+        ));
+    };
+
+    // A note with no line named follows the last thing the person typed, which
+    // is where they were when they wrote it. `--session` covers the whole
+    // conversation instead, and named lines override both.
+    let mut targets = Vec::with_capacity(args.lines.len());
+    for line in &args.lines {
+        targets.push(parse_line_argument(line)?);
+    }
+    if targets.is_empty() && !args.session {
+        if let Some(line) = latest_typed_prompt_line(&conversation)? {
+            targets.push(TargetSpan::single(line));
+        }
+    }
+    let placement = match targets.first() {
+        Some(span) => format!(" at line {}", span.start),
+        None => String::new(),
+    };
+
+    let stamp = crate::annotations::now_rfc3339();
+    let annotation = Annotation {
+        id: args.id.unwrap_or_else(generated_id),
+        targets,
+        kind: args.kind,
+        text,
+        annotator: String::new(),
+        origin: None,
+        created: Some(stamp.clone()),
+        modified: Some(stamp),
+    };
+
+    // The id reported is the one the annotator stored under, which is what a
+    // later delete names.
+    let stored = annotators.write(&conversation, &annotation, None)?;
+
+    Ok(format!("annotated {label}{placement} as {stored}\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_number_is_a_single_line() {
+        assert_eq!(parse_line_argument("7").unwrap(), TargetSpan::single(7));
+    }
+
+    #[test]
+    fn a_range_covers_its_whole_run() {
+        assert_eq!(
+            parse_line_argument("7..9").unwrap(),
+            TargetSpan { start: 7, end: 9 }
+        );
+    }
+
+    #[test]
+    fn a_range_ending_before_it_starts_is_refused() {
+        assert!(parse_line_argument("9..7").is_err());
+    }
+
+    #[test]
+    fn a_non_numeric_line_is_refused() {
+        assert!(parse_line_argument("m7").is_err());
+    }
+
+    #[test]
+    fn generated_ids_do_not_collide_across_calls() {
+        assert_ne!(generated_id(), generated_id());
+    }
+
+    /// Write `lines` as one transcript and return its path.
+    fn transcript(dir: &tempfile::TempDir, lines: &[&str]) -> std::path::PathBuf {
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(&path, format!("{}\n", lines.join("\n"))).unwrap();
+        path
+    }
+
+    #[test]
+    fn typed_prompt_line_is_the_last_typed_user_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = transcript(
+            &dir,
+            &[
+                r#"{"type":"user","promptSource":"typed"}"#,
+                r#"{"type":"assistant"}"#,
+                r#"{"type":"user","promptSource":"typed"}"#,
+                r#"{"type":"assistant"}"#,
+            ],
+        );
+        assert_eq!(latest_typed_prompt_line(&path).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn shell_invocation_and_tool_result_carry_no_typed_mark() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = transcript(
+            &dir,
+            &[
+                r#"{"type":"user","promptSource":"typed"}"#,
+                r#"{"type":"user"}"#,
+                r#"{"type":"user","toolUseResult":{"stdout":"ok"}}"#,
+            ],
+        );
+        assert_eq!(latest_typed_prompt_line(&path).unwrap(), Some(1));
+    }
+
+    #[test]
+    fn transcript_without_a_typed_prompt_yields_no_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = transcript(
+            &dir,
+            &[r#"{"type":"user"}"#, r#"{"type":"assistant"}"#, "not json"],
+        );
+        assert_eq!(latest_typed_prompt_line(&path).unwrap(), None);
+    }
+}

--- a/src/annotations/command_annotator.rs
+++ b/src/annotations/command_annotator.rs
@@ -1,0 +1,365 @@
+//! An annotator backed by an external command.
+//!
+//! The command is invoked as `<command> <op>` with one JSON object on stdin and
+//! one on stdout. A non-zero exit is the store refusing the operation and is
+//! reported as an error: a read drops the annotator from the merge, a write
+//! surfaces at the keystroke that caused it.
+
+use super::{Annotation, Annotator, ConversationAnnotations};
+use crate::error::{AppError, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Invokes a configured command for each operation.
+pub struct CommandAnnotator {
+    command_line: String,
+}
+
+#[derive(Serialize)]
+struct ReadRequest<'a> {
+    conversations: Vec<&'a Path>,
+}
+
+#[derive(Deserialize)]
+struct ReadResponse {
+    #[serde(default)]
+    annotations: Vec<ReadAnnotation>,
+}
+
+#[derive(Deserialize)]
+struct ReadAnnotation {
+    conversation: PathBuf,
+    #[serde(flatten)]
+    annotation: Annotation,
+}
+
+#[derive(Serialize)]
+struct WriteRequest<'a> {
+    conversation: &'a Path,
+    /// The annotation this write supersedes, absent on a new note.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replaces: Option<&'a str>,
+    #[serde(flatten)]
+    annotation: &'a Annotation,
+}
+
+#[derive(Deserialize)]
+struct WriteResponse {
+    id: String,
+}
+
+#[derive(Serialize)]
+struct DeleteRequest<'a> {
+    conversation: &'a Path,
+    id: &'a str,
+}
+
+#[derive(Deserialize)]
+struct DeleteResponse {
+    #[serde(default)]
+    deleted: bool,
+}
+
+impl CommandAnnotator {
+    pub fn new(command_line: impl Into<String>) -> Self {
+        Self {
+            command_line: command_line.into(),
+        }
+    }
+
+    /// Run one operation, writing `payload` to stdin and parsing stdout.
+    fn invoke<T: for<'de> Deserialize<'de>>(&self, operation: &str, payload: &str) -> Result<T> {
+        let mut parts = self.command_line.split_whitespace();
+        let Some(program) = parts.next() else {
+            return Err(AppError::ConfigError(
+                "annotator command is empty".to_string(),
+            ));
+        };
+
+        let mut child = Command::new(program)
+            .args(parts)
+            .arg(operation)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(payload.as_bytes())?;
+        }
+        // stdin closes before the wait, so a command reading to end of input
+        // reaches it rather than blocking while this process blocks on exit.
+        drop(child.stdin.take());
+
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            return Err(AppError::ConfigError(format!(
+                "annotator command `{}` exited with {}",
+                self.command_line, output.status
+            )));
+        }
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            AppError::ConfigError(format!(
+                "annotator command `{}` returned unreadable {operation} output: {error}",
+                self.command_line
+            ))
+        })
+    }
+}
+
+impl Annotator for CommandAnnotator {
+    fn read(&self, conversations: &[&Path]) -> Result<Vec<(PathBuf, ConversationAnnotations)>> {
+        if conversations.is_empty() {
+            return Ok(Vec::new());
+        }
+        let payload = serde_json::to_string(&ReadRequest {
+            conversations: conversations.to_vec(),
+        })?;
+        let response: ReadResponse = self.invoke("read", &payload)?;
+
+        // The request set bounds the response: an annotation naming a
+        // conversation outside it would render inside a transcript it does not
+        // describe.
+        let requested = conversations
+            .iter()
+            .map(|path| path.to_path_buf())
+            .collect::<HashSet<_>>();
+        let mut by_conversation: Vec<(PathBuf, Vec<Annotation>)> = Vec::new();
+        for entry in response.annotations {
+            if !requested.contains(&entry.conversation) {
+                continue;
+            }
+            match by_conversation
+                .iter_mut()
+                .find(|(path, _)| *path == entry.conversation)
+            {
+                Some((_, annotations)) => annotations.push(entry.annotation),
+                None => by_conversation.push((entry.conversation, vec![entry.annotation])),
+            }
+        }
+
+        Ok(by_conversation
+            .into_iter()
+            .map(|(path, annotations)| (path, ConversationAnnotations::from_flat(annotations)))
+            .collect())
+    }
+
+    fn write(
+        &self,
+        conversation: &Path,
+        annotation: &Annotation,
+        replaces: Option<&str>,
+    ) -> Result<String> {
+        let payload = serde_json::to_string(&WriteRequest {
+            conversation,
+            replaces,
+            annotation,
+        })?;
+        let response: WriteResponse = self.invoke("write", &payload)?;
+        Ok(response.id)
+    }
+
+    fn delete(&self, conversation: &Path, id: &str) -> Result<bool> {
+        let payload = serde_json::to_string(&DeleteRequest { conversation, id })?;
+        let response: DeleteResponse = self.invoke("delete", &payload)?;
+        Ok(response.deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Writes an executable shell script that prints `stdout_body` and exits
+    /// with `code`, and returns a command line invoking it.
+    fn stub(dir: &Path, stdout_body: &str, code: i32) -> String {
+        let path = dir.join("stub.sh");
+        std::fs::write(
+            &path,
+            format!("#!/bin/sh\ncat > /dev/null\nprintf '%s' '{stdout_body}'\nexit {code}\n"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path.display().to_string()
+    }
+
+    #[test]
+    fn a_read_returns_the_annotations_the_command_prints() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = r#"{"annotations":[{"conversation":"/tmp/a.jsonl","id":"n1","targets":[3],"kind":"recap","text":"hello"}]}"#;
+        let annotator = CommandAnnotator::new(stub(dir.path(), body, 0));
+
+        let read = annotator.read(&[Path::new("/tmp/a.jsonl")]).unwrap();
+
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].0, PathBuf::from("/tmp/a.jsonl"));
+        assert_eq!(read[0].1.positioned[0].text, "hello");
+    }
+
+    #[test]
+    fn a_read_carries_the_origin_the_command_states() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = r#"{"annotations":[{"conversation":"/tmp/a.jsonl","id":"n1","targets":[443],"kind":"recap","text":"agent work","origin":{"path":"/tmp/subagents/agent-1.jsonl","lines":"412..430"}}]}"#;
+        let annotator = CommandAnnotator::new(stub(dir.path(), body, 0));
+
+        let read = annotator.read(&[Path::new("/tmp/a.jsonl")]).unwrap();
+
+        let origin = read[0].1.positioned[0]
+            .origin
+            .as_ref()
+            .expect("origin read");
+        assert_eq!(origin.path, PathBuf::from("/tmp/subagents/agent-1.jsonl"));
+        assert_eq!(origin.lines, "412..430");
+        assert_eq!(origin.short(), "agent-1 @412..430");
+    }
+
+    #[test]
+    fn stamps_on_the_read_wire_reach_the_annotation() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = concat!(
+            r#"{"annotations":[{"conversation":"/tmp/a.jsonl","id":"n1","kind":"recap","#,
+            r#""text":"hello","created":"2026-09-01T09:00:00+10:00","#,
+            r#""modified":"2026-09-03T14:30:00+10:00"}]}"#
+        );
+        let annotator = CommandAnnotator::new(stub(dir.path(), body, 0));
+
+        let read = annotator.read(&[Path::new("/tmp/a.jsonl")]).unwrap();
+
+        let annotation = &read[0].1.session[0];
+        assert_eq!(
+            annotation.created.as_deref(),
+            Some("2026-09-01T09:00:00+10:00")
+        );
+        assert_eq!(
+            annotation.modified.as_deref(),
+            Some("2026-09-03T14:30:00+10:00")
+        );
+    }
+
+    #[test]
+    fn an_annotation_without_stamps_reads_with_neither() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = r#"{"annotations":[{"conversation":"/tmp/a.jsonl","id":"n1","kind":"recap","text":"hello"}]}"#;
+        let annotator = CommandAnnotator::new(stub(dir.path(), body, 0));
+
+        let read = annotator.read(&[Path::new("/tmp/a.jsonl")]).unwrap();
+
+        let annotation = &read[0].1.session[0];
+        assert!(annotation.created.is_none());
+        assert!(annotation.modified.is_none());
+    }
+
+    #[test]
+    fn a_conversation_outside_the_request_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = r#"{"annotations":[{"conversation":"/tmp/other.jsonl","id":"n1","kind":"recap","text":"hello"}]}"#;
+        let annotator = CommandAnnotator::new(stub(dir.path(), body, 0));
+
+        let read = annotator.read(&[Path::new("/tmp/a.jsonl")]).unwrap();
+
+        assert!(read.is_empty());
+    }
+
+    #[test]
+    fn a_non_zero_exit_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let annotator = CommandAnnotator::new(stub(dir.path(), "", 3));
+
+        assert!(annotator.read(&[Path::new("/tmp/a.jsonl")]).is_err());
+    }
+
+    #[test]
+    fn a_write_returns_the_id_the_command_minted() {
+        let dir = tempfile::tempdir().unwrap();
+        let annotator = CommandAnnotator::new(stub(dir.path(), r#"{"id":"an_from_store"}"#, 0));
+
+        let id = annotator
+            .write(
+                Path::new("/tmp/a.jsonl"),
+                &Annotation {
+                    id: "proposed".to_string(),
+                    ..Annotation::default()
+                },
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(id, "an_from_store");
+    }
+
+    /// A stub that copies its stdin to `record` and prints `stdout_body`, so a
+    /// test reads the request the annotator was sent.
+    fn recording_stub(dir: &Path, record: &Path, stdout_body: &str) -> String {
+        let path = dir.join("recording.sh");
+        std::fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\ncat > '{}'\nprintf '%s' '{stdout_body}'\n",
+                record.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path.display().to_string()
+    }
+
+    #[test]
+    fn a_write_replacing_a_note_names_it_on_the_wire() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = dir.path().join("request.json");
+        let annotator =
+            CommandAnnotator::new(recording_stub(dir.path(), &record, r#"{"id":"an_1"}"#));
+
+        let id = annotator
+            .write(
+                Path::new("/tmp/a.jsonl"),
+                &Annotation {
+                    id: "proposed".to_string(),
+                    ..Annotation::default()
+                },
+                Some("an_1"),
+            )
+            .unwrap();
+
+        let request: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&record).unwrap()).unwrap();
+        assert_eq!(request["replaces"], "an_1");
+        // The annotator kept the id, which is how a caller reads "updated in
+        // place" and skips removing the superseded record.
+        assert_eq!(id, "an_1");
+    }
+
+    #[test]
+    fn a_write_creating_a_note_names_nothing_it_replaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = dir.path().join("request.json");
+        let annotator =
+            CommandAnnotator::new(recording_stub(dir.path(), &record, r#"{"id":"an_new"}"#));
+
+        annotator
+            .write(Path::new("/tmp/a.jsonl"), &Annotation::default(), None)
+            .unwrap();
+
+        let request: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&record).unwrap()).unwrap();
+        assert!(request.get("replaces").is_none(), "{request}");
+    }
+
+    #[test]
+    fn a_delete_reports_what_the_command_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let annotator = CommandAnnotator::new(stub(dir.path(), r#"{"deleted":false}"#, 0));
+
+        assert!(!annotator.delete(Path::new("/tmp/a.jsonl"), "n1").unwrap());
+    }
+
+    #[test]
+    fn unreadable_output_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let annotator = CommandAnnotator::new(stub(dir.path(), "not json", 0));
+
+        assert!(annotator.read(&[Path::new("/tmp/a.jsonl")]).is_err());
+    }
+}

--- a/src/annotations/file_annotator.rs
+++ b/src/annotations/file_annotator.rs
@@ -1,0 +1,245 @@
+//! The file annotator: one JSONL sidecar per conversation, under a configured
+//! root laid out by project directory.
+//!
+//! An absent root and an absent sidecar each yield no annotations, so a user who
+//! has configured nothing pays one directory check per project and reads no
+//! files.
+
+use super::{Annotation, Annotator, ConversationAnnotations};
+use crate::error::Result;
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+/// Reads annotations from `<root>/<project dir>/<session>.jsonl`.
+pub struct FileAnnotator {
+    root: PathBuf,
+}
+
+impl FileAnnotator {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+/// The sidecar path for a conversation, mirroring the project directory name the
+/// conversation itself sits under.
+///
+/// A conversation whose path has no parent directory or no file stem has no
+/// sidecar, because neither half of the layout can be formed.
+pub fn sidecar_path(root: &Path, conversation: &Path) -> Option<PathBuf> {
+    let project = conversation.parent()?.file_name()?;
+    let session = conversation.file_stem()?;
+    let mut file_name = session.to_os_string();
+    file_name.push(".jsonl");
+    Some(root.join(project).join(file_name))
+}
+
+/// Parse one sidecar. Lines that do not parse are skipped rather than failing
+/// the read, so one malformed record does not hide every annotation in the file.
+fn read_sidecar(path: &Path) -> Vec<Annotation> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let reader = std::io::BufReader::new(file);
+    let mut annotations = Vec::new();
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(annotation) = serde_json::from_str::<Annotation>(&line) {
+            annotations.push(annotation);
+        }
+    }
+    annotations
+}
+
+impl Annotator for FileAnnotator {
+    fn read(&self, conversations: &[&Path]) -> Result<Vec<(PathBuf, ConversationAnnotations)>> {
+        if !self.root.is_dir() {
+            return Ok(Vec::new());
+        }
+
+        // One existence check per project directory rather than per
+        // conversation: a user with annotations in one project pays a single
+        // stat for every other project instead of one per conversation in it.
+        let mut project_exists: HashMap<PathBuf, bool> = HashMap::new();
+        let mut results = Vec::new();
+
+        for conversation in conversations {
+            let Some(path) = sidecar_path(&self.root, conversation) else {
+                continue;
+            };
+            let Some(project_dir) = path.parent() else {
+                continue;
+            };
+            let exists = *project_exists
+                .entry(project_dir.to_path_buf())
+                .or_insert_with(|| project_dir.is_dir());
+            if !exists {
+                continue;
+            }
+            let annotations = read_sidecar(&path);
+            if annotations.is_empty() {
+                continue;
+            }
+            results.push((
+                conversation.to_path_buf(),
+                ConversationAnnotations::from_flat(annotations),
+            ));
+        }
+
+        Ok(results)
+    }
+
+    /// `replaces` is not acted on: records are one JSONL line each, keyed by
+    /// id, and the caller's delete removes the superseded line. The new record
+    /// carries the new id.
+    fn write(
+        &self,
+        conversation: &Path,
+        annotation: &Annotation,
+        _replaces: Option<&str>,
+    ) -> Result<String> {
+        super::write::append_to_file(&self.root, conversation, annotation)?;
+        Ok(annotation.id.clone())
+    }
+
+    fn delete(&self, conversation: &Path, id: &str) -> Result<bool> {
+        super::write::remove_from_file(&self.root, conversation, id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::TargetSpan;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn sidecar_path_mirrors_the_project_directory() {
+        let conversation = PathBuf::from("/home/u/.claude/projects/-home-u-code/abc.jsonl");
+        let path = sidecar_path(Path::new("/root"), &conversation).unwrap();
+        assert_eq!(path, PathBuf::from("/root/-home-u-code/abc.jsonl"));
+    }
+
+    #[test]
+    fn absent_root_yields_no_annotations() {
+        let annotator = FileAnnotator::new("/does/not/exist");
+        let conversation = PathBuf::from("/home/u/.claude/projects/p/abc.jsonl");
+        let read = annotator.read(&[conversation.as_path()]).unwrap();
+        assert!(read.is_empty());
+    }
+
+    #[test]
+    fn absent_project_directory_yields_no_annotations() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("other")).unwrap();
+        let annotator = FileAnnotator::new(root.path());
+        let conversation = PathBuf::from("/home/u/.claude/projects/p/abc.jsonl");
+        let read = annotator.read(&[conversation.as_path()]).unwrap();
+        assert!(read.is_empty());
+    }
+
+    #[test]
+    fn reads_positioned_and_session_annotations() {
+        let root = tempfile::tempdir().unwrap();
+        write(
+            &root.path().join("p/abc.jsonl"),
+            concat!(
+                r#"{"id":"a","targets":[12],"kind":"recap","text":"later"}"#,
+                "\n",
+                r#"{"id":"b","targets":[],"kind":"note","text":"whole session"}"#,
+                "\n",
+                r#"{"id":"c","targets":[3,"7..9"],"kind":"recap","text":"earlier"}"#,
+                "\n",
+            ),
+        );
+        let annotator = FileAnnotator::new(root.path());
+        let conversation = PathBuf::from("/home/u/.claude/projects/p/abc.jsonl");
+        let read = annotator.read(&[conversation.as_path()]).unwrap();
+
+        assert_eq!(read.len(), 1);
+        let (path, annotations) = &read[0];
+        assert_eq!(path, &conversation);
+        assert_eq!(annotations.session.len(), 1);
+        assert_eq!(annotations.session[0].id, "b");
+
+        // Positioned annotations sort by anchor line, so a caller merges them
+        // against messages in one pass.
+        let ids = annotations
+            .positioned
+            .iter()
+            .map(|annotation| annotation.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["c", "a"]);
+        assert_eq!(
+            annotations.positioned[0].targets,
+            vec![TargetSpan::single(3), TargetSpan { start: 7, end: 9 }]
+        );
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_without_hiding_the_rest() {
+        let root = tempfile::tempdir().unwrap();
+        write(
+            &root.path().join("p/abc.jsonl"),
+            concat!(
+                "{not json\n",
+                "\n",
+                r#"{"id":"a","targets":[1],"kind":"note","text":"kept"}"#,
+                "\n",
+            ),
+        );
+        let annotator = FileAnnotator::new(root.path());
+        let conversation = PathBuf::from("/home/u/.claude/projects/p/abc.jsonl");
+        let read = annotator.read(&[conversation.as_path()]).unwrap();
+
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].1.positioned.len(), 1);
+        assert_eq!(read[0].1.positioned[0].text, "kept");
+    }
+
+    #[test]
+    fn a_range_ending_before_it_starts_is_rejected() {
+        let parsed = serde_json::from_str::<Annotation>(
+            r#"{"id":"a","targets":["9..7"],"kind":"note","text":"t"}"#,
+        );
+        assert!(parsed.is_err());
+    }
+}
+
+/// Annotation count per sidecar path, from one walk of the root.
+///
+/// The list screen states a count for every conversation it draws. Reading each
+/// conversation's sidecar on its own opens one file per row and one directory
+/// check per project; the sidecars that exist are the only ones carrying a
+/// count, so the walk visits exactly them.
+pub fn sidecar_counts(root: &Path) -> HashMap<PathBuf, usize> {
+    let mut counts = HashMap::new();
+    let Ok(projects) = std::fs::read_dir(root) else {
+        return counts;
+    };
+    for project in projects.flatten() {
+        let Ok(sidecars) = std::fs::read_dir(project.path()) else {
+            continue;
+        };
+        for sidecar in sidecars.flatten() {
+            let path = sidecar.path();
+            if path.extension().is_some_and(|ext| ext == "jsonl") {
+                let count = read_sidecar(&path).len();
+                if count > 0 {
+                    counts.insert(path, count);
+                }
+            }
+        }
+    }
+    counts
+}

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,0 +1,374 @@
+//! Annotations: external text attached to a conversation, optionally at one or
+//! more line positions within it.
+//!
+//! claude-history reads, indexes, and renders annotations. Authoring happens
+//! outside it: `kind` is a free string the producer sets, and `id` is the
+//! producer's handle for deletion.
+
+use crate::error::Result;
+use serde::de::{self, Deserializer, Visitor};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+mod command;
+mod command_annotator;
+mod file_annotator;
+mod registry_command;
+mod set;
+mod write;
+
+pub use command::{generated_id, run_annotate};
+pub use command_annotator::CommandAnnotator;
+pub use file_annotator::{FileAnnotator, sidecar_counts, sidecar_path};
+pub use registry_command::run as run_annotators;
+pub use set::AnnotatorSet;
+
+/// A contiguous run of JSONL lines an annotation attaches to.
+///
+/// Deserializes from either a bare number (`3`) or a range string (`"7..9"`).
+/// A bare number is the degenerate span whose start and end are equal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TargetSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl TargetSpan {
+    pub fn single(line: usize) -> Self {
+        Self {
+            start: line,
+            end: line,
+        }
+    }
+}
+
+impl Serialize for TargetSpan {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        if self.start == self.end {
+            serializer.serialize_u64(self.start as u64)
+        } else {
+            serializer.serialize_str(&format!("{}..{}", self.start, self.end))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetSpan {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        struct SpanVisitor;
+
+        impl<'de> Visitor<'de> for SpanVisitor {
+            type Value = TargetSpan;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a line number or a \"start..end\" range string")
+            }
+
+            fn visit_u64<E: de::Error>(self, value: u64) -> std::result::Result<TargetSpan, E> {
+                Ok(TargetSpan::single(value as usize))
+            }
+
+            fn visit_i64<E: de::Error>(self, value: i64) -> std::result::Result<TargetSpan, E> {
+                if value < 0 {
+                    return Err(E::custom("line number is negative"));
+                }
+                Ok(TargetSpan::single(value as usize))
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> std::result::Result<TargetSpan, E> {
+                let Some((start, end)) = value.split_once("..") else {
+                    return value
+                        .parse::<usize>()
+                        .map(TargetSpan::single)
+                        .map_err(|_| E::custom(format!("target {value} is not a line or range")));
+                };
+                let start = start
+                    .trim()
+                    .parse::<usize>()
+                    .map_err(|_| E::custom(format!("target {value} has a non-numeric start")))?;
+                let end = end
+                    .trim()
+                    .parse::<usize>()
+                    .map_err(|_| E::custom(format!("target {value} has a non-numeric end")))?;
+                if end < start {
+                    return Err(E::custom(format!("target {value} ends before it starts")));
+                }
+                Ok(TargetSpan { start, end })
+            }
+        }
+
+        deserializer.deserialize_any(SpanVisitor)
+    }
+}
+
+/// One annotation attached to a conversation.
+///
+/// An empty `targets` list makes the annotation session-level: it names no line
+/// and carries no position within the conversation.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+pub struct Annotation {
+    pub id: String,
+    #[serde(default)]
+    pub targets: Vec<TargetSpan>,
+    pub kind: String,
+    pub text: String,
+    /// Key of the annotator holding this annotation, filled in after a read.
+    /// Skipped by serde so the stored record carries no annotator name: the
+    /// same file read through a differently named entry stays valid, and a
+    /// delete reaches the annotator the note came from.
+    #[serde(skip)]
+    pub annotator: String,
+    /// Where the annotated material sits outside this conversation: an agent's
+    /// transcript and the rows a recap summarised. Supplied by the annotator on
+    /// the read wire; absent for a note about the conversation itself, so a
+    /// reader without it renders the note as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<AnnotationOrigin>,
+    /// When the annotation was first written, RFC 3339. An annotator that
+    /// sends no stamp leaves this absent and the note renders without a date,
+    /// so records written before stamps existed stay readable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+    /// When the annotation's text last changed, RFC 3339. An edit carries
+    /// `created` forward from the note it replaces and moves this to the time
+    /// of the edit, so the pair bounds the note's life rather than restarting
+    /// it at every edit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified: Option<String>,
+}
+
+/// The current local time as an RFC 3339 stamp, the form both timestamp fields
+/// carry on disk and on the annotator wire.
+pub fn now_rfc3339() -> String {
+    chrono::Local::now().to_rfc3339()
+}
+
+/// An RFC 3339 stamp as a local-time moment.
+///
+/// A stamp that does not parse yields nothing, so a malformed record renders
+/// without a time rather than with its raw string.
+pub fn stamp_moment(stamp: &str) -> Option<chrono::DateTime<chrono::Local>> {
+    chrono::DateTime::parse_from_rfc3339(stamp)
+        .ok()
+        .map(|moment| moment.with_timezone(&chrono::Local))
+}
+
+/// A path and, when the annotator states them, the rows within it, as `412` or
+/// `412..430`.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+pub struct AnnotationOrigin {
+    pub path: PathBuf,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub lines: String,
+}
+
+impl AnnotationOrigin {
+    /// The file stem and rows, the form short enough for a trailer.
+    pub fn short(&self) -> String {
+        let stem = self
+            .path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if self.lines.is_empty() {
+            stem
+        } else {
+            format!("{stem} @{}", self.lines)
+        }
+    }
+
+    /// The full path and rows, the form a reader opens.
+    pub fn long(&self) -> String {
+        if self.lines.is_empty() {
+            self.path.display().to_string()
+        } else {
+            format!("{} @{}", self.path.display(), self.lines)
+        }
+    }
+}
+
+impl Annotation {
+    /// An annotation with no targets attaches to the conversation as a whole.
+    pub fn is_session_level(&self) -> bool {
+        self.targets.is_empty()
+    }
+
+    /// The lowest line this annotation names. Session-level annotations return
+    /// `None`, which places them ahead of every positioned annotation.
+    pub fn anchor_line(&self) -> Option<usize> {
+        self.targets.iter().map(|span| span.start).min()
+    }
+}
+
+/// Annotations for one conversation, in the order the annotator returned them.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ConversationAnnotations {
+    pub session: Vec<Annotation>,
+    pub positioned: Vec<Annotation>,
+}
+
+impl ConversationAnnotations {
+    pub fn is_empty(&self) -> bool {
+        self.session.is_empty() && self.positioned.is_empty()
+    }
+
+    /// The number of notes attached, both session-level and positioned.
+    pub fn len(&self) -> usize {
+        self.session.len() + self.positioned.len()
+    }
+
+    /// Split a flat list into session-level and positioned, with positioned
+    /// sorted by anchor line so a caller can merge them against messages in one
+    /// pass.
+    pub fn from_flat(annotations: Vec<Annotation>) -> Self {
+        let (session, mut positioned): (Vec<_>, Vec<_>) = annotations
+            .into_iter()
+            .partition(Annotation::is_session_level);
+        positioned.sort_by_key(|annotation| annotation.anchor_line().unwrap_or(0));
+        Self {
+            session,
+            positioned,
+        }
+    }
+
+    /// Every annotation's text, session-level first, for appending to a
+    /// conversation's search fields.
+    pub fn texts(&self) -> impl Iterator<Item = &str> {
+        self.session
+            .iter()
+            .chain(self.positioned.iter())
+            .map(|annotation| annotation.text.as_str())
+    }
+}
+
+/// A source of annotations. Reads are batched: one call carries every
+/// conversation in scope, so an annotator backed by a subprocess runs once per
+/// query rather than once per conversation.
+pub trait Annotator {
+    fn read(&self, conversations: &[&Path]) -> Result<Vec<(PathBuf, ConversationAnnotations)>>;
+
+    /// Store one annotation and return the id it was stored under. The id is
+    /// the annotator's, so a later delete names what this annotator holds
+    /// rather than the id the caller supplied.
+    ///
+    /// `replaces` names the annotation this one supersedes, present on an edit
+    /// and on a move. An annotator that acts on it updates that record and
+    /// returns its id, which keeps the id and the note's history intact. An
+    /// annotator that ignores it stores a new record and returns a new id, and
+    /// the caller removes the superseded one, which is the behaviour before the
+    /// field existed.
+    fn write(
+        &self,
+        conversation: &Path,
+        annotation: &Annotation,
+        replaces: Option<&str>,
+    ) -> Result<String>;
+
+    /// Remove the annotation carrying `id`. The bool reports whether one was
+    /// found, so a caller states a missing id rather than a silent success.
+    fn delete(&self, conversation: &Path, id: &str) -> Result<bool>;
+}
+
+/// Annotations for one conversation, merged across every registered annotator.
+///
+/// Every failure yields no annotations rather than an error: a viewer opening a
+/// transcript shows the transcript whether or not annotations are readable.
+pub fn for_conversation(conversation: &Path) -> ConversationAnnotations {
+    let Ok(config) = crate::config::load_config() else {
+        return ConversationAnnotations::default();
+    };
+    AnnotatorSet::from_config(&config).read_one(conversation)
+}
+
+/// Read annotations for the scoped conversations and append their text to the
+/// lexical search fields, returning the annotations by conversation index.
+///
+/// The append reaches `agent_search_text` because agent search shortlists
+/// conversations from that field before loading any transcript; an annotation
+/// absent from it leaves its conversation unshortlisted and unfindable however
+/// well it matches. `full_text` and `search_text_lower` carry lexical scoring.
+///
+/// Semantic indexing takes the returned annotations and builds a separate
+/// candidate, because a `SemanticChunkSource` applies per conversation and an
+/// append here would be absorbed into dialogue chunks.
+pub fn enrich_scoped(
+    conversations: &mut [crate::history::Conversation],
+    scoped: &[usize],
+    annotators: &AnnotatorSet,
+) -> Result<std::collections::HashMap<usize, ConversationAnnotations>> {
+    let paths = scoped
+        .iter()
+        .filter_map(|index| conversations.get(*index))
+        .map(|conversation| conversation.path.as_path())
+        .collect::<Vec<_>>();
+    if paths.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    let read = annotators.read_all(&paths);
+    if read.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let by_path = read
+        .into_iter()
+        .collect::<std::collections::HashMap<_, _>>();
+
+    let mut by_index = std::collections::HashMap::new();
+    for index in scoped {
+        let Some(conversation) = conversations.get_mut(*index) else {
+            continue;
+        };
+        let Some(annotations) = by_path.get(&conversation.path) else {
+            continue;
+        };
+        if annotations.is_empty() {
+            continue;
+        }
+
+        let appended = annotations.texts().collect::<Vec<_>>().join("\n");
+        conversation.agent_search_text.push('\n');
+        conversation.agent_search_text.push_str(&appended);
+        conversation.full_text.push('\n');
+        conversation.full_text.push_str(&appended);
+        conversation
+            .search_text_lower
+            .push_str(&crate::text_match::normalize_for_search(&format!(
+                "\n{appended}"
+            )));
+
+        by_index.insert(*index, annotations.clone());
+    }
+
+    Ok(by_index)
+}
+
+#[cfg(test)]
+mod stamp_tests {
+    #[test]
+    fn a_stamp_returns_the_moment_it_names() {
+        // Built from the local clock, so the expected moment holds in any zone.
+        let now = chrono::Local::now();
+        let parsed = super::stamp_moment(&now.to_rfc3339()).expect("a written stamp parses");
+        assert_eq!(parsed.timestamp(), now.timestamp());
+    }
+
+    #[test]
+    fn a_stamp_in_another_zone_returns_the_same_instant() {
+        let parsed = super::stamp_moment("2026-09-06T12:00:00Z").expect("an RFC 3339 stamp parses");
+        let expected = chrono::DateTime::parse_from_rfc3339("2026-09-06T12:00:00Z").unwrap();
+        assert_eq!(parsed.timestamp(), expected.timestamp());
+    }
+
+    #[test]
+    fn a_stamp_that_does_not_parse_returns_no_moment() {
+        assert!(super::stamp_moment("last tuesday").is_none());
+    }
+
+    #[test]
+    fn a_written_stamp_parses_back() {
+        assert!(super::stamp_moment(&super::now_rfc3339()).is_some());
+    }
+}

--- a/src/annotations/registry_command.rs
+++ b/src/annotations/registry_command.rs
@@ -1,0 +1,226 @@
+//! `claude-history annotators`: the registrations annotations are read from and
+//! written to.
+//!
+//! Config is edited rather than regenerated, so comments and every section
+//! outside `[annotators]` survive the write.
+
+use crate::cli::{AnnotatorAddArgs, AnnotatorsCommand};
+use crate::config::{self, DEFAULT_ANNOTATOR};
+use crate::error::{AppError, Result};
+use std::path::PathBuf;
+use toml_edit::{DocumentMut, Item, Table, value};
+
+/// Read the config file into an editable document, an empty one when the file
+/// is absent.
+fn load_document(path: &PathBuf) -> Result<DocumentMut> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Ok(DocumentMut::new());
+    };
+    text.parse::<DocumentMut>()
+        .map_err(|error| AppError::ConfigError(format!("config at {}: {error}", path.display())))
+}
+
+fn save_document(path: &PathBuf, document: &DocumentMut) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, document.to_string())?;
+    Ok(())
+}
+
+fn config_path() -> Result<PathBuf> {
+    config::get_config_path().ok_or_else(|| {
+        AppError::ConfigError("no home directory, so no config file path".to_string())
+    })
+}
+
+/// The `[annotators]` table, created when absent.
+fn annotators_table(document: &mut DocumentMut) -> Result<&mut Table> {
+    let entry = document
+        .entry("annotators")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let table = entry.as_table_mut().ok_or_else(|| {
+        AppError::ConfigError("config key `annotators` is not a table".to_string())
+    })?;
+    // Implicit, so the file carries `[annotators.chsum]` alone rather than an
+    // empty `[annotators]` header above it.
+    table.set_implicit(true);
+    Ok(table)
+}
+
+pub fn run(command: AnnotatorsCommand) -> Result<String> {
+    match command {
+        AnnotatorsCommand::List => list(),
+        AnnotatorsCommand::Add(args) => add(args),
+        AnnotatorsCommand::Remove { key } => remove(&key),
+        AnnotatorsCommand::WriteTo { key } => write_to(&key),
+    }
+}
+
+fn list() -> Result<String> {
+    let config = config::load_config()?;
+    let set = super::AnnotatorSet::from_config(&config);
+    let write_target = set.write_target().to_string();
+
+    let mut output = String::new();
+    for key in set.keys() {
+        let label = set.label(key).unwrap_or(key);
+        let source = config
+            .annotators
+            .as_ref()
+            .and_then(|table| table.get(key))
+            .and_then(|entry| entry.command.clone())
+            .unwrap_or_else(|| match set.file_root() {
+                Some(root) => root.display().to_string(),
+                None => String::new(),
+            });
+        let marker = if key == write_target {
+            "  <- writes"
+        } else {
+            ""
+        };
+        output.push_str(&format!("  {key:<10} {label:<10} {source}{marker}\n"));
+    }
+    if output.is_empty() {
+        output.push_str("  no annotators registered\n");
+    }
+    Ok(output)
+}
+
+fn add(args: AnnotatorAddArgs) -> Result<String> {
+    if args.key == DEFAULT_ANNOTATOR {
+        return Err(AppError::ConfigError(format!(
+            "`{DEFAULT_ANNOTATOR}` is the built-in file annotator and takes no command"
+        )));
+    }
+    let path = config_path()?;
+    let mut document = load_document(&path)?;
+
+    let table = annotators_table(&mut document)?;
+    let entry = table
+        .entry(&args.key)
+        .or_insert_with(|| Item::Table(Table::new()));
+    let entry = entry.as_table_mut().ok_or_else(|| {
+        AppError::ConfigError(format!(
+            "config key `annotators.{}` is not a table",
+            args.key
+        ))
+    })?;
+    entry["command"] = value(&args.command);
+    match args.name {
+        Some(name) => entry["name"] = value(&name),
+        None => {
+            entry.remove("name");
+        }
+    }
+
+    save_document(&path, &document)?;
+    Ok(format!("registered {} as `{}`\n", args.key, args.command))
+}
+
+fn remove(key: &str) -> Result<String> {
+    let path = config_path()?;
+    let mut document = load_document(&path)?;
+
+    let table = annotators_table(&mut document)?;
+    if table.remove(key).is_none() {
+        return Err(AppError::ConfigError(format!(
+            "no annotator registered as {key}"
+        )));
+    }
+
+    // Writes addressed to a dropped annotator would fail at the next keystroke,
+    // so the target returns to the built-in file annotator with the
+    // registration.
+    let mut reset_write_target = false;
+    if super::AnnotatorSet::from_current_config().write_target() == key {
+        set_write_target(&mut document, DEFAULT_ANNOTATOR)?;
+        reset_write_target = true;
+    }
+
+    save_document(&path, &document)?;
+    if reset_write_target {
+        return Ok(format!(
+            "removed {key}; writes go to `{DEFAULT_ANNOTATOR}`\n"
+        ));
+    }
+    Ok(format!("removed {key}\n"))
+}
+
+fn set_write_target(document: &mut DocumentMut, key: &str) -> Result<()> {
+    let entry = document
+        .entry("annotations")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let table = entry.as_table_mut().ok_or_else(|| {
+        AppError::ConfigError("config key `annotations` is not a table".to_string())
+    })?;
+    table["write_to"] = value(key);
+    Ok(())
+}
+
+fn write_to(key: &str) -> Result<String> {
+    let config = config::load_config()?;
+    let registered = key == DEFAULT_ANNOTATOR
+        || config
+            .annotators
+            .as_ref()
+            .is_some_and(|table| table.contains_key(key));
+    if !registered {
+        return Err(AppError::ConfigError(format!(
+            "no annotator registered as {key}"
+        )));
+    }
+
+    let path = config_path()?;
+    let mut document = load_document(&path)?;
+    set_write_target(&mut document, key)?;
+    save_document(&path, &document)?;
+    Ok(format!("writes go to {key}\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adding_an_annotator_leaves_other_sections_and_comments_intact() {
+        let mut document = "# kept\n[display]\nwidth = 80\n"
+            .parse::<DocumentMut>()
+            .unwrap();
+
+        let table = annotators_table(&mut document).unwrap();
+        let entry = table
+            .entry("chsum")
+            .or_insert_with(|| Item::Table(Table::new()));
+        entry.as_table_mut().unwrap()["command"] = value("chsum annotations");
+
+        let rendered = document.to_string();
+        assert!(rendered.contains("# kept"), "{rendered}");
+        assert!(rendered.contains("width = 80"), "{rendered}");
+        assert!(
+            rendered.contains("command = \"chsum annotations\""),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn the_write_target_is_one_line_in_the_annotations_table() {
+        let mut document = "[annotations]\nroot = \"/tmp/notes\"\n"
+            .parse::<DocumentMut>()
+            .unwrap();
+
+        set_write_target(&mut document, "chsum").unwrap();
+
+        let rendered = document.to_string();
+        assert!(rendered.contains("root = \"/tmp/notes\""), "{rendered}");
+        assert!(rendered.contains("write_to = \"chsum\""), "{rendered}");
+    }
+
+    #[test]
+    fn a_missing_config_file_parses_as_an_empty_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let document = load_document(&dir.path().join("absent.toml")).unwrap();
+
+        assert_eq!(document.to_string(), "");
+    }
+}

--- a/src/annotations/set.rs
+++ b/src/annotations/set.rs
@@ -1,0 +1,388 @@
+//! The registered annotators, read together and written to one at a time.
+
+use super::{
+    Annotation, Annotator, CommandAnnotator, ConversationAnnotations, FileAnnotator, sidecar_counts,
+};
+use crate::config::{ConfigFile, DEFAULT_ANNOTATOR};
+use crate::error::{AppError, Result};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// One registered annotator: its key, the label the viewer prints, and the
+/// annotator itself.
+pub struct RegisteredAnnotator {
+    pub key: String,
+    pub label: String,
+    annotator: Box<dyn Annotator>,
+}
+
+/// Every registered annotator, plus the key writes are dispatched to.
+pub struct AnnotatorSet {
+    annotators: Vec<RegisteredAnnotator>,
+    write_to: String,
+    /// Root of the built-in file annotator, held for the startup count.
+    file_root: Option<PathBuf>,
+}
+
+/// The key rendered with its first letter capitalised, which is the label a
+/// registration without a `name` takes.
+fn label_from_key(key: &str) -> String {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+impl AnnotatorSet {
+    /// Build the set from config: every `[annotators.<key>]` carrying a
+    /// command, plus the built-in file annotator whenever a root resolves.
+    pub fn from_config(config: &ConfigFile) -> Self {
+        let file_root = crate::config::annotations_root(config);
+        let write_to = crate::config::annotation_write_target(config);
+        let mut annotators: Vec<RegisteredAnnotator> = Vec::new();
+
+        if let Some(root) = file_root.clone() {
+            annotators.push(RegisteredAnnotator {
+                key: DEFAULT_ANNOTATOR.to_string(),
+                label: config
+                    .annotators
+                    .as_ref()
+                    .and_then(|table| table.get(DEFAULT_ANNOTATOR))
+                    .and_then(|entry| entry.name.clone())
+                    .unwrap_or_else(|| label_from_key(DEFAULT_ANNOTATOR)),
+                annotator: Box::new(FileAnnotator::new(root)),
+            });
+        }
+
+        if let Some(table) = config.annotators.as_ref() {
+            for (key, entry) in table {
+                let Some(command) = entry.command.clone() else {
+                    continue;
+                };
+                annotators.push(RegisteredAnnotator {
+                    key: key.clone(),
+                    label: entry.name.clone().unwrap_or_else(|| label_from_key(key)),
+                    annotator: Box::new(CommandAnnotator::new(command)),
+                });
+            }
+        }
+
+        Self {
+            annotators,
+            write_to,
+            file_root,
+        }
+    }
+
+    /// The set built from the config file, empty when the file fails to load.
+    pub fn from_current_config() -> Self {
+        match crate::config::load_config() {
+            Ok(config) => Self::from_config(&config),
+            Err(_) => Self {
+                annotators: Vec::new(),
+                write_to: DEFAULT_ANNOTATOR.to_string(),
+                file_root: None,
+            },
+        }
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.annotators.iter().map(|entry| entry.key.as_str())
+    }
+
+    pub fn label(&self, key: &str) -> Option<&str> {
+        self.annotators
+            .iter()
+            .find(|entry| entry.key == key)
+            .map(|entry| entry.label.as_str())
+    }
+
+    /// Label per annotator key, for the viewer's name column.
+    pub fn labels(&self) -> HashMap<String, String> {
+        self.annotators
+            .iter()
+            .map(|entry| (entry.key.clone(), entry.label.clone()))
+            .collect()
+    }
+
+    pub fn write_target(&self) -> &str {
+        &self.write_to
+    }
+
+    pub fn file_root(&self) -> Option<&Path> {
+        self.file_root.as_deref()
+    }
+
+    /// Read every annotator and merge the results by conversation.
+    ///
+    /// An annotator that errors contributes nothing and the rest still return:
+    /// annotations are additive, and a store that is unreachable leaves the
+    /// transcript readable.
+    pub fn read_all(&self, conversations: &[&Path]) -> Vec<(PathBuf, ConversationAnnotations)> {
+        let mut merged: Vec<(PathBuf, Vec<Annotation>)> = Vec::new();
+
+        for entry in &self.annotators {
+            let Ok(read) = entry.annotator.read(conversations) else {
+                continue;
+            };
+            for (conversation, annotations) in read {
+                let mut flat = annotations
+                    .session
+                    .into_iter()
+                    .chain(annotations.positioned)
+                    .collect::<Vec<_>>();
+                for annotation in &mut flat {
+                    annotation.annotator = entry.key.clone();
+                }
+                match merged.iter_mut().find(|(path, _)| *path == conversation) {
+                    Some((_, existing)) => existing.extend(flat),
+                    None => merged.push((conversation, flat)),
+                }
+            }
+        }
+
+        merged
+            .into_iter()
+            .map(|(path, annotations)| (path, ConversationAnnotations::from_flat(annotations)))
+            .collect()
+    }
+
+    /// Annotations for one conversation, merged across annotators.
+    pub fn read_one(&self, conversation: &Path) -> ConversationAnnotations {
+        self.read_all(&[conversation])
+            .into_iter()
+            .next()
+            .map(|(_, annotations)| annotations)
+            .unwrap_or_default()
+    }
+
+    /// Note count per conversation, merged across annotators.
+    ///
+    /// The file annotator counts through one walk of its root rather than one
+    /// read per conversation, so a corpus with no command annotator registered
+    /// costs a directory walk at startup.
+    pub fn counts(&self, conversations: &[&Path]) -> HashMap<PathBuf, usize> {
+        let mut counts: HashMap<PathBuf, usize> = HashMap::new();
+
+        if let Some(root) = self.file_root.as_deref() {
+            let by_sidecar = sidecar_counts(root);
+            for conversation in conversations {
+                let Some(sidecar) = super::sidecar_path(root, conversation) else {
+                    continue;
+                };
+                if let Some(count) = by_sidecar.get(&sidecar) {
+                    *counts.entry(conversation.to_path_buf()).or_default() += count;
+                }
+            }
+        }
+
+        for entry in &self.annotators {
+            if entry.key == DEFAULT_ANNOTATOR {
+                continue;
+            }
+            let Ok(read) = entry.annotator.read(conversations) else {
+                continue;
+            };
+            for (conversation, annotations) in read {
+                *counts.entry(conversation).or_default() += annotations.len();
+            }
+        }
+
+        counts
+    }
+
+    /// Write one annotation to the configured target.
+    ///
+    /// A target naming no registered annotator is an error rather than a
+    /// fallback: a write silently landing somewhere other than where it was
+    /// addressed is the state INV-3 forbids.
+    pub fn write(
+        &self,
+        conversation: &Path,
+        annotation: &Annotation,
+        replaces: Option<&str>,
+    ) -> Result<String> {
+        self.write_to_annotator(&self.write_to, conversation, annotation, replaces)
+    }
+
+    /// Write one annotation to the annotator named by `key`.
+    ///
+    /// An edit and a move name the annotator holding the note, so a note stays
+    /// in the store that produced it. An empty key falls to the write target,
+    /// matching `delete`: a note written in this process carries no annotator
+    /// name until the next read. A key naming no registered annotator is an
+    /// error rather than a fallback: relocating a note as a consolation for a
+    /// refused write is the state INV-3 forbids.
+    pub fn write_to_annotator(
+        &self,
+        key: &str,
+        conversation: &Path,
+        annotation: &Annotation,
+        replaces: Option<&str>,
+    ) -> Result<String> {
+        let key = if key.is_empty() {
+            self.write_to.as_str()
+        } else {
+            key
+        };
+        let Some(entry) = self.annotators.iter().find(|entry| entry.key == key) else {
+            return Err(AppError::ConfigError(format!(
+                "`{key}` is not a registered annotator"
+            )));
+        };
+        entry.annotator.write(conversation, annotation, replaces)
+    }
+
+    /// Delete one annotation from the annotator holding it.
+    ///
+    /// `annotator` names that store, carried on the annotation since the read.
+    /// An empty name falls to the write target, which is where an annotation
+    /// written in this process sits.
+    pub fn delete(&self, conversation: &Path, id: &str, annotator: &str) -> Result<bool> {
+        let key = if annotator.is_empty() {
+            self.write_to.as_str()
+        } else {
+            annotator
+        };
+        let Some(entry) = self.annotators.iter().find(|entry| entry.key == key) else {
+            return Ok(false);
+        };
+        entry.annotator.delete(conversation, id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AnnotatorConfig;
+    use std::collections::BTreeMap;
+
+    fn config_with(
+        root: PathBuf,
+        entries: Vec<(&str, AnnotatorConfig)>,
+        write_to: &str,
+    ) -> ConfigFile {
+        let mut table = BTreeMap::new();
+        table.insert(
+            DEFAULT_ANNOTATOR.to_string(),
+            AnnotatorConfig {
+                root: Some(root),
+                ..AnnotatorConfig::default()
+            },
+        );
+        for (key, entry) in entries {
+            table.insert(key.to_string(), entry);
+        }
+        ConfigFile {
+            annotations: Some(crate::config::AnnotationsConfig {
+                root: None,
+                write_to: Some(write_to.to_string()),
+            }),
+            annotators: Some(table),
+            ..ConfigFile::default()
+        }
+    }
+
+    #[test]
+    fn a_registration_without_a_name_is_labelled_from_its_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with(
+            dir.path().to_path_buf(),
+            vec![(
+                "chsum",
+                AnnotatorConfig {
+                    command: Some("true".to_string()),
+                    ..AnnotatorConfig::default()
+                },
+            )],
+            DEFAULT_ANNOTATOR,
+        );
+
+        let set = AnnotatorSet::from_config(&config);
+
+        assert_eq!(set.label("chsum"), Some("Chsum"));
+        assert_eq!(set.label(DEFAULT_ANNOTATOR), Some("File"));
+    }
+
+    #[test]
+    fn a_registration_without_a_command_registers_no_annotator() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with(
+            dir.path().to_path_buf(),
+            vec![("empty", AnnotatorConfig::default())],
+            DEFAULT_ANNOTATOR,
+        );
+
+        let set = AnnotatorSet::from_config(&config);
+
+        assert_eq!(set.keys().collect::<Vec<_>>(), vec![DEFAULT_ANNOTATOR]);
+    }
+
+    #[test]
+    fn a_write_to_naming_nothing_registered_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with(dir.path().to_path_buf(), Vec::new(), "absent");
+        let set = AnnotatorSet::from_config(&config);
+
+        let written = set.write(Path::new("/tmp/x/a.jsonl"), &Annotation::default(), None);
+
+        assert!(written.is_err());
+    }
+
+    #[test]
+    fn a_read_tags_each_annotation_with_the_annotator_holding_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let conversation = PathBuf::from("/tmp/-tmp-x/a.jsonl");
+        let config = config_with(dir.path().to_path_buf(), Vec::new(), DEFAULT_ANNOTATOR);
+        let set = AnnotatorSet::from_config(&config);
+        set.write(
+            &conversation,
+            &Annotation {
+                id: "n1".to_string(),
+                kind: "note".to_string(),
+                text: "hello".to_string(),
+                ..Annotation::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        let read = set.read_one(&conversation);
+
+        assert_eq!(read.session[0].annotator, DEFAULT_ANNOTATOR);
+    }
+
+    #[test]
+    fn a_delete_names_the_annotator_the_annotation_came_from() {
+        let dir = tempfile::tempdir().unwrap();
+        let conversation = PathBuf::from("/tmp/-tmp-x/a.jsonl");
+        let config = config_with(dir.path().to_path_buf(), Vec::new(), DEFAULT_ANNOTATOR);
+        let set = AnnotatorSet::from_config(&config);
+        set.write(
+            &conversation,
+            &Annotation {
+                id: "n1".to_string(),
+                text: "hello".to_string(),
+                ..Annotation::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        assert!(set.delete(&conversation, "n1", DEFAULT_ANNOTATOR).unwrap());
+        assert!(set.read_one(&conversation).is_empty());
+    }
+
+    #[test]
+    fn a_delete_naming_an_unregistered_annotator_finds_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with(dir.path().to_path_buf(), Vec::new(), DEFAULT_ANNOTATOR);
+        let set = AnnotatorSet::from_config(&config);
+
+        assert!(
+            !set.delete(Path::new("/tmp/x/a.jsonl"), "n1", "gone")
+                .unwrap()
+        );
+    }
+}

--- a/src/annotations/write.rs
+++ b/src/annotations/write.rs
@@ -1,0 +1,167 @@
+//! Writing annotations to the file annotator's directory.
+
+use super::{Annotation, sidecar_path};
+use crate::error::{AppError, Result};
+use std::io::Write;
+use std::path::Path;
+
+/// Append an annotation to a conversation's sidecar, creating the project
+/// directory and the file when neither exists.
+pub fn append_to_file(root: &Path, conversation: &Path, annotation: &Annotation) -> Result<()> {
+    let Some(path) = sidecar_path(root, conversation) else {
+        return Err(AppError::ConfigError(format!(
+            "conversation {} has no project directory or session name, so it has no sidecar",
+            conversation.display()
+        )));
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut line = serde_json::to_string(annotation)?;
+    line.push('\n');
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?;
+    file.write_all(line.as_bytes())?;
+    Ok(())
+}
+
+/// Remove the annotation carrying `id`, rewriting the sidecar without it.
+///
+/// Returns whether a matching annotation was found, so a caller reports a
+/// missing id rather than a silent success.
+pub fn remove_from_file(root: &Path, conversation: &Path, id: &str) -> Result<bool> {
+    let Some(path) = sidecar_path(root, conversation) else {
+        return Ok(false);
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Ok(false);
+    };
+
+    let mut kept = Vec::new();
+    let mut removed = false;
+    for line in contents.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // A line that does not parse is kept: a write must not discard a record
+        // this version cannot read.
+        let matches_id =
+            serde_json::from_str::<Annotation>(line).is_ok_and(|annotation| annotation.id == id);
+        if matches_id {
+            removed = true;
+            continue;
+        }
+        kept.push(line.to_string());
+    }
+    if !removed {
+        return Ok(false);
+    }
+
+    // Write through a temporary file in the same directory, so an interrupted
+    // write leaves the previous sidecar rather than a truncated one.
+    let mut body = kept.join("\n");
+    if !body.is_empty() {
+        body.push('\n');
+    }
+    let temporary = path.with_extension("jsonl.tmp");
+    std::fs::write(&temporary, body)?;
+    std::fs::rename(&temporary, &path)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::{Annotator, FileAnnotator, TargetSpan};
+
+    fn annotation(id: &str, text: &str) -> Annotation {
+        Annotation {
+            id: id.to_string(),
+            targets: vec![TargetSpan::single(4)],
+            kind: "note".to_string(),
+            text: text.to_string(),
+            annotator: String::new(),
+            origin: None,
+            created: None,
+            modified: None,
+        }
+    }
+
+    #[test]
+    fn append_creates_the_project_directory_and_file() {
+        let root = tempfile::tempdir().unwrap();
+        let conversation = Path::new("/home/u/.claude/projects/p/abc.jsonl");
+
+        append_to_file(root.path(), conversation, &annotation("a", "first")).unwrap();
+        append_to_file(root.path(), conversation, &annotation("b", "second")).unwrap();
+
+        let annotator = FileAnnotator::new(root.path());
+        let read = annotator.read(&[conversation]).unwrap();
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].1.positioned.len(), 2);
+    }
+
+    #[test]
+    fn remove_deletes_only_the_named_annotation() {
+        let root = tempfile::tempdir().unwrap();
+        let conversation = Path::new("/home/u/.claude/projects/p/abc.jsonl");
+        append_to_file(root.path(), conversation, &annotation("a", "first")).unwrap();
+        append_to_file(root.path(), conversation, &annotation("b", "second")).unwrap();
+
+        assert!(remove_from_file(root.path(), conversation, "a").unwrap());
+
+        let read = FileAnnotator::new(root.path())
+            .read(&[conversation])
+            .unwrap();
+        assert_eq!(read[0].1.positioned.len(), 1);
+        assert_eq!(read[0].1.positioned[0].id, "b");
+    }
+
+    #[test]
+    fn remove_reports_a_missing_id_rather_than_succeeding() {
+        let root = tempfile::tempdir().unwrap();
+        let conversation = Path::new("/home/u/.claude/projects/p/abc.jsonl");
+        append_to_file(root.path(), conversation, &annotation("a", "first")).unwrap();
+
+        assert!(!remove_from_file(root.path(), conversation, "absent").unwrap());
+        let read = FileAnnotator::new(root.path())
+            .read(&[conversation])
+            .unwrap();
+        assert_eq!(read[0].1.positioned.len(), 1);
+    }
+
+    #[test]
+    fn remove_keeps_records_this_version_cannot_parse() {
+        let root = tempfile::tempdir().unwrap();
+        let conversation = Path::new("/home/u/.claude/projects/p/abc.jsonl");
+        append_to_file(root.path(), conversation, &annotation("a", "first")).unwrap();
+        let path = sidecar_path(root.path(), conversation).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(b"{\"from\":\"a later version\"}\n").unwrap();
+        drop(file);
+
+        assert!(remove_from_file(root.path(), conversation, "a").unwrap());
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("a later version"));
+        assert!(!contents.contains("\"id\":\"a\""));
+    }
+
+    #[test]
+    fn a_note_without_an_origin_is_stored_without_the_key() {
+        let root = tempfile::tempdir().unwrap();
+        let conversation = Path::new("/home/u/.claude/projects/p/abc.jsonl");
+        append_to_file(root.path(), conversation, &annotation("a", "first")).unwrap();
+        let path = sidecar_path(root.path(), conversation).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        // A hand-written note describes the conversation itself, so the record
+        // stays as it was before origins existed and older readers parse it.
+        assert!(!contents.contains("origin"), "{contents}");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,8 +62,75 @@ pub enum Commands {
         #[arg(long, group = "delete_empty_scope")]
         all: bool,
     },
+    /// Attach an annotation to a conversation, or remove one
+    Annotate(AnnotateArgs),
+    /// Register the tools annotations are read from and written to
+    Annotators {
+        #[command(subcommand)]
+        command: AnnotatorsCommand,
+    },
     /// Update claude-history to the latest version
     Update,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AnnotatorsCommand {
+    /// List the registered annotators and which one receives writes
+    List,
+    /// Register an annotator, or replace one registered under the same key
+    Add(AnnotatorAddArgs),
+    /// Drop an annotator's registration
+    Remove {
+        /// Key the annotator is registered under
+        key: String,
+    },
+    /// Name the annotator that receives writes
+    WriteTo {
+        /// Key of a registered annotator
+        key: String,
+    },
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct AnnotatorAddArgs {
+    /// Key to register under, used in config and as the fallback label
+    pub key: String,
+    /// Command line invoked as `<command> read|write|delete`
+    #[arg(long)]
+    pub command: String,
+    /// Label the viewer prints, truncated to nine characters. With this absent
+    /// the key is used, first letter capitalised.
+    #[arg(long)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, ClapArgs)]
+pub struct AnnotateArgs {
+    /// Conversation to annotate: a ch_ ref or a transcript path. With none, the
+    /// annotation lands on the transcript the running session writes to.
+    pub reference: Option<String>,
+    /// Annotation text. A write carries it; --delete names an existing
+    /// annotation and carries none.
+    #[arg(long, required_unless_present = "delete")]
+    pub text: Option<String>,
+    /// JSONL line the annotation attaches to. Repeat for several; a bare
+    /// `--line 7` names one line and `--line 7..9` a run of them. With none, the
+    /// annotation lands on the last prompt typed into the transcript.
+    #[arg(long = "line", value_name = "LINE|START..END")]
+    pub lines: Vec<String>,
+    /// Attach the annotation to the conversation as a whole instead of a line
+    #[arg(long, conflicts_with = "lines")]
+    pub session: bool,
+    /// Producer's label for this annotation. Free text, passed through
+    /// unchanged; the producer sets the vocabulary.
+    #[arg(long, default_value = "note")]
+    pub kind: String,
+    /// Identifier for the annotation. Generated when omitted.
+    #[arg(long)]
+    pub id: Option<String>,
+    /// Remove the annotation with this id instead of writing one
+    #[arg(long, conflicts_with_all = ["text", "lines", "kind", "id", "session"])]
+    pub delete: Option<String>,
 }
 
 #[derive(Debug, ClapArgs)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,80 @@ pub struct ConfigFile {
     pub tui: Option<TuiConfig>,
     pub search: Option<SearchConfig>,
     pub agent: Option<AgentConfig>,
+    pub annotations: Option<AnnotationsConfig>,
+    pub annotators: Option<std::collections::BTreeMap<String, AnnotatorConfig>>,
+}
+
+/// Where annotations are read from and written to.
+///
+/// Both fields are optional. With neither set, reads and writes use the default
+/// file-annotator directory, so annotating works without configuration.
+#[derive(Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
+pub struct AnnotationsConfig {
+    /// File-annotator root. Defaults to `~/.local/share/claude-history/annotations`.
+    pub root: Option<PathBuf>,
+    /// Key of the annotator that receives writes. Defaults to `file`.
+    pub write_to: Option<String>,
+}
+
+/// One registered annotator, keyed by name in the `[annotators]` table.
+///
+/// `command` absent names the built-in file annotator; a command is invoked as
+/// `<command> <op>` with one JSON object on stdin and one on stdout.
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct AnnotatorConfig {
+    /// Command line invoked for each operation.
+    pub command: Option<String>,
+    /// Label the viewer prints. With this absent the key is used, first letter
+    /// capitalised.
+    pub name: Option<String>,
+    /// File-annotator root, read for the `file` entry.
+    pub root: Option<PathBuf>,
+}
+
+/// Key of the annotator that receives writes.
+pub const DEFAULT_ANNOTATOR: &str = "file";
+
+/// The annotator writes are dispatched to: the configured key, else `file`.
+pub fn annotation_write_target(config: &ConfigFile) -> String {
+    config
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.write_to.clone())
+        .unwrap_or_else(|| DEFAULT_ANNOTATOR.to_string())
+}
+
+/// The file-annotator root: the configured path, else
+/// `~/.local/share/claude-history/annotations`.
+///
+/// A missing home directory leaves no default path, and the caller reads no
+/// annotations. A relative fallback would resolve against the working
+/// directory and name a different root per invocation.
+pub fn annotations_root(config: &ConfigFile) -> Option<PathBuf> {
+    if let Some(root) = config
+        .annotators
+        .as_ref()
+        .and_then(|annotators| annotators.get(DEFAULT_ANNOTATOR))
+        .and_then(|file| file.root.clone())
+    {
+        return Some(root);
+    }
+    if let Some(root) = config
+        .annotations
+        .as_ref()
+        .and_then(|annotations| annotations.root.clone())
+    {
+        return Some(root);
+    }
+    home::home_dir().map(|mut path| {
+        path.push(".local");
+        path.push("share");
+        path.push("claude-history");
+        path.push("annotations");
+        path
+    })
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -245,6 +319,7 @@ pub struct KeysConfig {
     pub fork: Option<KeyBinding>,
     pub rename: Option<KeyBinding>,
     pub delete: Option<KeyBinding>,
+    pub annotate: Option<KeyBinding>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -344,6 +419,7 @@ pub struct KeyBindings {
     pub fork: KeyBinding,
     pub rename: KeyBinding,
     pub delete: KeyBinding,
+    pub annotate: KeyBinding,
 }
 
 impl Default for KeyBindings {
@@ -365,6 +441,10 @@ impl Default for KeyBindings {
                 code: KeyCode::Char('x'),
                 modifiers: KeyModifiers::CONTROL,
             },
+            annotate: KeyBinding {
+                code: KeyCode::Char('a'),
+                modifiers: KeyModifiers::NONE,
+            },
         }
     }
 }
@@ -379,6 +459,7 @@ impl KeyBindings {
                 fork: cfg.fork.unwrap_or(defaults.fork),
                 rename: cfg.rename.unwrap_or(defaults.rename),
                 delete: cfg.delete.unwrap_or(defaults.delete),
+                annotate: cfg.annotate.unwrap_or(defaults.annotate),
             },
         }
     }
@@ -386,7 +467,7 @@ impl KeyBindings {
 
 /// Returns the path to the configuration file: ~/.config/claude-history/config.toml
 /// This path is used for all platforms.
-fn get_config_path() -> Option<PathBuf> {
+pub fn get_config_path() -> Option<PathBuf> {
     home::home_dir().map(|mut path| {
         path.push(".config");
         path.push("claude-history");

--- a/src/display.rs
+++ b/src/display.rs
@@ -816,6 +816,10 @@ pub fn render_to_terminal(file_path: &Path, options: &DisplayOptions) -> Result<
         show_timing: false, // Non-TUI render doesn't support timing toggle
         content_width,
         expanded_tool_outputs: BTreeSet::new(),
+        show_annotations: true,
+        annotations: crate::annotations::for_conversation(file_path),
+        annotator_labels: crate::annotations::AnnotatorSet::from_current_config().labels(),
+        focused_annotation: None,
     };
 
     let rendered = render_conversation(file_path, &render_options)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod annotations;
 mod claude;
 mod cli;
 mod config;
@@ -148,6 +149,12 @@ fn run() -> Result<()> {
             }),
             Commands::DeleteEmpty { yes, local, all } => {
                 run_delete_empty_command(DeleteEmptyArgs { yes, local, all })
+            }
+            Commands::Annotate(args) => {
+                annotations::run_annotate(args).map(|output| print!("{output}"))
+            }
+            Commands::Annotators { command } => {
+                annotations::run_annotators(command).map(|output| print!("{output}"))
             }
             Commands::Update => update::run(),
         };

--- a/src/semantic/chunk.rs
+++ b/src/semantic/chunk.rs
@@ -35,9 +35,14 @@ where
             })
             .collect::<Vec<_>>();
 
+        // Annotations group independently: each is a discrete statement, and
+        // concatenating two into one chunk would return a hit that names lines
+        // from both.
         let grouped = if matches!(
             source,
-            SemanticChunkSource::AgentTool | SemanticChunkSource::AgentSubagentTool
+            SemanticChunkSource::AgentTool
+                | SemanticChunkSource::AgentSubagentTool
+                | SemanticChunkSource::Annotation
         ) {
             independent_turns(&semantic_turns, config)
         } else {

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -69,6 +69,10 @@ pub enum SemanticChunkSource {
     AgentSubagentDialogue,
     AgentSubagentTool,
     AgentSubagentThinking,
+    /// Text a producer attached to the conversation, not text from the
+    /// conversation itself. Carried as its own variant so a hit names which it
+    /// is, and so ranking has a field to discriminate on later.
+    Annotation,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/semantic_cli.rs
+++ b/src/semantic_cli.rs
@@ -409,6 +409,19 @@ fn refresh_and_rank_interactive(
 fn semantic_cache_candidates(
     selected: &[&Conversation],
 ) -> Vec<crate::semantic::index::SemanticIndexCandidate> {
+    // One read for the whole corpus, which is what the cache covers. Without
+    // the annotation candidates, a note's chunk embeds at the first query that
+    // scopes it rather than during prewarm.
+    cache_candidates_with(selected, &annotations_by_path(selected))
+}
+
+fn cache_candidates_with(
+    selected: &[&Conversation],
+    annotations: &std::collections::HashMap<
+        std::path::PathBuf,
+        crate::annotations::ConversationAnnotations,
+    >,
+) -> Vec<crate::semantic::index::SemanticIndexCandidate> {
     let mut candidates = semantic_index_candidates(selected);
     for (index, conversation) in selected.iter().enumerate() {
         if !conversation.semantic_turns.is_empty()
@@ -421,8 +434,32 @@ fn semantic_cache_candidates(
                 conversation: std::sync::Arc::new(route),
             });
         }
+        if let Some(found) = annotations.get(&conversation.path)
+            && let Some(annotated) =
+                crate::agent::service::annotation_semantic_conversation(conversation, found)
+        {
+            candidates.push(crate::semantic::index::SemanticIndexCandidate {
+                index,
+                source: crate::semantic::types::SemanticChunkSource::Annotation,
+                conversation: std::sync::Arc::new(annotated),
+            });
+        }
     }
     candidates
+}
+
+/// Annotations for the selected conversations, keyed by transcript path.
+fn annotations_by_path(
+    selected: &[&Conversation],
+) -> std::collections::HashMap<std::path::PathBuf, crate::annotations::ConversationAnnotations> {
+    let paths = selected
+        .iter()
+        .map(|conversation| conversation.path.as_path())
+        .collect::<Vec<_>>();
+    crate::annotations::AnnotatorSet::from_current_config()
+        .read_all(&paths)
+        .into_iter()
+        .collect()
 }
 
 fn semantic_index_candidates(
@@ -811,5 +848,56 @@ mod tests {
         assert!(output.contains("intent: \"alpha\""));
         assert!(output.contains("\"RESTAURANT_SIGNALS\" (Sensitive)"));
         assert!(output.contains("\"lower phrase\" (Insensitive)"));
+    }
+
+    #[test]
+    fn the_cache_covers_a_conversation_s_annotations() {
+        let conversation =
+            SemanticConversationFixture::new("/tmp/session.jsonl", ["dialogue"]).build();
+        let selected = vec![&conversation];
+        let mut annotations = std::collections::HashMap::new();
+        annotations.insert(
+            conversation.path.clone(),
+            crate::annotations::ConversationAnnotations::from_flat(vec![
+                crate::annotations::Annotation {
+                    id: "a".to_string(),
+                    targets: vec![crate::annotations::TargetSpan::single(4)],
+                    kind: "recap".to_string(),
+                    text: "cache rewrite reverted".to_string(),
+                    annotator: "chsum".to_string(),
+                    origin: None,
+                    created: None,
+                    modified: None,
+                },
+            ]),
+        );
+
+        let candidates = cache_candidates_with(&selected, &annotations);
+
+        // Without an annotation candidate here, the note's chunk embeds at the
+        // first query that scopes it rather than during prewarm.
+        let annotation_candidates = candidates
+            .iter()
+            .filter(|candidate| {
+                candidate.source == crate::semantic::types::SemanticChunkSource::Annotation
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(annotation_candidates.len(), 1);
+        assert_eq!(
+            annotation_candidates[0].conversation.semantic_turns,
+            vec!["cache rewrite reverted".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_conversation_without_annotations_adds_no_candidate() {
+        let conversation =
+            SemanticConversationFixture::new("/tmp/session.jsonl", ["dialogue"]).build();
+
+        let candidates = cache_candidates_with(&[&conversation], &std::collections::HashMap::new());
+
+        assert!(candidates.iter().all(|candidate| {
+            candidate.source != crate::semantic::types::SemanticChunkSource::Annotation
+        }));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -99,6 +99,18 @@ pub struct App {
     semantic_search: SemanticSearchState,
     /// Cached lexical evidence produced outside the render path
     lexical_evidence: HashMap<usize, search::LexicalEvidence>,
+    /// The registered annotators, read together and written to one at a time.
+    annotators: crate::annotations::AnnotatorSet,
+    /// Note count per conversation, read when loading completes and refreshed
+    /// for one conversation after a write. The list row states a count per row,
+    /// and a per-row read would invoke every annotator once per visible row on
+    /// every frame.
+    annotation_counts: HashMap<PathBuf, usize>,
+    /// Whether note text has been appended to the corpus's lexical fields.
+    /// The append is not idempotent, so a second pass over the same
+    /// conversations would double every note's text and double its scoring
+    /// weight.
+    annotations_enriched: bool,
 }
 
 struct AppParts {
@@ -157,6 +169,55 @@ impl App {
             list_search_mode: parts.list_search_mode,
             semantic_search: parts.semantic_search,
             lexical_evidence: HashMap::new(),
+            annotators: crate::annotations::AnnotatorSet::from_current_config(),
+            annotation_counts: HashMap::new(),
+            annotations_enriched: false,
+        }
+    }
+
+    /// The registered annotators.
+    pub(super) fn annotators(&self) -> &crate::annotations::AnnotatorSet {
+        &self.annotators
+    }
+
+    /// The number of notes attached to one conversation.
+    pub fn annotation_count(&self, conversation: &std::path::Path) -> usize {
+        self.annotation_counts
+            .get(conversation)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Places a note count for one conversation without reading any annotator.
+    #[cfg(test)]
+    pub fn set_annotation_count_for_test(&mut self, conversation: &std::path::Path, count: usize) {
+        self.annotation_counts
+            .insert(conversation.to_path_buf(), count);
+    }
+
+    /// Replaces the registered annotators and drops the enrichment guard, so a
+    /// test corpus is read instead of the configured store.
+    #[cfg(test)]
+    pub fn set_annotators_for_test(&mut self, annotators: crate::annotations::AnnotatorSet) {
+        self.annotators = annotators;
+        self.annotations_enriched = false;
+    }
+
+    /// Re-reads one conversation's notes after a write or a delete, so the list
+    /// row states the count the annotators hold rather than the count read when
+    /// loading completed.
+    pub(super) fn refresh_annotation_count(&mut self, conversation: &std::path::Path) {
+        let count = self
+            .annotators
+            .counts(&[conversation])
+            .get(conversation)
+            .copied()
+            .unwrap_or(0);
+        if count == 0 {
+            self.annotation_counts.remove(conversation);
+        } else {
+            self.annotation_counts
+                .insert(conversation.to_path_buf(), count);
         }
     }
 
@@ -372,6 +433,72 @@ impl App {
         };
     }
 
+    /// Appends every conversation's note text to its lexical search fields.
+    ///
+    /// A note lives outside the transcript, so lexical search over the parsed
+    /// text alone never matches it and the conversation carrying it stays out
+    /// of the results. The append also reaches `full_text`, which the evidence
+    /// builder draws context from, so a row matched on a note shows that note's
+    /// text as its context line.
+    fn enrich_annotations(&mut self) {
+        if self.annotations_enriched {
+            return;
+        }
+        let scoped = (0..self.conversations.len()).collect::<Vec<_>>();
+        let _ =
+            crate::annotations::enrich_scoped(&mut self.conversations, &scoped, &self.annotators);
+        self.annotations_enriched = true;
+
+        let paths = self
+            .conversations
+            .iter()
+            .map(|conversation| conversation.path.as_path())
+            .collect::<Vec<_>>();
+        self.annotation_counts = self.annotators.counts(&paths);
+    }
+
+    /// Rebuilds one conversation's lexical fields after its notes change.
+    ///
+    /// The append in `enrich_annotations` cannot be undone in place, so the
+    /// transcript is re-parsed and the current notes appended to the fresh
+    /// text; without the re-parse a deleted note stays searchable and an edited
+    /// one is searchable under both its texts.
+    pub(super) fn refresh_conversation_annotations(&mut self, conversation: &std::path::Path) {
+        let Some(index) = self
+            .conversations
+            .iter()
+            .position(|conv| conv.path == conversation)
+        else {
+            return;
+        };
+        let modified = std::fs::metadata(conversation)
+            .and_then(|meta| meta.modified())
+            .ok();
+        let Ok(Some(reparsed)) =
+            process_conversation_file(conversation.to_path_buf(), modified, None)
+        else {
+            return;
+        };
+        let conv = &mut self.conversations[index];
+        conv.full_text = reparsed.full_text;
+        conv.search_text_lower = reparsed.search_text_lower;
+        conv.agent_search_text = reparsed.agent_search_text;
+
+        let _ =
+            crate::annotations::enrich_scoped(&mut self.conversations, &[index], &self.annotators);
+
+        // The worker scores against its own snapshot, so the corpus it holds is
+        // replaced before the next query runs against stale text.
+        self.conversations_snapshot = Arc::new(self.conversations.clone());
+        self.rebuild_semantic_conversations_snapshot();
+        self.searchable = search::precompute_search_text(&self.conversations);
+        let _ = self.search_tx.send(SearchCommand::UpdateData {
+            conversations: self.conversations_snapshot.clone(),
+            searchable: Arc::new(self.searchable.clone()),
+        });
+        self.invalidate_search_generation();
+    }
+
     /// Mark loading as complete: sort, precompute search, and transition to Ready
     pub fn finish_loading(&mut self) {
         // Sort all conversations by timestamp (newest first)
@@ -382,6 +509,10 @@ impl App {
         for (idx, conv) in self.conversations.iter_mut().enumerate() {
             conv.index = idx;
         }
+
+        // Notes join the lexical fields before the snapshot and the precompute,
+        // so the worker's corpus and the searchable text both carry them.
+        self.enrich_annotations();
 
         self.conversations_snapshot = Arc::new(self.conversations.clone());
         self.rebuild_semantic_conversations_snapshot();

--- a/src/tui/app/dialog_state.rs
+++ b/src/tui/app/dialog_state.rs
@@ -123,6 +123,509 @@ impl App {
         self.dialog_mode = DialogMode::Rename { input, cursor };
     }
 
+    /// The file line the focused message sits on.
+    ///
+    /// The line arrives through two hops: `focused_message` indexes
+    /// `message_ranges`, whose `entry_index` counts parsed entries after
+    /// filtering rather than file lines, so the matching entry carries the line.
+    /// No focused message yields no line.
+    pub(super) fn focused_message_line(&self) -> Option<usize> {
+        let AppMode::View(state) = &self.app_mode else {
+            return None;
+        };
+        state
+            .focused_message
+            .and_then(|index| state.message_ranges.get(index))
+            .and_then(|range| {
+                let entries = state.parsed_entries.as_ref()?;
+                entries
+                    .iter()
+                    .find(|entry| entry.entry_index == range.entry_index)
+                    .map(|entry| entry.jsonl_line)
+            })
+    }
+
+    /// The file lines of the entries the view currently renders, ascending and
+    /// without repeats.
+    ///
+    /// The set is drawn from `message_ranges`, which holds one range per
+    /// rendered block, rather than from every parsed entry. A summary record,
+    /// and an entry the filters hide, carries a line and draws no row, so
+    /// stepping onto it would move the note in the file while the screen held
+    /// still.
+    pub(super) fn rendered_entry_lines(&self) -> Vec<usize> {
+        let AppMode::View(state) = &self.app_mode else {
+            return Vec::new();
+        };
+        let Some(entries) = state.parsed_entries.as_ref() else {
+            return Vec::new();
+        };
+        let mut lines: Vec<usize> = state
+            .message_ranges
+            .iter()
+            .filter_map(|range| {
+                entries
+                    .iter()
+                    .find(|entry| entry.entry_index == range.entry_index)
+            })
+            .map(|entry| entry.jsonl_line)
+            .collect();
+        lines.sort_unstable();
+        lines.dedup();
+        lines
+    }
+
+    /// Put the selected note under a move.
+    ///
+    /// A note already on a line starts there. A session note carries no line
+    /// and stays as it is, so `m` on one leaves the viewer where it was.
+    pub(super) fn start_annotation_move(&mut self) {
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(id) = state.focused_annotation.clone() else {
+            return;
+        };
+        let Some(annotation) = find_annotation(&state.annotations, &id) else {
+            return;
+        };
+        let Some(line) = annotation.anchor_line() else {
+            return;
+        };
+        let original = annotation.targets.clone();
+        let scroll_offset = state.scroll_offset;
+        if let AppMode::View(state) = &mut self.app_mode {
+            state.moving_annotation = Some(crate::tui::app::types::AnnotationMove {
+                id,
+                original,
+                line,
+                scroll_offset,
+            });
+        }
+    }
+
+    /// Step the note under a move to the neighbouring entry line.
+    ///
+    /// The note's targets move with it, so the transcript shows it at the new
+    /// line as the key is pressed. The step stops at the first and last entry
+    /// line. Nothing is written until the move is saved.
+    pub(super) fn move_selected_annotation(&mut self, forward: bool, viewport_height: usize) {
+        let lines = self.rendered_entry_lines();
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(moving) = state.moving_annotation.clone() else {
+            return;
+        };
+        let next = match lines.iter().position(|candidate| *candidate == moving.line) {
+            Some(index) if forward => lines.get(index + 1).copied(),
+            Some(index) => index
+                .checked_sub(1)
+                .and_then(|prior| lines.get(prior).copied()),
+            None if forward => lines
+                .iter()
+                .find(|candidate| **candidate > moving.line)
+                .copied(),
+            None => lines
+                .iter()
+                .rev()
+                .find(|candidate| **candidate < moving.line)
+                .copied(),
+        };
+        let Some(target) = next else {
+            return;
+        };
+        if let AppMode::View(state) = &mut self.app_mode {
+            retarget_annotation(&mut state.annotations, &moving.id, target);
+            if let Some(moving) = state.moving_annotation.as_mut() {
+                moving.line = target;
+            }
+        }
+        self.re_render_view(viewport_height);
+        self.scroll_annotation_into_view(&moving.id, viewport_height);
+    }
+
+    /// Write the note at the line the move reached and leave move mode.
+    pub(super) fn commit_annotation_move(&mut self, viewport_height: usize) {
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(moving) = state.moving_annotation.clone() else {
+            return;
+        };
+        let path = state.conversation_path.clone();
+        let Some(annotation) = find_annotation(&state.annotations, &moving.id) else {
+            return;
+        };
+        let replacement = crate::annotations::Annotation {
+            id: crate::annotations::generated_id(),
+            targets: shifted_targets(&moving.original, moving.line),
+            kind: annotation.kind.clone(),
+            text: annotation.text.clone(),
+            annotator: String::new(),
+            origin: annotation.origin.clone(),
+            created: annotation.created.clone(),
+            modified: Some(crate::annotations::now_rfc3339()),
+        };
+        let holder = annotation.annotator.clone();
+        // The replacement is written before the original is removed, so a
+        // failure part-way leaves the note present rather than lost.
+        // A move is a modification, so it writes back to the annotator holding
+        // the note rather than to the configured write target. `write_to`
+        // governs new notes.
+        let stored = match self.annotators().write_to_annotator(
+            &holder,
+            &path,
+            &replacement,
+            Some(&moving.id),
+        ) {
+            Ok(stored) => stored,
+            Err(error) => {
+                // The note returns to where the move started and the row names
+                // the refusal, so a failed write reads as a refusal rather than
+                // as a key that did nothing.
+                self.cancel_annotation_move(viewport_height);
+                self.status_message = Some((
+                    format!("Note not moved: {error}"),
+                    std::time::Instant::now(),
+                ));
+                return;
+            }
+        };
+        // An annotator acting on `replaces` returns the id it kept and holds
+        // one record. A differing id means a second record was stored, so the
+        // superseded one is removed.
+        if stored != moving.id {
+            let _ = self.annotators().delete(&path, &moving.id, &holder);
+        }
+        let annotations = self.annotators().read_one(&path);
+        if let AppMode::View(state) = &mut self.app_mode {
+            state.annotations = annotations;
+            state.moving_annotation = None;
+            state.focused_annotation = None;
+        }
+        self.refresh_annotation_count(&path);
+        self.refresh_conversation_annotations(&path);
+        self.re_render_view(viewport_height);
+    }
+
+    /// Put the note back where the move started and leave move mode.
+    pub(super) fn cancel_annotation_move(&mut self, viewport_height: usize) {
+        let AppMode::View(state) = &mut self.app_mode else {
+            return;
+        };
+        let Some(moving) = state.moving_annotation.take() else {
+            return;
+        };
+        restore_annotation_targets(&mut state.annotations, &moving.id, moving.original);
+        self.re_render_view(viewport_height);
+        // The viewport returns after the re-render, which is what settles the
+        // line count the offset is clamped against.
+        if let AppMode::View(state) = &mut self.app_mode {
+            let max_scroll = state.total_lines.saturating_sub(viewport_height);
+            state.scroll_offset = moving.scroll_offset.min(max_scroll);
+        }
+    }
+
+    /// Scroll the rendered block for one note into view.
+    fn scroll_annotation_into_view(&mut self, id: &str, viewport_height: usize) {
+        let AppMode::View(state) = &mut self.app_mode else {
+            return;
+        };
+        let Some(range) = state
+            .annotation_ranges
+            .iter()
+            .find(|range| range.id == id)
+            .cloned()
+        else {
+            return;
+        };
+        let max_scroll = state.total_lines.saturating_sub(viewport_height);
+        if range.start_line < state.scroll_offset
+            || range.start_line >= state.scroll_offset + viewport_height
+        {
+            state.scroll_offset = range.start_line.min(max_scroll);
+        }
+    }
+
+    /// Open the annotate prompt for the conversation being viewed.
+    ///
+    /// The prompt opens on the focused message's line. With no focused message
+    /// the annotation attaches to the session.
+    pub(super) fn start_annotate(&mut self) {
+        if !matches!(self.app_mode, AppMode::View(_)) {
+            return;
+        }
+        let line = self.focused_message_line();
+        self.dialog_mode = DialogMode::Annotate {
+            input: String::new(),
+            cursor: 0,
+            line,
+            anchor: line,
+            replacing: None,
+        };
+    }
+
+    /// Open the annotate prompt on the selected note, pre-filled with its text.
+    pub(super) fn start_edit_annotation(&mut self) {
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(id) = state.focused_annotation.clone() else {
+            return;
+        };
+        let Some(annotation) = state
+            .annotations
+            .session
+            .iter()
+            .chain(state.annotations.positioned.iter())
+            .find(|annotation| annotation.id == id)
+        else {
+            return;
+        };
+        let input = annotation.text.clone();
+        let cursor = input.chars().count();
+        let line = annotation.anchor_line();
+        // A note already on a line returns to that line; a session note returns
+        // to the focused message, so Tab has a target in both directions.
+        let anchor = line.or_else(|| self.focused_message_line());
+        self.dialog_mode = DialogMode::Annotate {
+            input,
+            cursor,
+            line,
+            anchor,
+            replacing: Some(id),
+        };
+    }
+
+    /// Remove the selected note.
+    /// Copies the selected note's text to the clipboard.
+    pub(super) fn copy_focused_annotation(&mut self) {
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(id) = state.focused_annotation.as_deref() else {
+            return;
+        };
+        let Some(annotation) = find_annotation(&state.annotations, id) else {
+            return;
+        };
+        let text = annotation_yank_text(annotation, &state.conversation_path);
+        let message = match crate::tui::export::copy_to_system_clipboard(&text) {
+            Ok(crate::tui::export::ClipboardDestination::System) => {
+                "Note copied to clipboard".to_string()
+            }
+            Ok(crate::tui::export::ClipboardDestination::Terminal) => {
+                "Note sent to terminal clipboard".to_string()
+            }
+            Err(e) => e,
+        };
+        self.status_message = Some((message, std::time::Instant::now()));
+    }
+
+    pub(super) fn delete_focused_annotation(&mut self, viewport_height: usize) {
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let Some(id) = state.focused_annotation.clone() else {
+            return;
+        };
+        let path = state.conversation_path.clone();
+        // The annotator holding the note is carried on the note itself, so the
+        // delete reaches the store it came from rather than the one writes go
+        // to.
+        let annotator = state
+            .annotations
+            .session
+            .iter()
+            .chain(state.annotations.positioned.iter())
+            .find(|annotation| annotation.id == id)
+            .map(|annotation| annotation.annotator.clone())
+            .unwrap_or_default();
+        if self.annotators().delete(&path, &id, &annotator).is_err() {
+            return;
+        }
+        let annotations = self.annotators().read_one(&path);
+        if let AppMode::View(state) = &mut self.app_mode {
+            state.annotations = annotations;
+            state.focused_annotation = None;
+        }
+        self.refresh_annotation_count(&path);
+        self.refresh_conversation_annotations(&path);
+        self.re_render_view(viewport_height);
+    }
+
+    pub(super) fn submit_annotate(&mut self, viewport_height: usize) {
+        let (text, line, replacing) = match &self.dialog_mode {
+            DialogMode::Annotate {
+                input,
+                line,
+                replacing,
+                ..
+            } => (input.trim().to_string(), *line, replacing.clone()),
+            _ => return,
+        };
+        self.dialog_mode = DialogMode::None;
+        if text.is_empty() {
+            return;
+        }
+        let AppMode::View(state) = &self.app_mode else {
+            return;
+        };
+        let path = state.conversation_path.clone();
+
+        let replaced = replacing.as_ref().and_then(|id| {
+            state
+                .annotations
+                .session
+                .iter()
+                .chain(state.annotations.positioned.iter())
+                .find(|annotation| annotation.id == *id)
+        });
+        let replaced_annotator = replaced.map(|annotation| annotation.annotator.clone());
+        // An edit carries the original's creation stamp forward, so the pair
+        // bounds the note's life rather than restarting at every edit. A note
+        // written before stamps existed carries none, and the edit stamps both.
+        let stamp = crate::annotations::now_rfc3339();
+        let created = replaced
+            .and_then(|annotation| annotation.created.clone())
+            .unwrap_or_else(|| stamp.clone());
+
+        // The replacement is written before the original is removed, so a
+        // failure part-way leaves the note present rather than lost.
+        let annotation = crate::annotations::Annotation {
+            id: crate::annotations::generated_id(),
+            targets: line
+                .map(crate::annotations::TargetSpan::single)
+                .into_iter()
+                .collect(),
+            kind: "note".to_string(),
+            text,
+            annotator: String::new(),
+            origin: None,
+            created: Some(created),
+            modified: Some(stamp),
+        };
+        // An edit writes back to the annotator holding the note; a new note
+        // goes to the configured write target.
+        let written = match &replaced_annotator {
+            Some(holder) => self.annotators().write_to_annotator(
+                holder,
+                &path,
+                &annotation,
+                replacing.as_deref(),
+            ),
+            None => self.annotators().write(&path, &annotation, None),
+        };
+        let stored = match written {
+            Ok(stored) => stored,
+            Err(error) => {
+                self.status_message = Some((
+                    format!("Note not saved: {error}"),
+                    std::time::Instant::now(),
+                ));
+                return;
+            }
+        };
+        // An annotator acting on `replaces` returns the id it kept and holds
+        // one record. A differing id means a second record was stored, so the
+        // superseded one is removed.
+        if let Some(id) = replacing
+            && stored != id
+        {
+            let _ = self
+                .annotators()
+                .delete(&path, &id, &replaced_annotator.unwrap_or_default());
+        }
+        // Re-read rather than appending in memory, so the viewer renders what
+        // the annotators hold rather than the record this process sent them.
+        let annotations = self.annotators().read_one(&path);
+        if let AppMode::View(state) = &mut self.app_mode {
+            state.annotations = annotations;
+            state.focused_annotation = None;
+        }
+        self.refresh_annotation_count(&path);
+        self.refresh_conversation_annotations(&path);
+        // Without this the written annotation sits in state unseen until the
+        // next redraw is triggered by something else.
+        self.re_render_view(viewport_height);
+    }
+
+    pub(super) fn handle_annotate_key(
+        &mut self,
+        code: KeyCode,
+        modifiers: KeyModifiers,
+        viewport_height: usize,
+    ) -> Option<Action> {
+        match code {
+            KeyCode::Esc => {
+                self.dialog_mode = DialogMode::None;
+            }
+            KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.dialog_mode = DialogMode::None;
+            }
+            // Alt+Enter and Shift+Enter insert a newline; plain Enter saves.
+            // Terminals that report neither modifier reach the save arm, which
+            // is the behaviour the prompt had before newlines were accepted.
+            KeyCode::Enter if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::SHIFT) => {
+                if let DialogMode::Annotate { input, cursor, .. } = &mut self.dialog_mode {
+                    let byte_pos = input
+                        .char_indices()
+                        .nth(*cursor)
+                        .map(|(pos, _)| pos)
+                        .unwrap_or(input.len());
+                    input.insert(byte_pos, '\n');
+                    *cursor += 1;
+                }
+            }
+            KeyCode::Enter => self.submit_annotate(viewport_height),
+            // Tab moves the target between the anchored line and the session.
+            // With no anchor there is one target and the key does nothing.
+            KeyCode::Tab | KeyCode::BackTab => {
+                if let DialogMode::Annotate { line, anchor, .. } = &mut self.dialog_mode
+                    && anchor.is_some()
+                {
+                    *line = match line {
+                        Some(_) => None,
+                        None => *anchor,
+                    };
+                }
+            }
+            KeyCode::Left => {
+                if let DialogMode::Annotate { cursor, .. } = &mut self.dialog_mode {
+                    *cursor = cursor.saturating_sub(1);
+                }
+            }
+            KeyCode::Right => {
+                if let DialogMode::Annotate { input, cursor, .. } = &mut self.dialog_mode {
+                    *cursor = (*cursor + 1).min(input.chars().count());
+                }
+            }
+            KeyCode::Backspace => {
+                if let DialogMode::Annotate { input, cursor, .. } = &mut self.dialog_mode
+                    && *cursor > 0
+                    && let Some((byte_pos, _)) = input.char_indices().nth(*cursor - 1)
+                {
+                    input.remove(byte_pos);
+                    *cursor -= 1;
+                }
+            }
+            KeyCode::Char(character) => {
+                if let DialogMode::Annotate { input, cursor, .. } = &mut self.dialog_mode {
+                    let byte_pos = input
+                        .char_indices()
+                        .nth(*cursor)
+                        .map(|(pos, _)| pos)
+                        .unwrap_or(input.len());
+                    input.insert(byte_pos, character);
+                    *cursor += 1;
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
     pub(super) fn handle_rename_key(
         &mut self,
         code: KeyCode,
@@ -274,5 +777,188 @@ impl App {
         };
 
         self.status_message = Some((result.message, std::time::Instant::now()));
+    }
+}
+
+/// The note with this id, from either the session-level or the positioned
+/// notes of a conversation.
+/// Point one note at `line`, replacing whatever it targeted.
+///
+/// The change is in memory only, so a move shows in the transcript before it
+/// is written and leaves the store alone until it is saved.
+fn retarget_annotation(
+    annotations: &mut crate::annotations::ConversationAnnotations,
+    id: &str,
+    line: usize,
+) {
+    for annotation in annotations
+        .session
+        .iter_mut()
+        .chain(annotations.positioned.iter_mut())
+    {
+        if annotation.id == id {
+            annotation.targets = shifted_targets(&annotation.targets, line);
+        }
+    }
+}
+
+/// The targets a note holds once its first line sits at `line`.
+///
+/// Every span moves by the same distance, so a note covering three lines still
+/// covers three after a move, and a note covering one still covers one. A note
+/// with no target gains the single line, which is the degenerate case.
+fn shifted_targets(
+    targets: &[crate::annotations::TargetSpan],
+    line: usize,
+) -> Vec<crate::annotations::TargetSpan> {
+    let Some(first) = targets.iter().map(|span| span.start).min() else {
+        return vec![crate::annotations::TargetSpan::single(line)];
+    };
+    targets
+        .iter()
+        .map(|span| crate::annotations::TargetSpan {
+            // Distances are held in signed space so a move upward does not wrap
+            // a span's start below the first line of the file.
+            start: (span.start + line).saturating_sub(first),
+            end: (span.end + line).saturating_sub(first),
+        })
+        .collect()
+}
+
+/// Put one note's targets back to `original`, the state a cancelled move
+/// returns the viewer to.
+fn restore_annotation_targets(
+    annotations: &mut crate::annotations::ConversationAnnotations,
+    id: &str,
+    original: Vec<crate::annotations::TargetSpan>,
+) {
+    for annotation in annotations
+        .session
+        .iter_mut()
+        .chain(annotations.positioned.iter_mut())
+    {
+        if annotation.id == id {
+            annotation.targets = original.clone();
+        }
+    }
+}
+
+fn find_annotation<'a>(
+    annotations: &'a crate::annotations::ConversationAnnotations,
+    id: &str,
+) -> Option<&'a crate::annotations::Annotation> {
+    annotations
+        .session
+        .iter()
+        .chain(annotations.positioned.iter())
+        .find(|annotation| annotation.id == id)
+}
+
+/// The clipboard text for a note: its text, then a locator naming the
+/// annotator, the kind, the conversation and the lines targeted, and the
+/// origin when the note carries one. A note pasted elsewhere then leads back
+/// to the transcript it describes and to the file it summarised.
+fn annotation_yank_text(
+    annotation: &crate::annotations::Annotation,
+    conversation: &std::path::Path,
+) -> String {
+    let target = match annotation.targets.as_slice() {
+        [] => "session".to_string(),
+        targets => targets
+            .iter()
+            .map(|span| {
+                if span.start == span.end {
+                    span.start.to_string()
+                } else {
+                    format!("{}..{}", span.start, span.end)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+    };
+    let mut out = format!(
+        "{}\n\n— {} · {} · {} @{target}",
+        annotation.text.trim_end(),
+        annotation.annotator,
+        annotation.kind,
+        conversation.display()
+    );
+    if let Some(origin) = &annotation.origin {
+        out.push_str(&format!("\n  origin {}", origin.long()));
+    }
+    out
+}
+
+#[cfg(test)]
+mod annotation_copy_tests {
+    use super::{annotation_yank_text, find_annotation};
+    use crate::annotations::{Annotation, AnnotationOrigin, ConversationAnnotations, TargetSpan};
+    use std::path::{Path, PathBuf};
+
+    fn note(id: &str, targets: Vec<TargetSpan>, text: &str) -> Annotation {
+        Annotation {
+            id: id.to_string(),
+            targets,
+            kind: "recap".to_string(),
+            text: text.to_string(),
+            annotator: "chsum".to_string(),
+            origin: None,
+            created: None,
+            modified: None,
+        }
+    }
+
+    #[test]
+    fn the_selected_note_resolves_to_its_own_text_only() {
+        let annotations = ConversationAnnotations::from_flat(vec![
+            note("s1", Vec::new(), "session-level remark"),
+            note("p1", vec![TargetSpan::single(4)], "the line four remark"),
+        ]);
+
+        assert_eq!(
+            find_annotation(&annotations, "p1").map(|a| a.text.as_str()),
+            Some("the line four remark")
+        );
+        assert_eq!(
+            find_annotation(&annotations, "s1").map(|a| a.text.as_str()),
+            Some("session-level remark")
+        );
+        assert!(find_annotation(&annotations, "missing").is_none());
+    }
+
+    #[test]
+    fn a_yanked_note_carries_its_locator() {
+        let annotation = note(
+            "p1",
+            vec![TargetSpan::single(443)],
+            "Agent removed the wizard.\n",
+        );
+
+        let text = annotation_yank_text(&annotation, Path::new("/tmp/proj/session.jsonl"));
+
+        assert_eq!(
+            text,
+            "Agent removed the wizard.\n\n— chsum · recap · /tmp/proj/session.jsonl @443"
+        );
+    }
+
+    #[test]
+    fn a_yanked_note_with_an_origin_names_the_file_it_summarised() {
+        let mut annotation = note(
+            "p1",
+            vec![TargetSpan::single(443)],
+            "Agent removed the wizard.",
+        );
+        annotation.origin = Some(AnnotationOrigin {
+            path: PathBuf::from("/tmp/proj/subagents/agent-ac1cffaa.jsonl"),
+            lines: "412..430".to_string(),
+        });
+
+        let text = annotation_yank_text(&annotation, Path::new("/tmp/proj/session.jsonl"));
+
+        assert!(
+            text.ends_with("\n  origin /tmp/proj/subagents/agent-ac1cffaa.jsonl @412..430"),
+            "{text}"
+        );
     }
 }

--- a/src/tui/app/input_controller.rs
+++ b/src/tui/app/input_controller.rs
@@ -132,6 +132,9 @@ impl App {
                 return None;
             }
             DialogMode::Rename { .. } => return self.handle_rename_key(code, modifiers),
+            DialogMode::Annotate { .. } => {
+                return self.handle_annotate_key(code, modifiers, viewport_height);
+            }
             DialogMode::None => {}
         }
 
@@ -162,6 +165,88 @@ impl App {
             return self.handle_search_typing_key(code, modifiers);
         }
 
+        // A note under a move takes the arrows, Enter and Esc ahead of every
+        // other binding, so the keys act on the note rather than scrolling the
+        // conversation underneath it.
+        if let AppMode::View(ref state) = self.app_mode
+            && state.moving_annotation.is_some()
+        {
+            match code {
+                KeyCode::Up | KeyCode::Char('k') if modifiers.is_empty() => {
+                    self.move_selected_annotation(false, viewport_height);
+                    return None;
+                }
+                KeyCode::Down | KeyCode::Char('j') if modifiers.is_empty() => {
+                    self.move_selected_annotation(true, viewport_height);
+                    return None;
+                }
+                KeyCode::Enter => {
+                    self.commit_annotation_move(viewport_height);
+                    return None;
+                }
+                KeyCode::Esc => {
+                    self.cancel_annotation_move(viewport_height);
+                    return None;
+                }
+                // Quit reaches the caller through the move: a person leaning on
+                // Ctrl+C leaves the process rather than being held by a mode.
+                // The move is abandoned first, so the note is left where the
+                // store holds it.
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.cancel_annotation_move(viewport_height);
+                    return Some(Action::Quit);
+                }
+                KeyCode::Char('q') if modifiers.is_empty() => {
+                    self.cancel_annotation_move(viewport_height);
+                    return if self.single_file_mode {
+                        Some(Action::Quit)
+                    } else {
+                        self.app_mode = AppMode::List;
+                        None
+                    };
+                }
+                _ => return None,
+            }
+        }
+
+        // A selected note takes d, e and y ahead of every other binding, so
+        // the keys act on the selection rather than on the conversation. Without
+        // the y arm the key falls to the yank menu, whose every option copies
+        // the whole conversation.
+        if let AppMode::View(ref state) = self.app_mode
+            && state.focused_annotation.is_some()
+        {
+            match code {
+                KeyCode::Char('d') if modifiers.is_empty() => {
+                    self.delete_focused_annotation(viewport_height);
+                    return None;
+                }
+                KeyCode::Char('y') if modifiers.is_empty() => {
+                    self.copy_focused_annotation();
+                    return None;
+                }
+                KeyCode::Char('e') if modifiers.is_empty() => {
+                    self.start_edit_annotation();
+                    return None;
+                }
+                KeyCode::Char('m') if modifiers.is_empty() => {
+                    self.start_annotation_move();
+                    return None;
+                }
+                KeyCode::Esc => {
+                    if let AppMode::View(ref mut state) = self.app_mode {
+                        state.focused_annotation = None;
+                    }
+                    self.re_render_view(viewport_height);
+                    return None;
+                }
+                _ => {}
+            }
+        }
+        if self.keys.annotate.matches(code, modifiers) {
+            self.start_annotate();
+            return None;
+        }
         if self.keys.delete.matches(code, modifiers) {
             if !self.single_file_mode {
                 self.dialog_mode = DialogMode::ConfirmDelete;
@@ -296,6 +381,10 @@ impl App {
             }
             KeyCode::Char('i') => {
                 self.toggle_view_timing(viewport_height);
+                None
+            }
+            KeyCode::Char('A') => {
+                self.toggle_view_annotations(viewport_height);
                 None
             }
             KeyCode::Char('p') => {

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -35,6 +35,790 @@ fn conversation(project: Option<&str>, project_dir: &str, uuid: &str, text: &str
 }
 
 #[test]
+fn annotating_takes_its_line_from_the_focused_message() {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("abc.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"summary","summary":"dropped from the message list"}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    app.re_render_view(20);
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_message = Some(0);
+    }
+
+    app.start_annotate();
+
+    // The first message is on file line 2: line 1 is a summary record, which
+    // carries no ordinal but still consumes a line.
+    match app.dialog_mode {
+        DialogMode::Annotate { line, .. } => assert_eq!(line, Some(2)),
+        _ => panic!("annotate prompt opened"),
+    }
+}
+
+#[test]
+fn annotating_without_a_focused_message_attaches_to_the_session() {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("abc.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_message = None;
+    }
+
+    app.start_annotate();
+
+    match app.dialog_mode {
+        DialogMode::Annotate { line, .. } => assert_eq!(line, None),
+        _ => panic!("annotate prompt opened"),
+    }
+}
+
+/// Builds a viewer over a one-message transcript with that message focused.
+/// The directory is returned with the app, so the transcript outlives the test
+/// body rather than being removed when the helper returns.
+fn viewer_with_one_focused_message() -> (tempfile::TempDir, App) {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("abc.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"summary","summary":"s","leafUuid":"x"}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    app.re_render_view(20);
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_message = Some(0);
+    }
+    (root, app)
+}
+
+fn dialog_line(app: &App) -> Option<usize> {
+    match app.dialog_mode {
+        DialogMode::Annotate { line, .. } => line,
+        _ => panic!("annotate prompt open"),
+    }
+}
+
+#[test]
+fn tab_moves_a_new_note_between_the_line_and_the_session() {
+    let (_root, mut app) = viewer_with_one_focused_message();
+
+    app.start_annotate();
+    assert_eq!(dialog_line(&app), Some(2));
+
+    app.handle_key(KeyCode::Tab, KeyModifiers::NONE, 20);
+    assert_eq!(dialog_line(&app), None);
+
+    app.handle_key(KeyCode::Tab, KeyModifiers::NONE, 20);
+    assert_eq!(dialog_line(&app), Some(2));
+}
+
+#[test]
+fn alt_enter_inserts_a_newline_and_plain_enter_still_saves() {
+    // The store is a temporary directory: the save at the end of this test
+    // writes, and the app's own annotators resolve to the user's real
+    // annotation root.
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_one_focused_message();
+    app.annotators = annotators_rooted_at(store.path());
+
+    app.start_annotate();
+    app.handle_key(KeyCode::Char('a'), KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Enter, KeyModifiers::ALT, 20);
+    app.handle_key(KeyCode::Char('b'), KeyModifiers::NONE, 20);
+
+    match app.dialog_mode {
+        DialogMode::Annotate {
+            ref input, cursor, ..
+        } => {
+            assert_eq!(input, "a\nb");
+            assert_eq!(cursor, 3);
+        }
+        _ => panic!("annotate prompt open"),
+    }
+
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+    assert!(matches!(app.dialog_mode, DialogMode::None));
+}
+
+/// Points the app's annotators at `store`, so a write in a test lands there
+/// rather than in the user's own annotation directory.
+fn annotators_rooted_at(store: &std::path::Path) -> crate::annotations::AnnotatorSet {
+    crate::annotations::AnnotatorSet::from_config(&crate::config::ConfigFile {
+        annotations: Some(crate::config::AnnotationsConfig {
+            root: Some(store.to_path_buf()),
+            write_to: None,
+        }),
+        ..Default::default()
+    })
+}
+
+fn stored_notes(app: &App) -> Vec<crate::annotations::Annotation> {
+    let AppMode::View(state) = &app.app_mode else {
+        panic!("still in view mode");
+    };
+    state
+        .annotations
+        .session
+        .iter()
+        .chain(state.annotations.positioned.iter())
+        .cloned()
+        .collect()
+}
+
+fn type_text(app: &mut App, text: &str) {
+    for character in text.chars() {
+        app.handle_key(KeyCode::Char(character), KeyModifiers::NONE, 20);
+    }
+}
+
+/// Builds a viewer over a three-message transcript with the first focused, so
+/// a note has lines above and below it to move to.
+fn viewer_with_three_messages() -> (tempfile::TempDir, App) {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("abc.jsonl");
+    let message = |text: &str| {
+        format!(
+            r#"{{"type":"user","message":{{"role":"user","content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        )
+    };
+    std::fs::write(
+        &transcript,
+        format!(
+            "{}\n{}\n{}\n",
+            message("one"),
+            message("two"),
+            message("three")
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    app.re_render_view(20);
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_message = Some(0);
+    }
+    (root, app)
+}
+
+/// Places one note on `line` in the viewer's in-memory annotations and selects
+/// it, the state a click inside a note leaves behind.
+fn select_note_on_line(app: &mut App, id: &str, line: usize) {
+    let note = crate::annotations::Annotation {
+        id: id.to_string(),
+        targets: vec![crate::annotations::TargetSpan::single(line)],
+        kind: "note".to_string(),
+        text: "movable".to_string(),
+        annotator: "file".to_string(),
+        origin: None,
+        created: None,
+        modified: None,
+    };
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations.positioned = vec![note];
+        state.focused_annotation = Some(id.to_string());
+    }
+}
+
+fn app_path(app: &App) -> std::path::PathBuf {
+    let AppMode::View(state) = &app.app_mode else {
+        panic!("in view mode");
+    };
+    state.conversation_path.clone()
+}
+
+fn note_line(app: &App, id: &str) -> Option<usize> {
+    let AppMode::View(state) = &app.app_mode else {
+        panic!("in view mode");
+    };
+    state
+        .annotations
+        .positioned
+        .iter()
+        .chain(state.annotations.session.iter())
+        .find(|annotation| annotation.id == id)
+        .and_then(|annotation| annotation.anchor_line())
+}
+
+#[test]
+fn a_move_steps_only_across_lines_the_view_renders() {
+    // The summary record on line 1 is parsed and carries a line, and it draws
+    // no row, so a move must not stop on it.
+    let (_root, app) = viewer_with_one_focused_message();
+
+    assert_eq!(app.rendered_entry_lines(), vec![2]);
+}
+
+#[test]
+fn a_tool_entry_under_the_hidden_filter_still_draws_a_row_and_stays_a_stop() {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("filtered.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"one"}]}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]}}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"three"}]}}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    app.re_render_view(20);
+
+    // Hidden tools still draw a row for the entry holding them, so all three
+    // lines are stops. The set follows what is rendered, not what is parsed:
+    // a record drawing no row, such as a summary, is the case that is skipped.
+    let AppMode::View(state) = &app.app_mode else {
+        panic!("in view mode");
+    };
+    assert_eq!(state.message_ranges.len(), 3);
+    assert_eq!(app.rendered_entry_lines(), vec![1, 2, 3]);
+}
+
+#[test]
+fn m_puts_the_selected_note_under_a_move() {
+    let (_root, mut app) = viewer_with_three_messages();
+    select_note_on_line(&mut app, "note-1", 2);
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+
+    match app.app_mode {
+        AppMode::View(ref state) => {
+            let moving = state.moving_annotation.as_ref().expect("under a move");
+            assert_eq!(moving.id, "note-1");
+            assert_eq!(moving.line, 2);
+        }
+        _ => panic!("in view mode"),
+    }
+}
+
+#[test]
+fn a_move_steps_the_note_across_entry_lines_and_holds_at_the_ends() {
+    let (_root, mut app) = viewer_with_three_messages();
+    select_note_on_line(&mut app, "note-1", 2);
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    assert_eq!(note_line(&app, "note-1"), Some(3));
+
+    // Past the last entry line the note holds rather than leaving the file.
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    assert_eq!(note_line(&app, "note-1"), Some(3));
+
+    app.handle_key(KeyCode::Up, KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Up, KeyModifiers::NONE, 20);
+    assert_eq!(note_line(&app, "note-1"), Some(1));
+
+    app.handle_key(KeyCode::Up, KeyModifiers::NONE, 20);
+    assert_eq!(note_line(&app, "note-1"), Some(1));
+}
+
+#[test]
+fn esc_puts_a_moved_note_back_where_it_started() {
+    let (_root, mut app) = viewer_with_three_messages();
+    select_note_on_line(&mut app, "note-1", 2);
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    assert_eq!(note_line(&app, "note-1"), Some(3));
+
+    app.handle_key(KeyCode::Esc, KeyModifiers::NONE, 20);
+
+    assert_eq!(note_line(&app, "note-1"), Some(2));
+    match app.app_mode {
+        AppMode::View(ref state) => assert!(state.moving_annotation.is_none()),
+        _ => panic!("in view mode"),
+    }
+}
+
+#[test]
+fn a_move_scrolls_the_note_back_into_view() {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("long.jsonl");
+    let body: String = (1..=30)
+        .map(|n| {
+            format!(
+                "{}\n",
+                format_args!(
+                    r#"{{"type":"user","message":{{"role":"user","content":[{{"type":"text","text":"message {n}"}}]}}}}"#
+                )
+            )
+        })
+        .collect();
+    std::fs::write(&transcript, body).unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    app.re_render_view(4);
+    select_note_on_line(&mut app, "note-1", 1);
+    app.re_render_view(4);
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 4);
+    let start = match app.app_mode {
+        AppMode::View(ref state) => state.scroll_offset,
+        _ => panic!("in view mode"),
+    };
+
+    // Far enough down that the note leaves a four-row viewport.
+    for _ in 0..20 {
+        app.handle_key(KeyCode::Down, KeyModifiers::NONE, 4);
+    }
+
+    let (offset, note_start) = match app.app_mode {
+        AppMode::View(ref state) => (
+            state.scroll_offset,
+            state
+                .annotation_ranges
+                .iter()
+                .find(|range| range.id == "note-1")
+                .map(|range| range.start_line)
+                .expect("the note is rendered"),
+        ),
+        _ => panic!("in view mode"),
+    };
+    assert!(offset > start, "the viewport followed the note");
+    assert!(
+        note_start >= offset && note_start < offset + 4,
+        "note at {note_start}, viewport {offset}..{}",
+        offset + 4
+    );
+}
+
+#[test]
+fn esc_returns_the_viewport_to_where_the_move_started() {
+    let (_root, mut app) = viewer_with_three_messages();
+    select_note_on_line(&mut app, "note-1", 2);
+    let total = match app.app_mode {
+        AppMode::View(ref state) => state.total_lines,
+        _ => panic!("in view mode"),
+    };
+    // The restore is clamped to what the render holds, so the test scrolls
+    // inside that range rather than to an offset the transcript cannot reach.
+    assert!(total > 3, "transcript renders {total} lines");
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.scroll_offset = 2;
+    }
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 1);
+    if let AppMode::View(ref mut state) = app.app_mode {
+        // The scroll the move itself performed, which the cancel undoes.
+        state.scroll_offset = 0;
+    }
+
+    app.handle_key(KeyCode::Esc, KeyModifiers::NONE, 1);
+
+    match app.app_mode {
+        AppMode::View(ref state) => assert_eq!(state.scroll_offset, 2),
+        _ => panic!("in view mode"),
+    }
+}
+
+/// Points the app at the `file` annotator plus a command annotator that acts on
+/// `replaces`, with new notes routed to `file`. An edit of a note held by the
+/// command annotator must reach that annotator rather than the write target.
+fn annotators_with_a_replacing_command(
+    file_root: &std::path::Path,
+    store: &std::path::Path,
+) -> crate::annotations::AnnotatorSet {
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/annotators/replacing.sh");
+    let mut table = std::collections::BTreeMap::new();
+    table.insert(
+        "file".to_string(),
+        crate::config::AnnotatorConfig {
+            root: Some(file_root.to_path_buf()),
+            ..Default::default()
+        },
+    );
+    table.insert(
+        "replacing".to_string(),
+        crate::config::AnnotatorConfig {
+            command: Some(format!("{} {}", fixture.display(), store.display())),
+            ..Default::default()
+        },
+    );
+    crate::annotations::AnnotatorSet::from_config(&crate::config::ConfigFile {
+        annotations: Some(crate::config::AnnotationsConfig {
+            root: None,
+            write_to: Some("file".to_string()),
+        }),
+        annotators: Some(table),
+        ..Default::default()
+    })
+}
+
+#[test]
+fn a_move_writes_back_to_the_annotator_holding_the_note() {
+    let file_root = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_three_messages();
+    app.annotators = annotators_with_a_replacing_command(file_root.path(), store.path());
+    let path = app_path(&app);
+
+    // The note is created in the command annotator, not the write target.
+    app.annotators()
+        .write_to_annotator(
+            "replacing",
+            &path,
+            &crate::annotations::Annotation {
+                targets: vec![crate::annotations::TargetSpan::single(1)],
+                kind: "note".to_string(),
+                text: "held elsewhere".to_string(),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    let annotations = app.annotators().read_one(&path);
+    let id = annotations.positioned[0].id.clone();
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations = annotations;
+        state.focused_annotation = Some(id.clone());
+    }
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let stored = stored_notes(&app);
+    assert_eq!(stored.len(), 1, "one record, not one per store");
+    assert_eq!(stored[0].annotator, "replacing", "still held by its store");
+    assert_eq!(stored[0].anchor_line(), Some(2));
+    // The annotator acted on `replaces`, so the id survived and no delete
+    // removed the record it had just written.
+    assert_eq!(stored[0].id, id);
+    assert!(
+        crate::annotations::sidecar_path(file_root.path(), &path)
+            .is_none_or(|sidecar| !sidecar.exists()),
+        "the write target holds nothing"
+    );
+}
+
+#[test]
+fn an_edit_writes_back_to_the_annotator_holding_the_note() {
+    let file_root = tempfile::tempdir().unwrap();
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_three_messages();
+    app.annotators = annotators_with_a_replacing_command(file_root.path(), store.path());
+    let path = app_path(&app);
+
+    app.annotators()
+        .write_to_annotator(
+            "replacing",
+            &path,
+            &crate::annotations::Annotation {
+                targets: vec![crate::annotations::TargetSpan::single(1)],
+                kind: "note".to_string(),
+                text: "before".to_string(),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+    let annotations = app.annotators().read_one(&path);
+    let id = annotations.positioned[0].id.clone();
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations = annotations;
+        state.focused_annotation = Some(id.clone());
+    }
+
+    app.start_edit_annotation();
+    type_text(&mut app, " and after");
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let stored = stored_notes(&app);
+    assert_eq!(stored.len(), 1, "one record, not one per store");
+    assert_eq!(stored[0].annotator, "replacing", "still held by its store");
+    assert_eq!(stored[0].text, "before and after");
+    assert_eq!(stored[0].id, id, "the annotator kept the id");
+}
+
+#[test]
+fn a_move_keeps_the_length_of_a_multi_line_span() {
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_three_messages();
+    app.annotators = annotators_rooted_at(store.path());
+
+    let note = crate::annotations::Annotation {
+        id: "note-1".to_string(),
+        targets: vec![crate::annotations::TargetSpan { start: 1, end: 2 }],
+        kind: "note".to_string(),
+        text: "spanning".to_string(),
+        annotator: String::new(),
+        origin: None,
+        created: None,
+        modified: None,
+    };
+    app.annotators()
+        .write(&app_path(&app), &note, None)
+        .unwrap();
+    let annotations = app.annotators().read_one(&app_path(&app));
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations = annotations;
+        state.focused_annotation = Some(state.annotations.positioned[0].id.clone());
+    }
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let stored = stored_notes(&app);
+    assert_eq!(stored.len(), 1);
+    assert_eq!(
+        stored[0].targets,
+        vec![crate::annotations::TargetSpan { start: 2, end: 3 }]
+    );
+}
+
+#[test]
+fn ctrl_c_leaves_the_process_from_inside_a_move() {
+    let (_root, mut app) = viewer_with_three_messages();
+    select_note_on_line(&mut app, "note-1", 2);
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+
+    let action = app.handle_key(KeyCode::Char('c'), KeyModifiers::CONTROL, 20);
+
+    assert!(matches!(action, Some(Action::Quit)));
+    // The move is abandoned on the way out, so the note is left as the store
+    // holds it rather than at the line the move reached.
+    match app.app_mode {
+        AppMode::View(ref state) => assert!(state.moving_annotation.is_none()),
+        _ => panic!("in view mode"),
+    }
+}
+
+#[test]
+fn m_on_a_session_note_leaves_the_viewer_as_it_was() {
+    let (_root, mut app) = viewer_with_three_messages();
+    let note = crate::annotations::Annotation {
+        id: "note-1".to_string(),
+        targets: Vec::new(),
+        kind: "note".to_string(),
+        text: "session".to_string(),
+        annotator: "file".to_string(),
+        origin: None,
+        created: None,
+        modified: None,
+    };
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations.session = vec![note];
+        state.focused_annotation = Some("note-1".to_string());
+    }
+
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+
+    match app.app_mode {
+        AppMode::View(ref state) => assert!(state.moving_annotation.is_none()),
+        _ => panic!("in view mode"),
+    }
+}
+
+#[test]
+fn enter_writes_the_note_at_the_line_the_move_reached() {
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_three_messages();
+    app.annotators = annotators_rooted_at(store.path());
+
+    app.start_annotate();
+    type_text(&mut app, "movable");
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let written = stored_notes(&app);
+    assert_eq!(written.len(), 1);
+    assert_eq!(written[0].anchor_line(), Some(1));
+    let id = written[0].id.clone();
+    let created = written[0].created.clone();
+
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_annotation = Some(id.clone());
+    }
+    app.handle_key(KeyCode::Char('m'), KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Down, KeyModifiers::NONE, 20);
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let moved = stored_notes(&app);
+    assert_eq!(moved.len(), 1);
+    assert_eq!(moved[0].anchor_line(), Some(2));
+    assert_eq!(moved[0].text, "movable");
+    // The move is an edit: the creation stamp survives and the edit stamp moves.
+    assert_eq!(moved[0].created, created);
+    assert_ne!(moved[0].modified, moved[0].created);
+}
+
+#[test]
+fn an_edit_carries_the_creation_stamp_forward_and_moves_the_edit_stamp() {
+    let store = tempfile::tempdir().unwrap();
+    let (_root, mut app) = viewer_with_one_focused_message();
+    app.annotators = annotators_rooted_at(store.path());
+
+    app.start_annotate();
+    type_text(&mut app, "first");
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let written = stored_notes(&app);
+    assert_eq!(written.len(), 1);
+    let created = written[0].created.clone().expect("a write stamps created");
+    assert_eq!(written[0].modified, Some(created.clone()));
+
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.focused_annotation = Some(written[0].id.clone());
+    }
+    app.start_edit_annotation();
+    type_text(&mut app, " again");
+    app.handle_key(KeyCode::Enter, KeyModifiers::NONE, 20);
+
+    let edited = stored_notes(&app);
+    assert_eq!(edited.len(), 1);
+    assert_eq!(edited[0].text, "first again");
+    assert_eq!(edited[0].created, Some(created.clone()));
+    assert_ne!(edited[0].modified, Some(created));
+}
+
+#[test]
+fn tab_moves_an_edited_line_note_to_the_session_and_back() {
+    let (_root, mut app) = viewer_with_one_focused_message();
+    let note = crate::annotations::Annotation {
+        id: "note-1".to_string(),
+        targets: vec![crate::annotations::TargetSpan::single(2)],
+        kind: "note".to_string(),
+        text: "text".to_string(),
+        annotator: "file".to_string(),
+        origin: None,
+        created: None,
+        modified: None,
+    };
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations.positioned = vec![note];
+        state.focused_annotation = Some("note-1".to_string());
+    }
+
+    app.start_edit_annotation();
+    assert_eq!(dialog_line(&app), Some(2));
+
+    app.handle_key(KeyCode::Tab, KeyModifiers::NONE, 20);
+    assert_eq!(dialog_line(&app), None);
+
+    app.handle_key(KeyCode::Tab, KeyModifiers::NONE, 20);
+    assert_eq!(dialog_line(&app), Some(2));
+}
+
+#[test]
+fn tab_moves_an_edited_session_note_onto_the_focused_message() {
+    let (_root, mut app) = viewer_with_one_focused_message();
+    let note = crate::annotations::Annotation {
+        id: "note-1".to_string(),
+        targets: Vec::new(),
+        kind: "note".to_string(),
+        text: "text".to_string(),
+        annotator: "file".to_string(),
+        origin: None,
+        created: None,
+        modified: None,
+    };
+    if let AppMode::View(ref mut state) = app.app_mode {
+        state.annotations.session = vec![note];
+        state.focused_annotation = Some("note-1".to_string());
+    }
+
+    app.start_edit_annotation();
+    assert_eq!(dialog_line(&app), None);
+
+    app.handle_key(KeyCode::Tab, KeyModifiers::NONE, 20);
+    assert_eq!(dialog_line(&app), Some(2));
+}
+
+#[test]
+fn an_empty_annotation_closes_the_prompt_without_writing() {
+    let root = tempfile::tempdir().unwrap();
+    let transcript = root.path().join("abc.jsonl");
+    std::fs::write(
+        &transcript,
+        concat!(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+
+    let mut app = App::new_single_file(
+        transcript,
+        crate::tui::ToolDisplayMode::Hidden,
+        false,
+        crate::config::KeyBindings::default(),
+    );
+    // A temporary store even though the empty text returns before writing, so
+    // a regression writes into the test's own directory rather than the user's
+    // annotation root.
+    let store = tempfile::tempdir().unwrap();
+    app.annotators = annotators_rooted_at(store.path());
+
+    app.start_annotate();
+    app.submit_annotate(20);
+
+    assert!(matches!(app.dialog_mode, DialogMode::None));
+    let AppMode::View(state) = &app.app_mode else {
+        panic!("still in view mode");
+    };
+    assert!(state.annotations.is_empty());
+}
+
+#[test]
 fn mixed_sources_are_identified_and_pi_local_filter_uses_header_cwd() {
     let mut claude = conversation(Some("project"), "-tmp-project", "claude-id", "claude");
     let mut pi = conversation(Some("project"), "ignored", "pi-id", "pi");
@@ -1616,4 +2400,125 @@ fn single_file_mode_has_no_project_exclusions() {
 
     assert!(app.excluded_projects.is_empty());
     assert!(app.is_single_file_mode());
+}
+
+/// An annotator set holding only the file annotator, rooted at `root`.
+fn annotator_set_rooted_at(root: PathBuf) -> crate::annotations::AnnotatorSet {
+    let mut table = std::collections::BTreeMap::new();
+    table.insert(
+        crate::config::DEFAULT_ANNOTATOR.to_string(),
+        crate::config::AnnotatorConfig {
+            root: Some(root),
+            ..crate::config::AnnotatorConfig::default()
+        },
+    );
+    crate::annotations::AnnotatorSet::from_config(&crate::config::ConfigFile {
+        annotators: Some(table),
+        ..crate::config::ConfigFile::default()
+    })
+}
+
+/// Writes one sidecar for `conversation` under a fresh annotations root and
+/// returns that root, mirroring the layout the file annotator reads.
+fn annotations_root_with_note(
+    dir: &std::path::Path,
+    conversation: &Conversation,
+    text: &str,
+) -> PathBuf {
+    let root = dir.join("annotations");
+    let project = conversation
+        .path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .expect("conversation sits under a project directory");
+    let project_dir = root.join(project);
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let sidecar = project_dir.join(format!("{}.jsonl", conversation.session_id));
+    std::fs::write(
+        sidecar,
+        format!(
+            "{}\n",
+            serde_json::json!({"id": "note-1", "kind": "note", "text": text})
+        ),
+    )
+    .unwrap();
+    root
+}
+
+#[test]
+fn a_note_makes_its_conversation_match_a_list_search() {
+    let dir = tempfile::tempdir().unwrap();
+    let conv = conversation(
+        Some("Visible"),
+        "-tmp-visible",
+        "22222222-2222-4222-8222-222222222222",
+        "transcript body with no such word",
+    );
+    let root = annotations_root_with_note(dir.path(), &conv, "pelican crossing");
+
+    let mut app = app(vec![conv], vec![]);
+    app.set_annotators_for_test(annotator_set_rooted_at(root));
+    app.finish_loading();
+
+    app.query = "pelican".to_string();
+    app.update_filter();
+
+    assert_eq!(filtered_projects(&app), vec![Some("Visible")]);
+}
+
+#[test]
+fn note_text_reaches_the_field_the_evidence_line_is_drawn_from() {
+    let dir = tempfile::tempdir().unwrap();
+    let conv = conversation(
+        Some("Visible"),
+        "-tmp-visible",
+        "22222222-2222-4222-8222-222222222222",
+        "transcript body with no such word",
+    );
+    let root = annotations_root_with_note(dir.path(), &conv, "pelican crossing");
+
+    let mut app = app(vec![conv], vec![]);
+    app.set_annotators_for_test(annotator_set_rooted_at(root));
+    app.finish_loading();
+
+    // The evidence builder reads full_text and skips what the preview already
+    // shows, so the note's presence there is what puts it on the row.
+    assert!(
+        app.conversations()[0]
+            .full_text
+            .contains("pelican crossing"),
+        "{}",
+        app.conversations()[0].full_text
+    );
+    let evidence = crate::search::build_lexical_evidence(
+        &app.conversations()[0],
+        &crate::search::query::ParsedQuery::parse("pelican"),
+    )
+    .expect("evidence for a note-only match");
+    assert!(!evidence.context_ranges.is_empty());
+}
+
+#[test]
+fn enrichment_appends_one_copy_of_a_note() {
+    let dir = tempfile::tempdir().unwrap();
+    let conv = conversation(
+        Some("Visible"),
+        "-tmp-visible",
+        "22222222-2222-4222-8222-222222222222",
+        "transcript body",
+    );
+    let root = annotations_root_with_note(dir.path(), &conv, "pelican crossing");
+
+    let mut app = app(vec![conv], vec![]);
+    app.set_annotators_for_test(annotator_set_rooted_at(root));
+    app.finish_loading();
+    // A second pass would double the note's text and with it its lexical weight.
+    app.finish_loading();
+
+    assert_eq!(
+        app.conversations()[0].full_text.matches("pelican").count(),
+        1,
+        "{}",
+        app.conversations()[0].full_text
+    );
 }

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -33,6 +33,39 @@ pub enum DialogMode {
     SemanticDebug,
     /// Rename the selected conversation
     Rename { input: String, cursor: usize },
+    /// Write an annotation against the conversation being viewed.
+    ///
+    /// `line` is the JSONL line the focused message came from. With no focused
+    /// message it is `None`, and the annotation attaches to the session.
+    Annotate {
+        input: String,
+        cursor: usize,
+        /// The note's target: a file line, or `None` for the whole session.
+        /// Tab moves it between the two.
+        line: Option<usize>,
+        /// The line Tab returns to after the target has been set to the
+        /// session. Held separately so the message the prompt opened on
+        /// survives a round trip through session scope.
+        anchor: Option<usize>,
+        /// Id being replaced when editing. Writing removes it and appends the
+        /// new text, so an edit never leaves both versions in the store.
+        replacing: Option<String>,
+    },
+}
+
+/// A note under a move, and the target it held when the move started.
+///
+/// `original` is written back when the move is cancelled, so a cancelled move
+/// leaves the store untouched and the viewer showing what the store holds.
+#[derive(Clone, Debug)]
+pub struct AnnotationMove {
+    pub id: String,
+    pub original: Vec<crate::annotations::TargetSpan>,
+    /// The line the note sits on now, which a save writes as its target.
+    pub line: usize,
+    /// The scroll position when the move started. A cancel returns the viewport
+    /// to it, so leaving the move restores the screen as well as the note.
+    pub scroll_offset: usize,
 }
 
 /// Main application mode
@@ -62,6 +95,20 @@ pub struct ViewState {
     pub tool_display: ToolDisplayMode,
     /// Whether to show thinking blocks
     pub show_thinking: bool,
+    /// Whether to show annotations attached to this conversation
+    pub show_annotations: bool,
+    /// Annotations for the conversation being viewed, read once on entry so a
+    /// re-render does not touch the filesystem again.
+    pub annotations: crate::annotations::ConversationAnnotations,
+    /// Line spans of the rendered annotation blocks, kept apart from
+    /// `message_ranges` so the scroll anchor's search over `entry_index` is not
+    /// disturbed by blocks that carry no entry.
+    pub annotation_ranges: Vec<crate::tui::viewer::AnnotationRange>,
+    /// Id of the selected annotation, if one is selected.
+    pub focused_annotation: Option<String>,
+    /// The note being moved, present while the viewer is in move mode. Its
+    /// keys take the arrows, Enter and Esc for as long as it is set.
+    pub moving_annotation: Option<AnnotationMove>,
     /// Whether to show timing information (timestamps + durations)
     pub show_timing: bool,
     /// Content width used for rendering (for resize detection)
@@ -125,6 +172,10 @@ impl ViewState {
         show_timing: bool,
         content_width: usize,
     ) -> Self {
+        // Read here as well as on the list-to-viewer path: opening a transcript
+        // directly builds its state through this constructor and would otherwise
+        // show none.
+        let annotations = crate::annotations::for_conversation(&conversation_path);
         Self {
             conversation_path,
             parsed_entries: None,
@@ -133,6 +184,11 @@ impl ViewState {
             total_lines: 0,
             tool_display,
             show_thinking,
+            show_annotations: true,
+            annotations,
+            annotation_ranges: Vec::new(),
+            focused_annotation: None,
+            moving_annotation: None,
             show_timing,
             content_width,
             search_mode: ViewSearchMode::Off,

--- a/src/tui/app/view_state.rs
+++ b/src/tui/app/view_state.rs
@@ -17,12 +17,21 @@ impl App {
         };
         let path = self.conversations[conv_idx].path.clone();
 
+        // Read once on entry: a re-render reuses this rather than returning to
+        // the filesystem on every toggle and resize.
+        let annotations = self.annotators().read_one(&path);
+        let annotator_labels = self.annotators().labels();
+
         let options = RenderOptions {
             tool_display: self.tool_display,
             show_thinking: self.show_thinking,
             show_timing: self.show_timing,
             content_width,
             expanded_tool_outputs: BTreeSet::new(),
+            show_annotations: true,
+            annotations: annotations.clone(),
+            annotator_labels: annotator_labels.clone(),
+            focused_annotation: None,
         };
 
         match parse_conversation_file(&path) {
@@ -43,6 +52,11 @@ impl App {
                     total_lines,
                     tool_display: self.tool_display,
                     show_thinking: self.show_thinking,
+                    show_annotations: true,
+                    annotations,
+                    annotation_ranges: rendered.annotations.clone(),
+                    focused_annotation: None,
+                    moving_annotation: None,
                     show_timing: self.show_timing,
                     content_width,
                     search_mode: ViewSearchMode::Off,
@@ -208,6 +222,13 @@ impl App {
         }
     }
 
+    pub(super) fn toggle_view_annotations(&mut self, viewport_height: usize) {
+        if let AppMode::View(ref mut state) = self.app_mode {
+            state.show_annotations = !state.show_annotations;
+        }
+        self.re_render_view(viewport_height);
+    }
+
     pub(super) fn toggle_view_timing(&mut self, viewport_height: usize) {
         if let AppMode::View(ref mut state) = self.app_mode {
             state.show_timing = !state.show_timing;
@@ -219,6 +240,7 @@ impl App {
     pub(super) fn re_render_view(&mut self, viewport_height: usize) {
         use crate::tui::viewer::{parse_conversation_file, render_parsed_conversation};
 
+        let annotator_labels = self.annotators().labels();
         if let AppMode::View(ref mut state) = self.app_mode {
             let options = RenderOptions {
                 tool_display: state.tool_display,
@@ -226,6 +248,10 @@ impl App {
                 show_timing: state.show_timing,
                 content_width: state.content_width,
                 expanded_tool_outputs: state.expanded_tool_outputs.clone(),
+                show_annotations: state.show_annotations,
+                annotations: state.annotations.clone(),
+                annotator_labels,
+                focused_annotation: state.focused_annotation.clone(),
             };
 
             let anchor = capture_anchor(
@@ -251,6 +277,7 @@ impl App {
             state.total_lines = rendered.lines.len();
             state.rendered_lines = rendered.lines;
             state.message_ranges = rendered.messages;
+            state.annotation_ranges = rendered.annotations;
 
             let max_scroll = state.total_lines.saturating_sub(viewport_height);
 
@@ -428,6 +455,24 @@ impl App {
         true
     }
 
+    /// Places one annotation range over the given lines and selects it, the
+    /// state a click inside a note leaves behind.
+    #[cfg(test)]
+    pub fn select_annotation_for_test(&mut self, id: &str, start_line: usize, end_line: usize) {
+        let AppMode::View(state) = &mut self.app_mode else {
+            panic!("view mode");
+        };
+        state
+            .annotation_ranges
+            .push(crate::tui::viewer::AnnotationRange {
+                id: id.to_string(),
+                start_line,
+                end_line,
+            });
+        state.focused_annotation = Some(id.to_string());
+        state.message_nav_active = false;
+    }
+
     pub fn handle_view_click(
         &mut self,
         row: u16,
@@ -437,6 +482,33 @@ impl App {
         let Some(line_idx) = self.view_line_at_row(row, frame_area) else {
             return false;
         };
+        if let AppMode::View(state) = &self.app_mode
+            && let Some(id) = state
+                .annotation_ranges
+                .iter()
+                .find(|range| line_idx >= range.start_line && line_idx < range.end_line)
+                .map(|range| range.id.clone())
+        {
+            let already = state.focused_annotation.as_deref() == Some(id.as_str());
+            if let AppMode::View(state) = &mut self.app_mode {
+                // A second click clears the selection, so a deselect needs no
+                // key.
+                state.focused_annotation = if already { None } else { Some(id) };
+                state.message_nav_active = false;
+            }
+            self.re_render_view(viewport_height);
+            return true;
+        }
+
+        // A click landing outside every note clears the selection. While one is
+        // held, d, e, y and Esc act on the note rather than the conversation,
+        // and a yank leaves the selection in place, so without this the keys
+        // stay captured however far away the next click lands.
+        let deselected = match &mut self.app_mode {
+            AppMode::View(state) => state.focused_annotation.take().is_some(),
+            _ => false,
+        };
+
         let tool_output = self.view_tool_output_at_line(line_idx);
         let message_idx = if let AppMode::View(state) = &self.app_mode {
             Self::message_idx_at_line(&state.message_ranges, line_idx)
@@ -444,13 +516,16 @@ impl App {
             None
         };
         if tool_output.is_none() && message_idx.is_none() {
-            return false;
+            if deselected {
+                self.re_render_view(viewport_height);
+            }
+            return deselected;
         }
 
         let AppMode::View(state) = &mut self.app_mode else {
             return false;
         };
-        let mut changed = false;
+        let mut changed = deselected;
         if let Some(idx) = message_idx
             && (!state.message_nav_active || state.focused_message != Some(idx))
         {

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -34,6 +34,10 @@ pub struct Theme {
     pub heading: Rgb,
     pub thinking_text: Rgb,
     pub tool_text: Rgb,
+    /// Annotations: text attached to a conversation from outside it. Held apart
+    /// from `accent` and `text_primary` so an annotation never reads as a
+    /// message either party wrote.
+    pub annotation: Rgb,
 
     // List view specific
     pub custom_title: Rgb,
@@ -76,6 +80,7 @@ impl Theme {
         Self {
             accent: (78, 201, 176),
             accent_dim: (60, 160, 140),
+            annotation: (97, 175, 239),
 
             text_primary: (255, 255, 255),
             text_secondary: (140, 140, 140),
@@ -130,6 +135,7 @@ impl Theme {
         Self {
             accent: (13, 128, 118),     // Deep teal - legible on white
             accent_dim: (45, 115, 105), // Muted teal for secondary elements
+            annotation: (32, 96, 184),  // Blue, legible on white
 
             text_primary: (36, 45, 53),     // Deep slate for body text
             text_secondary: (88, 101, 112), // Cool gray for metadata

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -505,6 +505,26 @@ fn render_view_mode(frame: &mut Frame, app: &App, state: &ViewState) {
         }
         DialogMode::SemanticDebug => render_semantic_debug_popup(frame, app),
         DialogMode::Rename { input, cursor } => render_rename_dialog(frame, input, *cursor),
+        DialogMode::Annotate {
+            input,
+            cursor,
+            line,
+            anchor,
+            replacing,
+        } => {
+            let verb = if replacing.is_some() { "Edit" } else { "Note" };
+            let title = match line {
+                Some(line) => format!(" {verb} on line {line} "),
+                None => format!(" {verb} on session "),
+            };
+            // The Tab hint appears where an anchor line exists, which is the
+            // condition under which the key moves the target.
+            let hint = match anchor {
+                Some(_) => "Enter save · Alt+Enter newline · Tab scope · Esc cancel",
+                None => "Enter save · Alt+Enter newline · Esc cancel",
+            };
+            render_text_prompt(frame, input, *cursor, &title, hint, ANNOTATE_PROMPT_ROWS);
+        }
         DialogMode::None => {}
     }
 }
@@ -709,8 +729,16 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
     let visible_height = area.height as usize;
     let query_lower = state.search_query.to_lowercase();
 
-    // Determine focused message line range (only when nav mode active)
-    let focused_range = if state.message_nav_active {
+    // Determine the focused line range. A selected note takes the range first,
+    // so the gutter marks the selection the d and e keys act on; message nav
+    // supplies the range the rest of the time.
+    let focused_range = if let Some(id) = state.focused_annotation.as_deref() {
+        state
+            .annotation_ranges
+            .iter()
+            .find(|range| range.id == id)
+            .map(|range| range.start_line..range.end_line)
+    } else if state.message_nav_active {
         state
             .focused_message
             .and_then(|idx| state.message_ranges.get(idx))
@@ -718,6 +746,10 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
     } else {
         None
     };
+    // The gutter column is drawn while either selection is live. Without the
+    // note case the marker stays hidden, because clicking a note clears
+    // message_nav_active.
+    let gutter_active = state.message_nav_active || state.focused_annotation.is_some();
 
     let visible_lines: Vec<Line> = state
         .rendered_lines
@@ -733,8 +765,8 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
                 .as_ref()
                 .is_some_and(|r| r.contains(&line_idx));
 
-            // Gutter indicator (only shown in message nav mode)
-            let gutter = if state.message_nav_active {
+            // Gutter indicator (shown for a nav-focused message or a selected note)
+            let gutter = if gutter_active {
                 if is_focused {
                     Span::styled("▌ ", Style::default().fg(rgb(th().accent)))
                 } else {
@@ -820,6 +852,7 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
     let tools_status = state.tool_display.status_label();
     let thinking_status = if state.show_thinking { "on " } else { "off" };
     let timing_status = if state.show_timing { "on " } else { "off" };
+    let notes_status = if state.show_annotations { "on " } else { "off" };
 
     let mut spans = vec![
         Span::raw("  "),
@@ -830,13 +863,40 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
         Span::styled("T", key_style),
         Span::styled(format!("hink·{} ", thinking_status), label_style),
         Span::styled("i", key_style),
-        Span::styled(format!("nfo·{}", timing_status), label_style),
+        Span::styled(format!("nfo·{} ", timing_status), label_style),
+        Span::styled("A", key_style),
+        Span::styled(format!("notes·{}", notes_status), label_style),
         Span::raw("  "),
         Span::styled("│", label_style),
         Span::raw("  "),
     ];
 
-    if state.search_mode == ViewSearchMode::Active && !state.search_matches.is_empty() {
+    // A note under a move takes the arrows, Enter and Esc, and a selected note
+    // takes d, e, y and Esc, ahead of every other binding. The row names the
+    // keys that fire in each state instead of export, delete and yank.
+    if state.moving_annotation.is_some() {
+        spans.extend([
+            Span::styled("↑↓", key_style),
+            Span::styled(" move note  ", label_style),
+            Span::styled("Enter", key_style),
+            Span::styled(" save  ", label_style),
+            Span::styled("Esc", key_style),
+            Span::styled(" cancel", label_style),
+        ]);
+    } else if state.focused_annotation.is_some() {
+        spans.extend([
+            Span::styled("e", key_style),
+            Span::styled("dit  ", label_style),
+            Span::styled("m", key_style),
+            Span::styled("ove  ", label_style),
+            Span::styled("d", key_style),
+            Span::styled("elete  ", label_style),
+            Span::styled("y", key_style),
+            Span::styled("ank  ", label_style),
+            Span::styled("Esc", key_style),
+            Span::styled(" deselect", label_style),
+        ]);
+    } else if state.search_mode == ViewSearchMode::Active && !state.search_matches.is_empty() {
         spans.extend([
             Span::styled("n", key_style),
             Span::styled("ext  ", label_style),
@@ -855,6 +915,8 @@ fn render_view_status_bar(frame: &mut Frame, app: &App, state: &ViewState, area:
         ]);
     } else {
         spans.extend([
+            Span::styled("a", key_style),
+            Span::styled("nnotate  ", label_style),
             Span::styled("?", key_style),
             Span::styled("help  ", label_style),
             Span::styled("/", key_style),
@@ -1175,9 +1237,125 @@ fn render_confirm_dialog(frame: &mut Frame, area: Rect) {
 }
 
 fn render_rename_dialog(frame: &mut Frame, input: &str, cursor: usize) {
+    render_text_prompt(
+        frame,
+        input,
+        cursor,
+        " Rename session ",
+        " Enter save · Esc cancel",
+        1,
+    )
+}
+
+/// Rows the annotate prompt grows to before it holds its height and scrolls.
+const ANNOTATE_PROMPT_ROWS: usize = 8;
+
+/// Break `input` into rows no wider than `width` display columns.
+///
+/// Each row carries the char index it starts at, so a cursor's char index
+/// resolves to a row and a column within it. A newline ends a row and occupies
+/// no column. Otherwise a row ends at the last space it holds, and a word wider
+/// than the row breaks at the row edge. An input ending at a row edge or on a
+/// newline gains a trailing empty row, which is where the cursor sits after the
+/// final character.
+fn wrap_rows(input: &str, width: usize) -> Vec<(usize, String)> {
+    let width = width.max(1);
+    let chars: Vec<char> = input.chars().collect();
+    let mut rows: Vec<(usize, String)> = Vec::new();
+    let mut start = 0usize;
+    while start < chars.len() {
+        let mut end = start;
+        let mut used = 0usize;
+        let mut last_space = None;
+        let mut newline = false;
+        while end < chars.len() {
+            if chars[end] == '\n' {
+                newline = true;
+                break;
+            }
+            let char_width = UnicodeWidthChar::width(chars[end]).unwrap_or(0);
+            if used + char_width > width {
+                break;
+            }
+            if chars[end] == ' ' {
+                last_space = Some(end);
+            }
+            used += char_width;
+            end += 1;
+        }
+        if !newline
+            && end < chars.len()
+            && let Some(space) = last_space
+            && space >= start
+        {
+            end = space + 1;
+        }
+        // A single char wider than the row still advances, so the loop ends.
+        if end == start && !newline {
+            end = start + 1;
+        }
+        rows.push((start, chars[start..end].iter().collect()));
+        if newline {
+            start = end + 1;
+            if start == chars.len() {
+                rows.push((start, String::new()));
+            }
+        } else {
+            if end == chars.len() && used == width {
+                rows.push((end, String::new()));
+            }
+            start = end;
+        }
+    }
+    if rows.is_empty() {
+        rows.push((0, String::new()));
+    }
+    rows
+}
+
+/// Render a bordered input prompt holding `input`, wrapped across at most
+/// `max_rows` rows. The box grows with the text; past `max_rows` it holds its
+/// height and shows the rows ending at the cursor.
+fn render_text_prompt(
+    frame: &mut Frame,
+    input: &str,
+    cursor: usize,
+    title: &str,
+    hint: &str,
+    max_rows: usize,
+) {
     let area = frame.area();
-    let menu_width = area.width.saturating_sub(4).clamp(30, 70);
-    let menu_height = 4;
+    // The lower clamp holds a readable box on an ordinary terminal. The hint
+    // widens it further where the terminal has the columns, so the keys it
+    // names sit on one row. The frame width caps the result, so a terminal
+    // narrower than the clamp draws inside its own buffer rather than past the
+    // right edge.
+    let hint_width = UnicodeWidthStr::width(hint).saturating_add(4) as u16;
+    let menu_width = area
+        .width
+        .saturating_sub(4)
+        .clamp(30, 70)
+        .max(hint_width)
+        .min(area.width);
+    let input_width = menu_width.saturating_sub(4) as usize;
+
+    let rows = wrap_rows(input, input_width);
+    let cursor_row = rows
+        .iter()
+        .rposition(|(start, _)| *start <= cursor)
+        .unwrap_or(0);
+    let visible = rows.len().min(max_rows.max(1));
+    let first_row = if cursor_row >= visible {
+        cursor_row + 1 - visible
+    } else {
+        0
+    };
+
+    // The hint wraps like the body, so a prompt naming several keys states them
+    // all rather than clipping the last at the border.
+    let hint_rows = wrap_rows(hint, input_width);
+    // borders (2) + text rows + hint rows
+    let menu_height = (visible as u16 + hint_rows.len() as u16 + 2).min(area.height);
     let menu_area = Rect {
         x: (area.width.saturating_sub(menu_width)) / 2,
         y: (area.height.saturating_sub(menu_height)) / 2,
@@ -1190,37 +1368,54 @@ fn render_rename_dialog(frame: &mut Frame, input: &str, cursor: usize) {
     frame.render_widget(background, menu_area);
 
     let block = Block::default()
-        .title(" Rename session ")
+        .title(title)
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(rgb(th().accent)));
     let inner = block.inner(menu_area);
     frame.render_widget(block, menu_area);
 
-    let input_width = inner.width.saturating_sub(2) as usize;
-    let display = simple_truncate(input, input_width);
-    let lines = vec![
+    let mut lines: Vec<Line> = rows
+        .iter()
+        .skip(first_row)
+        .take(visible)
+        .map(|(_, text)| {
+            Line::from(vec![
+                Span::raw(" "),
+                Span::styled(text.clone(), Style::default().fg(rgb(th().text_primary))),
+            ])
+        })
+        .collect();
+    lines.extend(hint_rows.iter().map(|(_, text)| {
         Line::from(vec![
             Span::raw(" "),
-            Span::styled(display, Style::default().fg(rgb(th().text_primary))),
-        ]),
-        Line::styled(
-            " Enter save · Esc cancel",
-            Style::default().fg(rgb(th().text_muted)),
-        ),
-    ];
+            Span::styled(text.clone(), Style::default().fg(rgb(th().text_muted))),
+        ])
+    }));
     frame.render_widget(Paragraph::new(lines), inner);
 
+    let (row_start, _) = rows[cursor_row];
     let cursor_offset: u16 = input
         .chars()
-        .take(cursor)
+        .skip(row_start)
+        .take(cursor.saturating_sub(row_start))
         .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
         .sum::<usize>()
         .min(input_width) as u16;
-    frame.set_cursor_position(Position::new(
-        inner.x.saturating_add(1).saturating_add(cursor_offset),
-        inner.y,
-    ));
+    // A box narrower or shorter than its borders leaves no cell for a cursor,
+    // and a position outside the frame is what the buffer rejects.
+    if inner.width > 0 && inner.height > 0 {
+        let x = inner
+            .x
+            .saturating_add(1)
+            .saturating_add(cursor_offset)
+            .min(area.width.saturating_sub(1));
+        let y = inner
+            .y
+            .saturating_add((cursor_row - first_row) as u16)
+            .min(area.height.saturating_sub(1));
+        frame.set_cursor_position(Position::new(x, y));
+    }
 }
 
 fn render_export_menu(frame: &mut Frame, selected: usize, is_yank: bool) {
@@ -1494,6 +1689,14 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 }
             });
 
+            // Note count, stated only where notes exist, so a row without them
+            // keeps its width for the summary.
+            let note_count = match app.annotation_count(&conv.path) {
+                0 => None,
+                1 => Some("1 note".to_string()),
+                n => Some(format!("{n} notes")),
+            };
+
             // Selection indicator: vertical bar for all rows (with left padding)
             let indicator = " ▌ ";
             let indicator_style = if is_selected {
@@ -1515,7 +1718,12 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 .as_ref()
                 .map(|d| UnicodeWidthStr::width(d.as_str()) + 3)
                 .unwrap_or(0);
+            let note_count_len = note_count
+                .as_ref()
+                .map(|n| UnicodeWidthStr::width(n.as_str()) + 3)
+                .unwrap_or(0);
             let right_len = UnicodeWidthStr::width(msg_count.as_str())
+                + note_count_len
                 + duration_len
                 + semantic_meta_len
                 + 3
@@ -1645,6 +1853,16 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                 msg_count,
                 Style::default().fg(rgb(th().msg_count)),
             ));
+            if let Some(ref notes) = note_count {
+                header_spans.push(Span::styled(
+                    " · ",
+                    Style::default().fg(rgb(th().dot_separator)),
+                ));
+                header_spans.push(Span::styled(
+                    notes.clone(),
+                    Style::default().fg(rgb(th().annotation)),
+                ));
+            }
             if let Some(ref metadata_text) = semantic_meta_part {
                 header_spans.push(Span::styled(
                     " · ",
@@ -1777,7 +1995,7 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 /// Recency level for timestamp color grading
-enum Recency {
+pub(super) enum Recency {
     Now,
     Minutes,
     Hours,
@@ -1787,7 +2005,10 @@ enum Recency {
 
 /// Format a timestamp as relative time for recent entries, absolute for older ones.
 /// Returns (formatted_string, recency) for color grading.
-fn format_timestamp(timestamp: DateTime<Local>, now: DateTime<Local>) -> (String, Recency) {
+pub(super) fn format_timestamp(
+    timestamp: DateTime<Local>,
+    now: DateTime<Local>,
+) -> (String, Recency) {
     let age = now.signed_duration_since(timestamp);
 
     // Future timestamps (clock skew): show absolute
@@ -2643,6 +2864,58 @@ fn highlight_ranges(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn wrap_rows_breaks_at_a_space_and_records_each_row_start() {
+        let rows = super::wrap_rows("alpha beta gamma", 11);
+        let texts: Vec<&str> = rows.iter().map(|(_, text)| text.as_str()).collect();
+        assert_eq!(texts, vec!["alpha beta ", "gamma"]);
+        let starts: Vec<usize> = rows.iter().map(|(start, _)| *start).collect();
+        assert_eq!(starts, vec![0, 11]);
+    }
+
+    #[test]
+    fn wrap_rows_breaks_a_word_wider_than_the_row_at_the_row_edge() {
+        let rows = super::wrap_rows("aaaaaaaa", 3);
+        let texts: Vec<&str> = rows.iter().map(|(_, text)| text.as_str()).collect();
+        assert_eq!(texts, vec!["aaa", "aaa", "aa"]);
+    }
+
+    #[test]
+    fn wrap_rows_returns_one_row_for_an_empty_input() {
+        assert_eq!(super::wrap_rows("", 10), vec![(0, String::new())]);
+    }
+
+    #[test]
+    fn wrap_rows_ends_a_row_at_a_newline() {
+        let rows = super::wrap_rows("one\ntwo", 20);
+        assert_eq!(rows, vec![(0, "one".to_string()), (4, "two".to_string())]);
+    }
+
+    #[test]
+    fn wrap_rows_holds_an_empty_row_for_a_blank_line() {
+        let rows = super::wrap_rows("one\n\ntwo", 20);
+        assert_eq!(
+            rows,
+            vec![
+                (0, "one".to_string()),
+                (4, String::new()),
+                (5, "two".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn wrap_rows_adds_a_trailing_row_after_a_closing_newline() {
+        let rows = super::wrap_rows("one\n", 20);
+        assert_eq!(rows, vec![(0, "one".to_string()), (4, String::new())]);
+    }
+
+    #[test]
+    fn wrap_rows_adds_a_trailing_row_when_the_text_fills_the_last_one() {
+        let rows = super::wrap_rows("abc", 3);
+        assert_eq!(rows, vec![(0, "abc".to_string()), (3, String::new())]);
+    }
     use super::*;
     use crate::history::Conversation;
     use crate::semantic::types::{
@@ -2680,6 +2953,60 @@ mod tests {
             terminal
                 .draw(|frame| {
                     render_help_overlay(frame, false, false, false, &KeyBindings::default(), 0)
+                })
+                .unwrap();
+        }
+    }
+
+    const ANNOTATE_HINT: &str = "Enter save · Alt+Enter newline · Tab scope · Esc cancel";
+
+    #[test]
+    fn the_box_widens_so_the_hint_sits_on_one_row() {
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_text_prompt(frame, "body", 4, " Note on line 2 ", ANNOTATE_HINT, 8)
+            })
+            .unwrap();
+
+        let contents = terminal_contents(&terminal);
+        assert!(contents.contains(ANNOTATE_HINT), "{contents:?}");
+    }
+
+    #[test]
+    fn a_hint_wider_than_the_terminal_wraps_with_nothing_dropped() {
+        let backend = TestBackend::new(50, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                render_text_prompt(frame, "body", 4, " Note on line 2 ", ANNOTATE_HINT, 8)
+            })
+            .unwrap();
+
+        // The wrap falls between words, so the assertions name the pieces
+        // rather than the whole string.
+        let contents = terminal_contents(&terminal);
+        assert!(contents.contains("Alt+Enter newline"), "{contents:?}");
+        assert!(contents.contains("Tab scope"), "{contents:?}");
+        assert!(contents.contains("cancel"), "{contents:?}");
+    }
+
+    #[test]
+    fn a_prompt_survives_a_tiny_terminal() {
+        for (width, height) in [(20, 8), (10, 3), (2, 2), (1, 1)] {
+            let backend = TestBackend::new(width, height);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal
+                .draw(|frame| {
+                    render_text_prompt(
+                        frame,
+                        "body text that runs past a narrow box",
+                        4,
+                        " Note on line 2 ",
+                        ANNOTATE_HINT,
+                        8,
+                    )
                 })
                 .unwrap();
         }
@@ -4119,5 +4446,149 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         let ranges = find_normalized_match_ranges("the red", "red");
         assert_eq!(ranges.len(), 1);
+    }
+
+    /// The transcript and app used by the note-selection chrome tests: one
+    /// user message, viewed as a single file.
+    fn app_viewing_one_message(dir: &std::path::Path) -> App {
+        let transcript = dir.join("abc.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let mut app = App::new_single_file(
+            transcript,
+            ToolDisplayMode::Hidden,
+            false,
+            KeyBindings::default(),
+        );
+        // The single-file view opens at width 0 and renders no lines until a
+        // frame reports its size, so the gutter column would have nothing to
+        // sit beside.
+        app.check_view_resize(60, 4);
+        app
+    }
+
+    #[test]
+    fn a_selected_note_swaps_the_status_row_for_its_own_keys() {
+        let root = tempfile::tempdir().unwrap();
+        let mut app = app_viewing_one_message(root.path());
+        app.select_annotation_for_test("note-1", 0, 1);
+
+        let AppMode::View(state) = app.app_mode() else {
+            panic!("still in view mode");
+        };
+        let backend = TestBackend::new(100, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_view_status_bar(frame, &app, state, frame.area()))
+            .unwrap();
+
+        // The row drops the repeated "note" so five keys fit in one hundred
+        // columns; the notes indicator to its left already names the subject.
+        let contents = terminal_contents(&terminal);
+        assert!(contents.contains("edit"), "{contents:?}");
+        assert!(contents.contains("move"), "{contents:?}");
+        assert!(contents.contains("delete"), "{contents:?}");
+        assert!(contents.contains("yank"), "{contents:?}");
+        assert!(contents.contains("deselect"), "{contents:?}");
+        // e is bound to export until a selection takes it: naming export here
+        // would print a binding that does not fire.
+        assert!(!contents.contains("xport"), "{contents:?}");
+    }
+
+    #[test]
+    fn a_click_away_from_a_note_clears_the_selection() {
+        let root = tempfile::tempdir().unwrap();
+        let mut app = app_viewing_one_message(root.path());
+        // The note covers the first rendered line only, so a click on a later
+        // row lands outside it.
+        app.select_annotation_for_test("note-1", 0, 1);
+
+        let frame_area = Rect::new(0, 0, 60, 10);
+        let content_y = {
+            let AppMode::View(state) = app.app_mode() else {
+                panic!("still in view mode");
+            };
+            view_layout_rects(frame_area, &app, state).content.y
+        };
+
+        app.handle_view_click(content_y + 1, frame_area, 4);
+
+        let AppMode::View(state) = app.app_mode() else {
+            panic!("still in view mode");
+        };
+        assert_eq!(state.focused_annotation, None);
+    }
+
+    #[test]
+    fn a_selected_note_draws_the_focus_gutter() {
+        let root = tempfile::tempdir().unwrap();
+        let mut app = app_viewing_one_message(root.path());
+        app.select_annotation_for_test("note-1", 0, 1);
+
+        let AppMode::View(state) = app.app_mode() else {
+            panic!("still in view mode");
+        };
+        // message_nav_active stays false, the state a note click leaves behind.
+        assert!(!state.message_nav_active);
+
+        let backend = TestBackend::new(60, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_view_content(frame, state, frame.area()))
+            .unwrap();
+
+        let contents = terminal_contents(&terminal);
+        assert!(contents.contains('\u{258c}'), "{contents:?}");
+    }
+
+    #[test]
+    fn a_list_row_states_its_note_count_beside_the_other_metadata() {
+        let conversation = test_conversation();
+        let path = conversation.path.clone();
+        let mut app = App::new(
+            vec![conversation],
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            vec![],
+        );
+        app.set_annotation_count_for_test(&path, 2);
+
+        let backend = TestBackend::new(120, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_list(frame, &app, frame.area()))
+            .unwrap();
+
+        let contents = terminal_contents(&terminal);
+        assert!(contents.contains("2 notes"), "{contents:?}");
+        // The count joins the existing metadata rather than displacing it.
+        assert!(contents.contains("1 msg"), "{contents:?}");
+    }
+
+    #[test]
+    fn a_list_row_without_notes_states_no_count() {
+        let app = App::new(
+            vec![test_conversation()],
+            ToolDisplayMode::Truncated,
+            false,
+            KeyBindings::default(),
+            vec![],
+        );
+
+        let backend = TestBackend::new(120, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_list(frame, &app, frame.area()))
+            .unwrap();
+
+        let contents = terminal_contents(&terminal);
+        assert!(!contents.contains("note"), "{contents:?}");
     }
 }

--- a/src/tui/viewer/ledger.rs
+++ b/src/tui/viewer/ledger.rs
@@ -383,5 +383,7 @@ mod tests {
             assert_eq!(UnicodeWidthStr::width(fitted.as_str()), NAME_WIDTH);
         }
         assert_eq!(padded_name("Branch summary"), "Branch s…");
+        // The annotation label is sized to the existing column.
+        assert_eq!(padded_name("Note"), "     Note");
     }
 }

--- a/src/tui/viewer/mod.rs
+++ b/src/tui/viewer/mod.rs
@@ -101,6 +101,13 @@ pub struct RenderOptions {
     pub show_timing: bool,
     pub content_width: usize,
     pub expanded_tool_outputs: BTreeSet<ToolOutputId>,
+    pub show_annotations: bool,
+    pub annotations: crate::annotations::ConversationAnnotations,
+    /// Label per annotator key, printed in the name column. A key absent here
+    /// prints with its first letter capitalised.
+    pub annotator_labels: std::collections::HashMap<String, String>,
+    /// Id of the annotation currently selected, styled apart from the rest.
+    pub focused_annotation: Option<String>,
 }
 
 /// Tracks the line range of a single message (User or Assistant entry) in the rendered output
@@ -114,10 +121,23 @@ pub struct MessageRange {
     pub end_line: usize,
 }
 
+/// The lines one annotation occupies, and the annotation it came from.
+///
+/// Held separately from `MessageRange` because an annotation carries no entry,
+/// and `MessageRange::entry_index` is binary-searched when restoring scroll
+/// position: a synthetic or duplicated index there corrupts that search.
+#[derive(Clone, Debug)]
+pub struct AnnotationRange {
+    pub id: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
 /// Result of rendering a conversation
 pub struct RenderedConversation {
     pub lines: Vec<RenderedLine>,
     pub messages: Vec<MessageRange>,
+    pub annotations: Vec<AnnotationRange>,
 }
 
 /// Format an ISO 8601 timestamp to HH:MM local time
@@ -132,6 +152,10 @@ fn format_timestamp(iso_timestamp: &str) -> Option<String> {
 #[derive(Debug)]
 pub struct RenderableEntry {
     pub entry_index: usize,
+    /// Physical JSONL line this entry came from, 1-based, blank lines counted
+    /// before being skipped. Kept because annotations name lines, and
+    /// `entry_index` counts parsed entries after filtering rather than lines.
+    pub jsonl_line: usize,
     entry: LogEntry,
 }
 
@@ -140,11 +164,13 @@ pub fn parse_conversation_file(file_path: &Path) -> std::io::Result<Vec<Renderab
         .map_err(|error| std::io::Error::other(error.to_string()))?;
     Ok(normalized
         .into_iter()
-        .map(|(_, entry)| entry)
         .enumerate()
-        .filter_map(|(entry_index, entry)| {
-            (!matches!(entry, LogEntry::FileHistorySnapshot { .. }))
-                .then_some(RenderableEntry { entry_index, entry })
+        .filter_map(|(entry_index, (jsonl_line, entry))| {
+            (!matches!(entry, LogEntry::FileHistorySnapshot { .. })).then_some(RenderableEntry {
+                entry_index,
+                jsonl_line,
+                entry,
+            })
         })
         .collect())
 }
@@ -155,8 +181,26 @@ pub fn render_parsed_conversation(
 ) -> RenderedConversation {
     let mut lines = Vec::new();
     let mut messages = Vec::new();
+    let mut annotation_ranges = Vec::new();
     let mut pending_tool_summary: Option<PendingToolSummary> = None;
 
+    // Session-level annotations name no line, so they carry no position in the
+    // file and print ahead of the conversation.
+    if options.show_annotations {
+        for annotation in &options.annotations.session {
+            push_annotation_lines(
+                &mut lines,
+                &mut annotation_ranges,
+                annotation,
+                options.content_width,
+                options.show_timing,
+                options.focused_annotation.as_deref() == Some(annotation.id.as_str()),
+                &options.annotator_labels,
+            );
+        }
+    }
+
+    let mut next_annotation = 0;
     for (parsed_idx, parsed) in entries.iter().enumerate() {
         if options.tool_display.is_summary()
             && try_extend_or_start_pending_summary(
@@ -180,6 +224,33 @@ pub fn render_parsed_conversation(
         );
 
         render_entry_with_range(&mut lines, &mut messages, parsed, options);
+
+        // Annotations print after the entry holding the line they name, so a
+        // note follows what it describes. An annotation naming a line that
+        // produced no entry -- a snapshot record, a line absorbed into a tool
+        // summary -- prints after the next entry rendered rather than being
+        // dropped.
+        if options.show_annotations {
+            while let Some(annotation) = options.annotations.positioned.get(next_annotation) {
+                let Some(anchor) = annotation.anchor_line() else {
+                    next_annotation += 1;
+                    continue;
+                };
+                if anchor > parsed.jsonl_line {
+                    break;
+                }
+                push_annotation_lines(
+                    &mut lines,
+                    &mut annotation_ranges,
+                    annotation,
+                    options.content_width,
+                    options.show_timing,
+                    options.focused_annotation.as_deref() == Some(annotation.id.as_str()),
+                    &options.annotator_labels,
+                );
+                next_annotation += 1;
+            }
+        }
     }
 
     flush_tool_summary(
@@ -190,9 +261,204 @@ pub fn render_parsed_conversation(
         options,
     );
 
+    // Annotations naming a line past the last entry still belong to the
+    // conversation, so they print at its end rather than vanishing.
+    if options.show_annotations {
+        for annotation in options.annotations.positioned.iter().skip(next_annotation) {
+            push_annotation_lines(
+                &mut lines,
+                &mut annotation_ranges,
+                annotation,
+                options.content_width,
+                options.show_timing,
+                options.focused_annotation.as_deref() == Some(annotation.id.as_str()),
+                &options.annotator_labels,
+            );
+        }
+    }
+
     postprocess_blank_lines(&mut lines, &mut messages);
 
-    RenderedConversation { lines, messages }
+    RenderedConversation {
+        lines,
+        messages,
+        annotations: annotation_ranges,
+    }
+}
+
+/// Render one annotation as its own lines, labelled with its kind and the lines
+/// it names.
+///
+/// The label carries the target because a filtered view -- tools, thinking or
+/// subagents hidden -- prints an annotation between its visible neighbours
+/// rather than among the entries it sat with. Stating the line keeps that gap
+/// visible instead of silently approximate.
+/// The name column for one annotation: the annotator's configured label, else
+/// its key with the first letter capitalised, truncated to the column width so
+/// every row's text starts in the same place.
+fn annotator_label(key: &str, labels: &std::collections::HashMap<String, String>) -> String {
+    let full = match labels.get(key) {
+        Some(label) => label.clone(),
+        None => {
+            let mut chars = key.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => "Note".to_string(),
+            }
+        }
+    };
+    full.chars().take(NAME_WIDTH).collect()
+}
+
+fn push_annotation_lines(
+    lines: &mut Vec<RenderedLine>,
+    ranges: &mut Vec<AnnotationRange>,
+    annotation: &crate::annotations::Annotation,
+    content_width: usize,
+    timing_enabled: bool,
+    focused: bool,
+    labels: &std::collections::HashMap<String, String>,
+) {
+    let label = annotator_label(&annotation.annotator, labels);
+    let start_line = lines.len();
+    use ledger::{LedgerRow, NameCol, push_row};
+    use timing::TimingSlot;
+
+    let color = th().annotation;
+    let timing = || {
+        if timing_enabled {
+            TimingSlot::Pad
+        } else {
+            TimingSlot::Disabled
+        }
+    };
+    // A focused note drops the italic and takes bold, so the selection is
+    // marked by weight rather than by a colour outside the theme's palette.
+    let text_style = LineStyle {
+        fg: Some(color),
+        italic: !focused,
+        bold: focused,
+        ..LineStyle::default()
+    };
+    let trailer_style = LineStyle {
+        fg: Some(color),
+        dimmed: true,
+        ..LineStyle::default()
+    };
+
+    // The trailer names the lines targeted and the producer's kind. The target
+    // is stated because a filtered view -- tools, thinking or subagents hidden
+    // -- prints an annotation between its visible neighbours rather than among
+    // the entries it sat with, and stating it keeps that gap visible instead of
+    // silently approximate.
+    let target = match annotation.targets.as_slice() {
+        [] => "session".to_string(),
+        targets => targets
+            .iter()
+            .map(|span| {
+                if span.start == span.end {
+                    span.start.to_string()
+                } else {
+                    format!("{}..{}", span.start, span.end)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+    };
+    let mut trailer = if annotation.kind.trim().is_empty() {
+        format!("  @{target}")
+    } else {
+        format!("  @{target} · {}", annotation.kind)
+    };
+    // An origin names the file the note summarises when that file is not this
+    // conversation, so a recap of an agent's work leads back to the agent.
+    if let Some(origin) = &annotation.origin {
+        trailer.push_str(&format!(" · {}", origin.short()));
+    }
+    // The creation time states when the note entered the record, in the same
+    // relative form the list prints. The edit time follows it where the two
+    // render differently; rendering alike, the second repeats the first and the
+    // row carries one.
+    let now = chrono::Local::now();
+    let elapsed = |stamp: &str| {
+        crate::annotations::stamp_moment(stamp)
+            .map(|moment| crate::tui::ui::format_timestamp(moment, now).0)
+    };
+    let created_text = annotation.created.as_deref().and_then(elapsed);
+    let modified_text = annotation.modified.as_deref().and_then(elapsed);
+    if let Some(created) = &created_text {
+        trailer.push_str(&format!(" · created {created}"));
+    }
+    if let Some(modified) = &modified_text
+        && Some(modified) != created_text.as_ref()
+    {
+        trailer.push_str(&format!(" · edited {modified}"));
+    }
+
+    let width = content_width.max(20);
+    let mut wrapped = Vec::new();
+    for text_line in annotation.text.lines() {
+        for piece in textwrap::wrap(text_line, width) {
+            wrapped.push(piece.to_string());
+        }
+    }
+    if wrapped.is_empty() {
+        wrapped.push(String::new());
+    }
+    // The trailer shares a row with the body's final line only where both fit
+    // inside the content width. Past that it takes a row of its own, so a full
+    // final line and a trailer do not run past the column.
+    let trailer_width = unicode_width::UnicodeWidthStr::width(trailer.as_str());
+    let final_width = unicode_width::UnicodeWidthStr::width(
+        wrapped.last().map(String::as_str).unwrap_or_default(),
+    );
+    if final_width + trailer_width > width {
+        wrapped.push(String::new());
+    }
+    let last = wrapped.len() - 1;
+
+    for (index, piece) in wrapped.into_iter().enumerate() {
+        let name = if index == 0 {
+            NameCol::Label {
+                text: &label,
+                color,
+                bold: true,
+                dimmed: false,
+            }
+        } else {
+            NameCol::BlankColoredDim { color }
+        };
+        let mut content = vec![(piece, text_style.clone())];
+        // The trailer follows the body's final line, so a wrapped annotation
+        // does not push its target off the first row.
+        if index == last {
+            content.push((trailer.clone(), trailer_style.clone()));
+        }
+        push_row(
+            lines,
+            LedgerRow {
+                timing: timing(),
+                name,
+                separator_dimmed: true,
+                tool_output_id: None,
+                clickable: false,
+            },
+            content,
+        );
+    }
+
+    // A blank row after the block, matching the separation between message
+    // blocks. Consecutive blanks are collapsed later, so a run of annotations
+    // does not open a gap per annotation.
+    lines.push(RenderedLine::new(Vec::new()));
+
+    ranges.push(AnnotationRange {
+        id: annotation.id.clone(),
+        start_line,
+        // The trailing blank is excluded, so a click on the gap between blocks
+        // selects nothing rather than the block above it.
+        end_line: lines.len().saturating_sub(1),
+    });
 }
 
 /// Handle a parsed entry while in summary tool-display mode.

--- a/src/tui/viewer/tests.rs
+++ b/src/tui/viewer/tests.rs
@@ -325,13 +325,318 @@ fn test_render_options(tool_display: ToolDisplayMode) -> RenderOptions {
         show_timing: false,
         content_width: 80,
         expanded_tool_outputs: BTreeSet::new(),
+        show_annotations: false,
+        annotations: crate::annotations::ConversationAnnotations::default(),
+        annotator_labels: std::collections::HashMap::new(),
+        focused_annotation: None,
     }
+}
+
+fn annotation(
+    id: &str,
+    kind: &str,
+    text: &str,
+    targets: Vec<usize>,
+) -> crate::annotations::Annotation {
+    crate::annotations::Annotation {
+        id: id.to_string(),
+        targets: targets
+            .into_iter()
+            .map(crate::annotations::TargetSpan::single)
+            .collect(),
+        kind: kind.to_string(),
+        text: text.to_string(),
+        annotator: String::new(),
+        origin: None,
+        created: None,
+        modified: None,
+    }
+}
+
+fn annotated_options(
+    annotations: Vec<crate::annotations::Annotation>,
+    show: bool,
+) -> RenderOptions {
+    let mut options = test_render_options(ToolDisplayMode::Hidden);
+    options.show_annotations = show;
+    options.annotations = crate::annotations::ConversationAnnotations::from_flat(annotations);
+    options
+}
+
+/// Index of the first rendered line containing `needle`, for asserting the
+/// order annotations and entries print in.
+fn position_of(text: &str, needle: &str) -> Option<usize> {
+    text.lines().position(|line| line.contains(needle))
+}
+
+#[test]
+fn each_annotation_reports_the_lines_it_occupies() {
+    let entries = vec![
+        user_entry(0, "first message", None),
+        assistant_text_entry(1, "second message", None),
+    ];
+    let options = annotated_options(
+        vec![
+            annotation("s", "note", "session note", vec![]),
+            annotation("a", "recap", "about the second turn", vec![2]),
+        ],
+        true,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+
+    let ids = rendered
+        .annotations
+        .iter()
+        .map(|range| range.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["s", "a"]);
+    for range in &rendered.annotations {
+        assert!(range.end_line > range.start_line);
+    }
+    // Message ranges stay free of annotation blocks: the scroll anchor binary
+    // searches them by entry_index, which an entry-less block would corrupt.
+    assert_eq!(rendered.messages.len(), 2);
+}
+
+#[test]
+fn session_annotations_print_ahead_of_the_conversation() {
+    // entry_index 0 and 1 carry jsonl_line 1 and 2.
+    let entries = vec![
+        user_entry(0, "first message", None),
+        assistant_text_entry(1, "second message", None),
+    ];
+    let options = annotated_options(
+        vec![annotation("s", "note", "whole session note", vec![])],
+        true,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let note = position_of(&text, "whole session note").expect("annotation rendered");
+    let first = position_of(&text, "first message").expect("conversation rendered");
+    assert!(
+        note < first,
+        "session annotation should precede the conversation"
+    );
+}
+
+#[test]
+fn a_positioned_annotation_prints_after_the_entry_at_its_line() {
+    let entries = vec![
+        user_entry(0, "first message", None),
+        assistant_text_entry(1, "second message", None),
+    ];
+    // jsonl_line 2 belongs to the second entry.
+    let options = annotated_options(
+        vec![annotation("a", "recap", "about the second turn", vec![2])],
+        true,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let first = position_of(&text, "first message").unwrap();
+    let second = position_of(&text, "second message").unwrap();
+    let note = position_of(&text, "about the second turn").unwrap();
+    // The note follows the entry it names.
+    assert!(first < second && second < note, "{text}");
+}
+
+#[test]
+fn an_annotation_past_the_last_entry_prints_at_the_end() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let options = annotated_options(
+        vec![annotation(
+            "a",
+            "recap",
+            "names a line that has no entry",
+            vec![99],
+        )],
+        true,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let only = position_of(&text, "only message").unwrap();
+    let note = position_of(&text, "names a line that has no entry")
+        .expect("an annotation past the last entry is kept, not dropped");
+    assert!(note > only);
+}
+
+#[test]
+fn the_trailer_names_the_origin_when_the_note_carries_one() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let mut note = annotation("a", "recap", "agent work", vec![1]);
+    note.origin = Some(crate::annotations::AnnotationOrigin {
+        path: std::path::PathBuf::from("/tmp/subagents/agent-ac1cffaa.jsonl"),
+        lines: "412..430".to_string(),
+    });
+    let options = annotated_options(vec![note], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("agent work"))
+        .expect("annotation line rendered");
+    assert!(
+        labelled.contains("@1 · recap · agent-ac1cffaa @412..430"),
+        "{labelled}"
+    );
+}
+
+#[test]
+fn the_trailer_names_the_creation_time_and_the_edit_time_when_they_differ() {
+    let entries = vec![user_entry(0, "only message", None)];
+    // Whole days back from the local clock, so each stamp is that many calendar
+    // days earlier whatever the hour and the zone.
+    let now = chrono::Local::now();
+    let created = (now - chrono::Duration::days(4)).to_rfc3339();
+    let modified = (now - chrono::Duration::days(2)).to_rfc3339();
+    let mut note = annotation("a", "recap", "dated body", vec![1]);
+    note.created = Some(created);
+    note.modified = Some(modified);
+    let options = annotated_options(vec![note], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("dated body"))
+        .expect("annotation line rendered");
+    assert!(
+        labelled.contains("@1 · recap · created 4 days ago · edited 2 days ago"),
+        "{labelled}"
+    );
+}
+
+#[test]
+fn the_trailer_names_one_time_when_the_edit_renders_as_the_creation() {
+    let entries = vec![user_entry(0, "only message", None)];
+    // The stamps a fresh write leaves: one moment, both fields.
+    let stamp = (chrono::Local::now() - chrono::Duration::days(4)).to_rfc3339();
+    let mut note = annotation("a", "recap", "same day body", vec![1]);
+    note.created = Some(stamp.clone());
+    note.modified = Some(stamp);
+    let options = annotated_options(vec![note], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("same day body"))
+        .expect("annotation line rendered");
+    assert!(
+        labelled.contains("@1 · recap · created 4 days ago"),
+        "{labelled}"
+    );
+    assert!(!labelled.contains("edited"), "{labelled}");
+}
+
+#[test]
+fn a_note_without_stamps_renders_the_trailer_it_had_before_stamps_existed() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let options = annotated_options(
+        vec![annotation("a", "recap", "undated body", vec![1])],
+        true,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("undated body"))
+        .expect("annotation line rendered");
+    assert!(labelled.contains("@1 · recap"), "{labelled}");
+    assert!(!labelled.contains("created"), "{labelled}");
+    assert!(!labelled.contains("edited"), "{labelled}");
+    assert!(!labelled.contains("ago"), "{labelled}");
+}
+
+#[test]
+fn a_trailer_that_does_not_fit_beside_the_final_line_takes_a_row_of_its_own() {
+    let entries = vec![user_entry(0, "only message", None)];
+    // A body whose final line reaches the content width leaves no room beside
+    // it, which is the condition the trailer's own row exists for.
+    let body = "w".repeat(test_render_options(ToolDisplayMode::Hidden).content_width);
+    let mut note = annotation("a", "recap", &body, vec![1]);
+    note.created = Some((chrono::Local::now() - chrono::Duration::days(4)).to_rfc3339());
+    let options = annotated_options(vec![note], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let body_row = position_of(&text, &body).expect("annotation body rendered");
+    let trailer_row = position_of(&text, "· recap ·").expect("trailer rendered");
+    assert!(
+        trailer_row > body_row,
+        "trailer on row {trailer_row}, body on row {body_row}"
+    );
+}
+
+#[test]
+fn a_trailer_that_fits_beside_the_final_line_shares_its_row() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let options = annotated_options(vec![annotation("a", "recap", "short", vec![1])], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("short"))
+        .expect("annotation body rendered");
+    assert!(labelled.contains("@1 · recap"), "{labelled}");
+}
+
+#[test]
+fn the_label_names_the_kind_and_the_lines_targeted() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let options = annotated_options(vec![annotation("a", "recap", "body", vec![1])], true);
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    // The kind sits in the name column and the target follows the body, so the
+    // two are no longer adjacent in the rendered line.
+    let labelled = text
+        .lines()
+        .find(|line| line.contains("recap") && line.contains("body"))
+        .expect("annotation line rendered");
+    assert!(labelled.contains("@1"), "target named on the label row");
+}
+
+#[test]
+fn annotations_are_absent_when_the_toggle_is_off() {
+    let entries = vec![user_entry(0, "only message", None)];
+    let options = annotated_options(
+        vec![
+            annotation("a", "recap", "positioned note", vec![1]),
+            annotation("s", "note", "session note", vec![]),
+        ],
+        false,
+    );
+
+    let rendered = render_parsed_conversation(&entries, &options);
+    let text = rendered_text(&rendered);
+
+    assert!(position_of(&text, "positioned note").is_none());
+    assert!(position_of(&text, "session note").is_none());
+    assert!(position_of(&text, "only message").is_some());
 }
 
 fn tool_summary_entries() -> Vec<RenderableEntry> {
     vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Grep","input":{"pattern":"one"}}]}}"#,
             )
@@ -339,6 +644,7 @@ fn tool_summary_entries() -> Vec<RenderableEntry> {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"grep result"}]}}"#,
             )
@@ -346,6 +652,7 @@ fn tool_summary_entries() -> Vec<RenderableEntry> {
         },
         RenderableEntry {
             entry_index: 2,
+            jsonl_line: 3,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file_path":"src/main.rs"}},{"type":"tool_use","id":"toolu_3","name":"Bash","input":{"command":"cargo test"}}]}}"#,
             )
@@ -353,6 +660,7 @@ fn tool_summary_entries() -> Vec<RenderableEntry> {
         },
         RenderableEntry {
             entry_index: 3,
+            jsonl_line: 4,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_3","content":"bash result"}]}}"#,
             )
@@ -365,6 +673,7 @@ fn tool_summary_entries() -> Vec<RenderableEntry> {
 fn hidden_tool_mode_renders_activity_summary() {
     let entry = RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Grep","input":{"pattern":"one"}},{"type":"tool_use","id":"toolu_2","name":"Grep","input":{"pattern":"two"}},{"type":"tool_use","id":"toolu_3","name":"Read","input":{"file_path":"src/main.rs"}}]}}"#,
         )
@@ -397,6 +706,7 @@ fn tool_summary_uses_source_agent_label() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","agent":"Pi","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"bash","input":{"command":"pwd"}}]}}"#,
             )
@@ -404,6 +714,7 @@ fn tool_summary_uses_source_agent_label() {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"result"}]}}"#,
             )
@@ -431,6 +742,7 @@ fn hidden_pi_thinking_allows_clickable_grouped_tool_summary() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","agent":"Pi","message":{"role":"assistant","content":[{"type":"thinking","thinking":"inspect files","signature":""},{"type":"tool_use","id":"call_1","name":"bash","input":{"command":"pwd"}}]}}"#,
             )
@@ -438,6 +750,7 @@ fn hidden_pi_thinking_allows_clickable_grouped_tool_summary() {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"/tmp/project"}]}}"#,
             )
@@ -445,6 +758,7 @@ fn hidden_pi_thinking_allows_clickable_grouped_tool_summary() {
         },
         RenderableEntry {
             entry_index: 2,
+            jsonl_line: 3,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","agent":"Pi","message":{"role":"assistant","content":[{"type":"thinking","thinking":"inspect status","signature":""},{"type":"tool_use","id":"call_2","name":"bash","input":{"command":"git status"}}]}}"#,
             )
@@ -452,6 +766,7 @@ fn hidden_pi_thinking_allows_clickable_grouped_tool_summary() {
         },
         RenderableEntry {
             entry_index: 3,
+            jsonl_line: 4,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_2","content":"clean"}]}}"#,
             )
@@ -511,6 +826,7 @@ fn subagent_summary_label_parity() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","parent_tool_use_id":"toolu_parent_abc","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Grep","input":{"pattern":"one"}}]}}"#,
             )
@@ -518,6 +834,7 @@ fn subagent_summary_label_parity() {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"user","parent_tool_use_id":"toolu_parent_abc","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"grep result"}]}}"#,
             )
@@ -625,6 +942,7 @@ fn show_thinking_controls_subagent_entries() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","parent_tool_use_id":"toolu_parent","message":{"role":"assistant","content":[{"type":"text","text":"subagent text"}]}}"#,
             )
@@ -632,6 +950,7 @@ fn show_thinking_controls_subagent_entries() {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"progress","data":{"type":"agent_progress","agentId":"agent-abcdef123456","message":{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"agent progress text"}]}}}}"#,
             )
@@ -756,6 +1075,7 @@ fn user_entry(entry_index: usize, text: &str, timestamp: Option<&str>) -> Render
     );
     RenderableEntry {
         entry_index,
+        jsonl_line: entry_index + 1,
         entry: serde_json::from_str(&json).unwrap(),
     }
 }
@@ -775,6 +1095,7 @@ fn assistant_text_entry(
     );
     RenderableEntry {
         entry_index,
+        jsonl_line: entry_index + 1,
         entry: serde_json::from_str(&json).unwrap(),
     }
 }
@@ -813,6 +1134,7 @@ fn message_ranges_skip_non_message_entries() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(r#"{"type":"summary","summary":"ignored"}"#).unwrap(),
         },
         user_entry(1, "Hello", None),
@@ -935,6 +1257,7 @@ fn assistant_label_uses_accent_bold() {
 fn subagent_assistant_uses_nested_label_when_thinking_shown() {
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","parent_tool_use_id":"toolu_parent_abc","message":{"role":"assistant","content":[{"type":"text","text":"sub text"}]}}"#,
         )
@@ -957,6 +1280,7 @@ fn subagent_assistant_uses_nested_label_when_thinking_shown() {
 fn truncated_tool_call_header_carries_expected_tool_output_id() {
     let entries = vec![RenderableEntry {
         entry_index: 7,
+        jsonl_line: 8,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_xyz","name":"Bash","input":{"command":"ls"}}]}}"#,
         )
@@ -983,6 +1307,7 @@ fn truncated_tool_call_header_carries_expected_tool_output_id() {
 fn full_tool_mode_lines_are_not_clickable() {
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"one\ntwo\nthree\nfour\nfive"}}]}}"#,
         )
@@ -1006,6 +1331,7 @@ fn tool_result_string_content_renders_as_text() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"echo hi"}}]}}"#,
             )
@@ -1013,6 +1339,7 @@ fn tool_result_string_content_renders_as_text() {
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(
                 r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"hello-world-output"}]}}"#,
             )
@@ -1036,6 +1363,7 @@ fn assistant_with_reordered_blocks_entry() -> RenderableEntry {
     // must reorder to text → tool/summary → thinking.
     RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[
                 {"type":"thinking","thinking":"THINK_BLOCK","signature":"sig"},
@@ -1323,6 +1651,7 @@ fn pending_summary_flushes_at_eof() {
     // result still flushes at EOF and produces a message range.
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Grep","input":{"pattern":"x"}}]}}"#,
         )
@@ -1345,6 +1674,7 @@ fn pending_summary_flushes_before_non_tool_message() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Grep","input":{"pattern":"x"}}]}}"#,
             )
@@ -1406,6 +1736,7 @@ fn assistant_template_order_is_text_then_tool_then_thinking() {
     // (text → tool → thinking) must override that.
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"assistant","message":{"role":"assistant","content":[
                 {"type":"thinking","thinking":"deep thought","signature":"sig"},
@@ -1436,6 +1767,7 @@ fn assistant_template_order_is_text_then_tool_then_thinking() {
 fn skill_marker_user_message_renders_dimmed_but_top_level() {
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"user","message":{"role":"user","content":"Base directory for this skill: /tmp/x"}}"#,
         )
@@ -1459,6 +1791,7 @@ fn agent_progress_user_with_text_and_result_keeps_template_order() {
     // results. Both must appear, in that order.
     let entries = vec![RenderableEntry {
         entry_index: 0,
+        jsonl_line: 1,
         entry: serde_json::from_str(
             r#"{"type":"progress","data":{"type":"agent_progress","agentId":"agent-abc1234","message":{"type":"user","message":{"role":"user","content":[
                 {"type":"text","text":"agent says hi"},
@@ -1485,10 +1818,12 @@ fn excluded_entry_kinds_produce_no_lines() {
     let entries = vec![
         RenderableEntry {
             entry_index: 0,
+            jsonl_line: 1,
             entry: serde_json::from_str(r#"{"type":"summary","summary":"x"}"#).unwrap(),
         },
         RenderableEntry {
             entry_index: 1,
+            jsonl_line: 2,
             entry: serde_json::from_str(r#"{"type":"system","subtype":"info","message":"sys"}"#)
                 .unwrap(),
         },
@@ -1497,4 +1832,50 @@ fn excluded_entry_kinds_produce_no_lines() {
         render_parsed_conversation(&entries, &test_render_options(ToolDisplayMode::Hidden));
     assert!(rendered.lines.is_empty());
     assert!(rendered.messages.is_empty());
+}
+
+#[test]
+fn a_note_prints_the_label_of_the_annotator_holding_it() {
+    let entries = vec![user_entry(0, "first message", None)];
+    let mut note = annotation("n1", "recap", "cache rewrite reverted", vec![1]);
+    note.annotator = "chsum".to_string();
+    let mut options = annotated_options(vec![note], true);
+    options
+        .annotator_labels
+        .insert("chsum".to_string(), "Chsum".to_string());
+
+    let rendered = rendered_text(&render_parsed_conversation(&entries, &options));
+
+    assert!(rendered.contains("Chsum"), "{rendered}");
+    assert!(!rendered.contains("Note"), "{rendered}");
+}
+
+#[test]
+fn a_note_from_an_unlabelled_annotator_prints_its_key_capitalised() {
+    let entries = vec![user_entry(0, "first message", None)];
+    let mut note = annotation("n1", "note", "by hand", vec![1]);
+    note.annotator = "file".to_string();
+    let options = annotated_options(vec![note], true);
+
+    let rendered = rendered_text(&render_parsed_conversation(&entries, &options));
+
+    assert!(rendered.contains("File"), "{rendered}");
+}
+
+#[test]
+fn a_label_longer_than_the_name_column_is_truncated() {
+    let entries = vec![user_entry(0, "first message", None)];
+    let mut note = annotation("n1", "finding", "unchecked index", vec![1]);
+    note.annotator = "review".to_string();
+    let mut options = annotated_options(vec![note], true);
+    options
+        .annotator_labels
+        .insert("review".to_string(), "CodeReviewer".to_string());
+
+    let rendered = rendered_text(&render_parsed_conversation(&entries, &options));
+
+    // Nine characters is the width every other name in the ledger occupies;
+    // a wider one would push this row's text out of the shared column.
+    assert!(rendered.contains("CodeRevie"), "{rendered}");
+    assert!(!rendered.contains("CodeReviewer"), "{rendered}");
 }

--- a/tests/annotator_contract.rs
+++ b/tests/annotator_contract.rs
@@ -1,0 +1,293 @@
+//! The annotator contract, exercised against fixture annotators in
+//! `tests/fixtures/annotators`.
+//!
+//! Each test names the property it holds. The fixtures stand in for any tool
+//! implementing the contract, so the suite runs without an installed
+//! annotator.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_claude-history"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/annotators")
+        .join(name)
+}
+
+/// A home directory holding a claude config root, a transcript, and the
+/// annotator registrations under test.
+struct Harness {
+    home: tempfile::TempDir,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let home = tempfile::tempdir().expect("temp home");
+        let project = home.path().join("claude/projects/-tmp-contract");
+        std::fs::create_dir_all(&project).expect("create project");
+        std::fs::write(
+            project.join("11111111-1111-4111-8111-111111111111.jsonl"),
+            concat!(
+                r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"transcript body"}]},"timestamp":"2026-09-01T10:00:00.000Z","sessionId":"11111111-1111-4111-8111-111111111111","cwd":"/tmp/contract"}"#,
+                "\n",
+                r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"reply body"}]},"timestamp":"2026-09-01T10:00:05.000Z","sessionId":"11111111-1111-4111-8111-111111111111","cwd":"/tmp/contract"}"#,
+                "\n",
+            ),
+        )
+        .expect("write transcript");
+        Self { home }
+    }
+
+    fn transcript(&self) -> PathBuf {
+        self.home
+            .path()
+            .join("claude/projects/-tmp-contract/11111111-1111-4111-8111-111111111111.jsonl")
+    }
+
+    /// Register one annotator as the write target.
+    fn register(&self, key: &str, script: &str) {
+        let config = self.home.path().join(".config/claude-history");
+        std::fs::create_dir_all(&config).expect("create config dir");
+        std::fs::write(
+            config.join("config.toml"),
+            format!(
+                "[annotations]\nwrite_to = \"{key}\"\n\n[annotators.{key}]\ncommand = \"{}\"\n",
+                fixture(script).display()
+            ),
+        )
+        .expect("write config");
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        self.run_with_env(args, &[])
+    }
+
+    fn run_logged(&self, args: &[&str], call_log: Option<&Path>) -> Output {
+        match call_log {
+            Some(path) => self.run_with_env(args, &[("ANNOTATOR_CALL_LOG", path)]),
+            None => self.run_with_env(args, &[]),
+        }
+    }
+
+    /// Run with `extra` in the environment, which is how a fixture is told
+    /// where to record what it received.
+    fn run_with_env(&self, args: &[&str], extra: &[(&str, &Path)]) -> Output {
+        let mut command = Command::new(binary());
+        command
+            .env("HOME", self.home.path())
+            .env("CLAUDE_CONFIG_DIR", self.home.path().join("claude"))
+            .env(
+                "PI_CODING_AGENT_SESSION_DIR",
+                self.home.path().join("empty-agent-sessions"),
+            )
+            .args(args);
+        for (key, value) in extra {
+            command.env(key, value);
+        }
+        command.output().expect("run claude-history")
+    }
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn a_note_held_only_by_an_annotator_is_found_by_search() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+
+    let output = harness.run(&["agent", "search", "pelican", "--mode", "lexical"]);
+    let text = stdout(&output);
+
+    // The word appears in no transcript, so the hit exists only because the
+    // annotator was read and its text reached the lexical fields.
+    assert!(text.contains("hits=1"), "{text}");
+    assert!(text.contains("source=annotation"), "{text}");
+    assert!(text.contains("pelican crossing from the fixture"), "{text}");
+}
+
+#[test]
+fn a_write_reports_the_id_the_annotator_stored_under() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+    let transcript = harness.transcript();
+
+    let output = harness.run(&[
+        "annotate",
+        transcript.to_str().unwrap(),
+        "--text",
+        "written through the contract",
+        "--line",
+        "2",
+    ]);
+    let text = stdout(&output);
+
+    // The id is the annotator's, not the one claude-history supplied: a later
+    // delete names what the store holds.
+    assert!(text.contains("fixture_written"), "{text}");
+}
+
+#[test]
+fn a_write_request_carries_the_creation_and_edit_stamps() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+    let transcript = harness.transcript();
+    let write_log = harness.home.path().join("write.json");
+
+    harness.run_with_env(
+        &[
+            "annotate",
+            transcript.to_str().unwrap(),
+            "--text",
+            "written through the contract",
+            "--line",
+            "2",
+        ],
+        &[("ANNOTATOR_WRITE_LOG", &write_log)],
+    );
+
+    let payload = std::fs::read_to_string(&write_log).expect("the fixture recorded the write");
+    let request: serde_json::Value = serde_json::from_str(&payload).expect("the request is JSON");
+    // A write carries both stamps at the one moment, so an annotator storing
+    // them has what a later read returns.
+    let created = request["created"].as_str().expect("created sent");
+    let modified = request["modified"].as_str().expect("modified sent");
+    assert_eq!(created, modified, "{payload}");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(created).is_ok(),
+        "{payload}"
+    );
+}
+
+#[test]
+fn a_new_note_carries_no_replaces() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+    let transcript = harness.transcript();
+    let write_log = harness.home.path().join("write.json");
+
+    harness.run_with_env(
+        &[
+            "annotate",
+            transcript.to_str().unwrap(),
+            "--text",
+            "a new note",
+            "--line",
+            "2",
+        ],
+        &[("ANNOTATOR_WRITE_LOG", &write_log)],
+    );
+
+    let payload = std::fs::read_to_string(&write_log).expect("the fixture recorded the write");
+    let request: serde_json::Value = serde_json::from_str(&payload).expect("the request is JSON");
+    assert!(request.get("replaces").is_none(), "{payload}");
+}
+
+#[test]
+fn stamps_from_an_annotator_survive_the_read() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+
+    let output = harness.run(&["agent", "search", "pelican", "--mode", "lexical"]);
+    let text = stdout(&output);
+
+    // The fixture is the only source of this note, so a hit proves its record
+    // parsed with both stamps present rather than being dropped by them.
+    assert!(text.contains("hits=1"), "{text}");
+    assert!(text.contains("pelican crossing from the fixture"), "{text}");
+}
+
+#[test]
+fn a_delete_reaches_the_annotator_holding_the_note() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+    let transcript = harness.transcript();
+
+    let output = harness.run(&[
+        "annotate",
+        transcript.to_str().unwrap(),
+        "--delete",
+        "fixture_1",
+    ]);
+    let text = stdout(&output);
+
+    assert!(text.contains("removed fixture_1"), "{text}");
+}
+
+#[test]
+fn a_query_invokes_an_annotator_once() {
+    let harness = Harness::new();
+    harness.register("fixture", "conforming.sh");
+    let log = harness.home.path().join("calls.log");
+
+    harness.run_logged(
+        &["agent", "search", "pelican", "--mode", "lexical"],
+        Some(&log),
+    );
+
+    let calls = std::fs::read_to_string(&log).unwrap_or_default();
+    let reads = calls.lines().filter(|line| *line == "read").count();
+    // One invocation carries every conversation in scope. One per conversation
+    // would spawn a subprocess per row of a real history.
+    assert_eq!(reads, 1, "{calls}");
+}
+
+/// A note naming a conversation outside the request is dropped by
+/// `CommandAnnotator::read`, covered by
+/// `annotations::command_annotator::tests::a_conversation_outside_the_request_is_dropped`.
+/// It is not asserted here: the search path matches annotations to loaded
+/// conversations by path and drops an unknown one again, so this suite does
+/// not separate the filter working from the filter absent.
+#[test]
+fn an_annotator_returning_beyond_the_request_still_covers_the_conversations_requested() {
+    let harness = Harness::new();
+    harness.register("trespasser", "foreign.sh");
+
+    let output = harness.run(&["agent", "search", "avocet", "--mode", "lexical"]);
+    let text = stdout(&output);
+
+    assert!(
+        text.contains("avocet note for a requested conversation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn an_annotator_that_fails_leaves_the_conversation_searchable() {
+    let harness = Harness::new();
+    harness.register("broken", "failing.sh");
+
+    let output = harness.run(&["agent", "search", "transcript", "--mode", "lexical"]);
+    let text = stdout(&output);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("hits=1"), "{text}");
+}
+
+#[test]
+fn notes_in_the_file_annotator_stay_readable_once_another_is_registered() {
+    let harness = Harness::new();
+    let sidecar_dir = harness
+        .home
+        .path()
+        .join(".local/share/claude-history/annotations/-tmp-contract");
+    std::fs::create_dir_all(&sidecar_dir).expect("create sidecar dir");
+    std::fs::write(
+        sidecar_dir.join("11111111-1111-4111-8111-111111111111.jsonl"),
+        "{\"id\":\"older\",\"targets\":[1],\"kind\":\"note\",\"text\":\"kingfisher from before\"}\n",
+    )
+    .expect("write sidecar");
+    harness.register("fixture", "conforming.sh");
+
+    let output = harness.run(&["agent", "search", "kingfisher", "--mode", "lexical"]);
+    let text = stdout(&output);
+
+    // Registering an annotator moves nothing: notes written earlier keep being
+    // read from where they sit.
+    assert!(text.contains("kingfisher from before"), "{text}");
+}

--- a/tests/fixtures/annotators/conforming.sh
+++ b/tests/fixtures/annotators/conforming.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# A conforming annotator: one note per requested conversation, a fixed id on
+# write, a found delete. Every invocation appends its operation to
+# $ANNOTATOR_CALL_LOG, so a test counts invocations per query, and a write
+# copies its payload to $ANNOTATOR_WRITE_LOG, so a test reads the request the
+# contract sent.
+op="$1"
+payload=$(cat)
+[ -n "$ANNOTATOR_CALL_LOG" ] && echo "$op" >> "$ANNOTATOR_CALL_LOG"
+case "$op" in
+  read)
+    printf '%s' "$payload" | python3 -c '
+import json, sys
+conversations = json.load(sys.stdin)["conversations"]
+print(json.dumps({"annotations": [
+    {"conversation": path, "id": "fixture_1", "targets": [2], "kind": "recap",
+     "text": "pelican crossing from the fixture",
+     "created": "2026-09-01T09:00:00+10:00",
+     "modified": "2026-09-03T14:30:00+10:00"}
+    for path in conversations
+]}))'
+    ;;
+  write)
+    [ -n "$ANNOTATOR_WRITE_LOG" ] && printf '%s' "$payload" > "$ANNOTATOR_WRITE_LOG"
+    printf '{"id":"fixture_written"}'
+    ;;
+  delete) printf '{"deleted":true}' ;;
+esac

--- a/tests/fixtures/annotators/failing.sh
+++ b/tests/fixtures/annotators/failing.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# An annotator that refuses every operation, for the case where a store is
+# unreachable and the transcript still has to render.
+cat > /dev/null
+exit 3

--- a/tests/fixtures/annotators/foreign.sh
+++ b/tests/fixtures/annotators/foreign.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# An annotator that answers with one note for each conversation asked about and
+# one for a conversation nobody asked about, so a test tells a dropped note from
+# an annotator that was never read.
+op="$1"
+payload=$(cat)
+case "$op" in
+  read)
+    printf '%s' "$payload" | python3 -c '
+import json, sys
+conversations = json.load(sys.stdin)["conversations"]
+notes = [
+    {"conversation": path, "id": "requested_1", "targets": [1], "kind": "recap",
+     "text": "avocet note for a requested conversation"}
+    for path in conversations
+]
+notes.append({"conversation": "/tmp/not-requested.jsonl", "id": "foreign_1",
+              "targets": [1], "kind": "recap", "text": "avocet trespassing note"})
+print(json.dumps({"annotations": notes}))'
+    ;;
+  write) printf '{"id":"foreign_written"}' ;;
+  delete) printf '{"deleted":false}' ;;
+esac

--- a/tests/fixtures/annotators/replacing.sh
+++ b/tests/fixtures/annotators/replacing.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# An annotator that acts on `replaces`, holding one note per conversation in
+# $ANNOTATOR_STORE. A write naming an id keeps that id and rewrites the record;
+# a write naming none mints one. Reads return whatever the store holds, so an
+# edit or a move made against this annotator is visible on the next read.
+# Invoked as `replacing.sh <store> <operation>`: claude-history appends the
+# operation to whatever the registered command line holds, so the store travels
+# in the registration rather than in the environment.
+if [ "$#" -ge 2 ]; then
+  store="$1"
+  op="$2"
+else
+  store="${ANNOTATOR_STORE:-/tmp/replacing-annotator}"
+  op="$1"
+fi
+payload=$(cat)
+mkdir -p "$store"
+export STORE="$store"
+printf '%s' "$payload" | ANNOTATOR_OP="$op" python3 -c '
+import json, os, pathlib, sys
+
+store = pathlib.Path(os.environ["STORE"])
+op = os.environ["ANNOTATOR_OP"]
+request = json.load(sys.stdin)
+path = store / "notes.json"
+held = json.loads(path.read_text()) if path.exists() else {}
+
+if op == "read":
+    out = []
+    for conversation in request["conversations"]:
+        for record in held.get(conversation, []):
+            out.append({"conversation": conversation, **record})
+    print(json.dumps({"annotations": out}))
+elif op == "write":
+    conversation = request.pop("conversation")
+    replaces = request.pop("replaces", None)
+    rows = held.get(conversation, [])
+    if replaces:
+        request["id"] = replaces
+        rows = [request if row.get("id") == replaces else row for row in rows]
+    else:
+        request["id"] = "replacing_%d" % (len(rows) + 1)
+        rows = rows + [request]
+    held[conversation] = rows
+    path.write_text(json.dumps(held))
+    print(json.dumps({"id": request["id"]}))
+elif op == "delete":
+    conversation = request["conversation"]
+    rows = held.get(conversation, [])
+    kept = [row for row in rows if row.get("id") != request["id"]]
+    held[conversation] = kept
+    path.write_text(json.dumps(held))
+    print(json.dumps({"deleted": len(kept) != len(rows)}))
+'


### PR DESCRIPTION
Claude Code writes a transcript once and never rewrites it. Text about a conversation — a reviewer's mark, a decision recorded after the fact, a per-turn recap generated by another tool — has no place inside the file it describes, so today it lives in files claude-history never opens. A search for that text returns nothing, and a transcript renders without it.

This branch gives that text a home beside the transcript and routes it through search and the viewer.

## What a user does

`claude-history annotate <ref> --text "..."` attaches a note to a conversation, with `<ref>` a `ch_` ref from search output, a session uuid, or a transcript path. `--line 412` or `--line 7..9` targets lines, `--session` attaches to the conversation as a whole; `--kind` is a free label defaulting to `note`; `--delete <id>` removes the note by the id the write reported. Nothing needs configuring first: the built-in `file` annotator stores one JSONL sidecar per conversation under `~/.local/share/claude-history/annotations`, laid out by project directory, and a user who never annotates pays one directory check per project and reads no file.

In the viewer, the `annotate` key (default `a`) writes a note against the focused message and `A` toggles notes off and on. In the prompt, Tab moves the note between its line and the session, and Alt+Enter inserts a newline; the box wraps and grows with the text and widens to hold its keys on one row. A note prints after the entry holding its line, with a trailer naming the lines it targets, so a filtered view still states what the note refers to. The trailer carries the note's age — `created 4 days ago · edited yesterday`, the second only where the two render differently.

Clicking a note selects it; `e` reopens its text, `d` deletes it, `y` copies it, and `m` moves it. Under a move the arrows step the note across the lines the view renders, redrawing it at each step with the viewport following, Enter writes it where the move reached, and Esc restores both the note and the scroll position the move started from. Clicking away clears the selection. List rows show a note count beside the message count, and a list search matches note text.

A tool that already holds notes of its own registers as an annotator: `claude-history annotators add chsum --command "chsum annotations"`, then `write-to chsum` to route writes there. `list` and `remove` complete the set. These commands edit `config.toml` through `toml_edit`, so comments and unrelated sections survive. `remove` on the write target returns writes to `file`; `write-to` refuses a key that names no registration. An external annotator is any command answering `read|write|delete` with one JSON object on stdin and one on stdout, invoked once per query rather than once per conversation.

## What it achieves

Annotation text joins the lexical fields after scoping and before chunking, so a conversation whose only match is a note is shortlisted, and a `--local` query reads notes for one project rather than the whole machine. Semantic indexing embeds each note as its own chunk, so a hit names one note rather than a run of them, and carries `source=annotation` so a caller reads it as text about the conversation rather than something said in it. Cache generation covers notes, so the embedding cost lands at prewarm.

Notes are read from every registered annotator and merged. A new note goes to the annotator named by `annotations.write_to`. An edit and a move write back to the annotator the note was read from, so a note stays in the store that produced it, and the write carries `replaces` naming the record it supersedes: an annotator acting on it updates that record and returns its id, and no delete follows; one ignoring it stores a new record and returns a new id, and the delete follows as before. `created` and `modified` are RFC 3339 stamps on the annotation, both optional, so records written before them stay readable and an annotator sending neither renders without times. A failing annotator drops out of the merge and the transcript still renders.

Three fixture annotators — conforming, refusing, over-answering — hold the contract in CI, with a fourth exercising `replaces` from the viewer. Twenty properties across the contract, semantic-candidate, cache, prompt, move and stamp tests were confirmed by breaking the code and watching the named test fail.

Five commits, 37 files, +6,385 / −55. One direct dependency added, `toml_edit`, pulling `toml_datetime` and `winnow` into the lock file. Default behaviour with no configuration is unchanged.

## Checks

`cargo fmt --all --check` exit 0; `cargo clippy --all --locked` 24 warnings against main's 23, the extra being `src/annotations/command.rs:164`; `cargo test --all --locked` 925 + 11 + 10 + 1 passed, 0 failed; `cargo build --all --locked` exit 0. The viewer was driven under a pty and its frames captured: the note and its trailer, the annotate prompt with Tab switching scope, click-to-select, and a move stepping the note down the transcript and Esc putting it back.

https://claude.ai/code/session_01GRUR4KVvFuduscJ7jUCYqB
